### PR TITLE
Update OpenSSH for wolfSSL compatibility

### DIFF
--- a/openssh/key.c
+++ b/openssh/key.c
@@ -43,6 +43,7 @@
 
 #ifdef USING_WOLFSSL
 #include <wolfssl/openssl/evp.h>
+#include <wolfssl/openssl/crypto.h>
 #else
 #include <openssl/evp.h>
 #include <openbsd-compat/openssl-compat.h>

--- a/openssh/ssh-keyscan.c
+++ b/openssh/ssh-keyscan.c
@@ -627,6 +627,7 @@ main(int argc, char **argv)
 	extern int optind;
 	extern char *optarg;
 
+	OpenSSL_add_all_algorithms();
 	__progname = ssh_get_progname(argv[0]);
 	seed_rng();
 	TAILQ_INIT(&tq);


### PR DESCRIPTION
Added crytpo header in key.c for call to OPENSSL_free(). 

Call to OpenSSL_add_all_algorithms() in ssh-keyscan.c resolves segmentation fault when running keyscan test with wolfSSL. 