### PR TITLE
Fixes to stunnel to get it working with latest wolfSSL

### DIFF
--- a/stunnel/example/certs/client-cert.pem
+++ b/stunnel/example/certs/client-cert.pem
@@ -1,12 +1,12 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 12260966172072242701 (0xaa27b3c5a9726e0d)
+        Serial Number: 12305170416376042871 (0xaac4bf4c50bd5577)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=wolfSSL_2048, OU=Programming-2048, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: May  7 18:21:01 2015 GMT
-            Not After : Jan 31 18:21:01 2018 GMT
+            Not Before: Apr 13 15:23:09 2018 GMT
+            Not After : Jan  7 15:23:09 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL_2048, OU=Programming-2048, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -37,32 +37,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:33:D8:45:66:D7:68:87:18:7E:54:0D:70:27:91:C7:26:D7:85:65:C0
                 DirName:/C=US/ST=Montana/L=Bozeman/O=wolfSSL_2048/OU=Programming-2048/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:AA:27:B3:C5:A9:72:6E:0D
+                serial:AA:C4:BF:4C:50:BD:55:77
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         51:96:a7:1c:26:5d:1c:90:c6:32:9f:96:15:f2:1d:e7:93:9c:
-         ac:75:56:95:fd:20:70:ab:45:6a:09:b0:f3:f2:03:a8:db:dc:
-         2f:bc:1f:87:7a:a3:d4:8f:d5:49:97:7e:3c:54:ac:b1:e3:f0:
-         39:0d:fe:09:9a:23:f6:32:a6:41:59:bd:60:e8:bd:de:00:36:
-         6f:3e:e9:41:6f:a9:63:c7:aa:d5:7b:f3:e4:39:48:9e:f6:60:
-         c6:c6:86:d5:72:86:23:cd:f5:6a:63:53:a4:f8:fc:51:6a:cd:
-         60:74:8e:a3:86:61:01:34:78:f7:29:97:b3:a7:34:b6:0a:de:
-         b5:71:7a:09:a6:3e:d6:82:58:89:67:9c:c5:68:62:ba:06:d6:
-         39:bb:cb:3a:c0:e0:63:1f:c7:0c:9c:12:86:ec:f7:39:6a:61:
-         93:d0:33:14:c6:55:3b:b6:cf:80:5b:8c:43:ef:43:44:0b:3c:
-         93:39:a3:4e:15:d1:0b:5f:84:98:1d:cd:9f:a9:47:eb:3b:56:
-         30:b6:76:92:c1:48:5f:bc:95:b0:50:1a:55:c8:4e:62:47:87:
-         54:64:0c:9b:91:fa:43:b3:29:48:be:e6:12:eb:e3:44:c6:52:
-         e4:40:c6:83:95:1b:a7:65:27:69:73:2f:c8:a0:4d:7f:be:ea:
-         9b:67:b2:7b
+         80:52:54:61:2a:77:80:53:44:a9:80:6d:45:ff:0d:25:7d:1a:
+         8f:23:93:53:74:35:12:6f:f0:2e:20:ea:ed:80:63:69:88:e6:
+         0c:a1:49:30:e0:82:db:68:0f:7e:84:ac:ff:ff:7b:42:fa:7e:
+         2f:b2:52:9f:d2:79:5e:35:12:27:36:bc:df:96:58:44:96:55:
+         c8:4a:94:02:5f:4a:9d:dc:d3:3a:f7:6d:ac:8b:79:6e:fc:be:
+         8f:23:58:6a:8a:f5:38:0a:42:f6:98:74:88:53:2e:02:af:e1:
+         0e:be:6f:cc:74:33:7c:ec:b4:cb:a7:49:6d:82:42:4f:eb:73:
+         29:c3:32:00:2b:15:f8:88:7a:8f:6d:20:1b:ae:65:5f:c5:d0:
+         8a:d1:e2:64:6d:a3:a8:fe:64:e1:a9:5b:e6:d0:23:d6:02:72:
+         5a:ec:03:8e:87:67:19:8d:e4:a8:99:15:c1:3d:91:48:99:8d:
+         fe:ae:1c:bf:f6:28:1b:45:be:ad:ef:72:83:9a:f6:c7:3b:51:
+         a3:6e:7a:73:bd:83:aa:97:fd:63:b4:f4:6b:1c:14:81:9a:ef:
+         14:24:d3:e1:8b:f4:04:04:84:54:0f:61:a2:a8:f2:50:37:0c:
+         17:0c:bc:e0:c2:84:85:f4:0b:ae:00:ca:9f:27:e2:44:4f:15:
+         0b:8b:1d:b4
 -----BEGIN CERTIFICATE-----
-MIIEyjCCA7KgAwIBAgIJAKons8Wpcm4NMA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
+MIIEyjCCA7KgAwIBAgIJAKrEv0xQvVV3MA0GCSqGSIb3DQEBCwUAMIGeMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjEVMBMG
 A1UECgwMd29sZlNTTF8yMDQ4MRkwFwYDVQQLDBBQcm9ncmFtbWluZy0yMDQ4MRgw
 FgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29s
-ZnNzbC5jb20wHhcNMTUwNTA3MTgyMTAxWhcNMTgwMTMxMTgyMTAxWjCBnjELMAkG
+ZnNzbC5jb20wHhcNMTgwNDEzMTUyMzA5WhcNMjEwMTA3MTUyMzA5WjCBnjELMAkG
 A1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xFTAT
 BgNVBAoMDHdvbGZTU0xfMjA0ODEZMBcGA1UECwwQUHJvZ3JhbW1pbmctMjA0ODEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
@@ -77,11 +77,11 @@ xybXhWXAMIHTBgNVHSMEgcswgciAFDPYRWbXaIcYflQNcCeRxybXhWXAoYGkpIGh
 MIGeMQswCQYDVQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96
 ZW1hbjEVMBMGA1UECgwMd29sZlNTTF8yMDQ4MRkwFwYDVQQLDBBQcm9ncmFtbWlu
 Zy0yMDQ4MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEW
-EGluZm9Ad29sZnNzbC5jb22CCQCqJ7PFqXJuDTAMBgNVHRMEBTADAQH/MA0GCSqG
-SIb3DQEBCwUAA4IBAQBRlqccJl0ckMYyn5YV8h3nk5ysdVaV/SBwq0VqCbDz8gOo
-29wvvB+HeqPUj9VJl348VKyx4/A5Df4JmiP2MqZBWb1g6L3eADZvPulBb6ljx6rV
-e/PkOUie9mDGxobVcoYjzfVqY1Ok+PxRas1gdI6jhmEBNHj3KZezpzS2Ct61cXoJ
-pj7WgliJZ5zFaGK6BtY5u8s6wOBjH8cMnBKG7Pc5amGT0DMUxlU7ts+AW4xD70NE
-CzyTOaNOFdELX4SYHc2fqUfrO1YwtnaSwUhfvJWwUBpVyE5iR4dUZAybkfpDsylI
-vuYS6+NExlLkQMaDlRunZSdpcy/IoE1/vuqbZ7J7
+EGluZm9Ad29sZnNzbC5jb22CCQCqxL9MUL1VdzAMBgNVHRMEBTADAQH/MA0GCSqG
+SIb3DQEBCwUAA4IBAQCAUlRhKneAU0SpgG1F/w0lfRqPI5NTdDUSb/AuIOrtgGNp
+iOYMoUkw4ILbaA9+hKz//3tC+n4vslKf0nleNRInNrzfllhEllXISpQCX0qd3NM6
+922si3lu/L6PI1hqivU4CkL2mHSIUy4Cr+EOvm/MdDN87LTLp0ltgkJP63MpwzIA
+KxX4iHqPbSAbrmVfxdCK0eJkbaOo/mThqVvm0CPWAnJa7AOOh2cZjeSomRXBPZFI
+mY3+rhy/9igbRb6t73KDmvbHO1GjbnpzvYOql/1jtPRrHBSBmu8UJNPhi/QEBIRU
+D2GiqPJQNwwXDLzgwoSF9AuuAMqfJ+JETxULix20
 -----END CERTIFICATE-----

--- a/stunnel/example/certs/server-cert.pem
+++ b/stunnel/example/certs/server-cert.pem
@@ -5,8 +5,8 @@ Certificate:
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: May  7 18:21:01 2015 GMT
-            Not After : Jan 31 18:21:01 2018 GMT
+            Not Before: Apr 13 15:23:10 2018 GMT
+            Not After : Jan  7 15:23:10 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=wolfSSL, OU=Support, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -37,32 +37,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:D9:80:3A:C3:D2:F4:DA:37
+                serial:86:FF:F5:8E:10:DE:B8:FB
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         67:c0:2c:a9:43:47:e7:11:14:77:ae:cc:d8:e0:6b:23:82:91:
-         63:e8:a8:0d:21:c5:c8:47:97:2f:d5:f3:86:fb:6c:ce:25:f9:
-         7c:78:c8:3a:22:68:f2:16:1e:d2:d2:3f:24:04:87:f2:b7:c1:
-         62:63:ba:c5:fa:ae:d2:20:81:1a:d2:0c:ae:26:6b:1b:2b:10:
-         d3:e1:9a:4e:64:6c:97:db:36:a8:8f:f8:05:63:bf:ba:0d:88:
-         0b:87:46:c9:e4:64:e3:d7:bd:b8:2d:d5:c1:c3:c4:db:55:68:
-         dc:a3:7a:40:b9:a9:f6:04:4a:22:cf:98:76:1c:e4:a3:ff:79:
-         19:96:57:63:07:6f:f6:32:77:16:50:9b:e3:34:18:d4:eb:be:
-         fd:b6:6f:e3:c7:f6:85:bf:ac:32:ad:98:57:be:13:92:44:10:
-         a5:f3:ae:e2:66:da:44:a9:94:71:3f:d0:2f:20:59:87:e4:5a:
-         40:ee:d2:e4:0c:ce:25:94:dc:0f:fe:38:e0:41:52:34:5c:bb:
-         c3:db:c1:5f:76:c3:5d:0e:32:69:2b:9d:01:ed:50:1b:4f:77:
-         a9:a9:d8:71:30:cb:2e:2c:70:00:ab:78:4b:d7:15:d9:17:f8:
-         64:b2:f7:3a:da:e1:0b:8b:0a:e1:4e:b1:03:46:14:ca:94:e3:
-         44:77:d7:59
+         b4:54:60:ad:a0:03:32:de:02:7f:21:4a:81:c6:ed:cd:cd:d8:
+         12:8a:c0:ba:82:5b:75:ad:54:e3:7c:80:6a:ac:2e:6c:20:4e:
+         be:4d:82:a7:47:13:5c:f4:c6:6a:2b:10:99:58:de:ab:6b:7c:
+         22:05:c1:83:9d:cb:ff:3c:e4:2d:57:6a:a6:96:df:d3:c1:68:
+         e3:d2:c6:83:4b:97:e2:c6:32:0e:be:c4:03:b9:07:8a:5b:b8:
+         84:ba:c5:39:3f:1c:58:a7:55:d7:f0:9b:e8:d2:45:b9:e3:83:
+         2e:ee:b6:71:56:b9:3a:ee:3f:27:d8:77:e8:fb:44:48:65:27:
+         47:4c:fb:fe:72:c3:ac:05:7b:1d:cb:eb:5e:65:9a:ab:02:e4:
+         88:5b:3b:8b:0b:c7:cc:a9:a6:8b:e1:87:b0:19:1a:0c:28:58:
+         6f:99:52:7e:ed:b0:3a:68:3b:8c:0a:08:74:72:ab:b9:09:c5:
+         ed:04:7e:6f:0b:1c:09:21:d0:cd:7f:f9:c4:5e:27:20:e4:85:
+         73:52:05:d2:ba:f8:d5:8f:41:cc:23:2e:12:6d:bc:31:98:e7:
+         63:a3:8e:26:cd:e8:2b:88:ee:e2:fe:3a:74:52:34:0e:fd:12:
+         e5:5e:69:50:20:31:34:e4:31:f1:e7:e4:5b:03:13:da:ac:41:
+         6c:e7:cf:2b
 -----BEGIN CERTIFICATE-----
 MIIEnjCCA4agAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMx
 EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
 d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
-bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTUwNTA3
-MTgyMTAxWhcNMTgwMTMxMTgyMTAxWjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTgwNDEz
+MTUyMzEwWhcNMjEwMTA3MTUyMzEwWjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
 B01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xEDAOBgNVBAoMB3dvbGZTU0wxEDAO
 BgNVBAsMB1N1cHBvcnQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
 SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
@@ -76,23 +76,23 @@ sxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAUJ45nEXTDJh0/7TNj
 s6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5h
 MRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwK
 Q29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcN
-AQkBFhBpbmZvQHdvbGZzc2wuY29tggkA2YA6w9L02jcwDAYDVR0TBAUwAwEB/zAN
-BgkqhkiG9w0BAQsFAAOCAQEAZ8AsqUNH5xEUd67M2OBrI4KRY+ioDSHFyEeXL9Xz
-hvtsziX5fHjIOiJo8hYe0tI/JASH8rfBYmO6xfqu0iCBGtIMriZrGysQ0+GaTmRs
-l9s2qI/4BWO/ug2IC4dGyeRk49e9uC3VwcPE21Vo3KN6QLmp9gRKIs+Ydhzko/95
-GZZXYwdv9jJ3FlCb4zQY1Ou+/bZv48f2hb+sMq2YV74TkkQQpfOu4mbaRKmUcT/Q
-LyBZh+RaQO7S5AzOJZTcD/444EFSNFy7w9vBX3bDXQ4yaSudAe1QG093qanYcTDL
-LixwAKt4S9cV2Rf4ZLL3OtrhC4sK4U6xA0YUypTjRHfXWQ==
+AQkBFhBpbmZvQHdvbGZzc2wuY29tggkAhv/1jhDeuPswDAYDVR0TBAUwAwEB/zAN
+BgkqhkiG9w0BAQsFAAOCAQEAtFRgraADMt4CfyFKgcbtzc3YEorAuoJbda1U43yA
+aqwubCBOvk2Cp0cTXPTGaisQmVjeq2t8IgXBg53L/zzkLVdqppbf08Fo49LGg0uX
+4sYyDr7EA7kHilu4hLrFOT8cWKdV1/Cb6NJFueODLu62cVa5Ou4/J9h36PtESGUn
+R0z7/nLDrAV7HcvrXmWaqwLkiFs7iwvHzKmmi+GHsBkaDChYb5lSfu2wOmg7jAoI
+dHKruQnF7QR+bwscCSHQzX/5xF4nIOSFc1IF0rr41Y9BzCMuEm28MZjnY6OOJs3o
+K4ju4v46dFI0Dv0S5V5pUCAxNOQx8efkWwMT2qxBbOfPKw==
 -----END CERTIFICATE-----
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 15672591315981621815 (0xd9803ac3d2f4da37)
+        Serial Number: 9727763710660753659 (0x86fff58e10deb8fb)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Validity
-            Not Before: May  7 18:21:01 2015 GMT
-            Not After : Jan 31 18:21:01 2018 GMT
+            Not Before: Apr 13 15:23:09 2018 GMT
+            Not After : Jan  7 15:23:09 2021 GMT
         Subject: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -123,32 +123,32 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:D9:80:3A:C3:D2:F4:DA:37
+                serial:86:FF:F5:8E:10:DE:B8:FB
 
             X509v3 Basic Constraints: 
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
-         7a:af:44:3b:aa:6f:53:42:b2:33:aa:43:5f:56:30:d3:b9:96:
-         0b:9a:55:5a:39:2a:0b:4e:e4:2e:f1:95:66:c9:86:36:82:8d:
-         63:7c:4d:a2:ee:48:ba:03:c7:90:d7:a7:c6:74:60:48:5f:31:
-         a2:f9:5e:3e:c3:82:e1:e5:2f:41:81:83:29:25:79:d1:53:00:
-         69:3c:ed:0a:30:3b:41:1d:92:a1:2c:a8:9d:2c:e3:23:87:79:
-         e0:55:6e:91:a8:50:da:46:2f:c2:20:50:3e:2b:47:97:14:b0:
-         7d:04:ba:45:51:d0:6e:e1:5a:a2:4b:84:9c:4d:cd:85:04:f9:
-         28:31:82:93:bc:c7:59:49:91:03:e8:df:6a:e4:56:ad:6a:cb:
-         1f:0d:37:e4:5e:bd:e7:9f:d5:ec:9d:3c:18:25:9b:f1:2f:50:
-         7d:eb:31:cb:f1:63:22:9d:57:fc:f3:84:20:1a:c6:07:87:92:
-         26:9e:15:18:59:33:06:dc:fb:b0:b6:76:5d:f1:c1:2f:c8:2f:
-         62:9c:c0:d6:de:eb:65:77:f3:5c:a6:c3:88:27:96:75:b4:f4:
-         54:cd:ff:2d:21:2e:96:f0:07:73:4b:e9:93:92:90:de:62:d9:
-         a3:3b:ac:6e:24:5f:27:4a:b3:94:70:ff:30:17:e7:7e:32:8f:
-         65:b7:75:58
+         9e:28:88:72:00:ca:e6:e7:97:ca:c1:f1:1f:9e:12:b2:b8:c7:
+         51:ea:28:e1:36:b5:2d:e6:2f:08:23:cb:a9:4a:87:25:c6:5d:
+         89:45:ea:f5:00:98:ac:76:fb:1b:af:f0:ce:64:9e:da:08:bf:
+         b6:eb:b4:b5:0c:a0:e7:f6:47:59:1c:61:cf:2e:0e:58:a4:82:
+         ac:0f:3f:ec:c4:ae:80:f7:b0:8a:1e:85:41:e8:ff:fe:fe:4f:
+         1a:24:d5:49:fa:fb:fe:5e:e5:d3:91:0e:4f:4e:0c:21:51:71:
+         83:04:6b:62:7b:4f:59:76:48:81:1e:b4:f7:04:47:8a:91:57:
+         a3:11:a9:f2:20:b4:78:33:62:3d:b0:5e:0d:f9:86:38:82:da:
+         a1:98:8d:19:06:87:21:39:b7:02:f7:da:7d:58:ba:52:15:d8:
+         3b:c9:7b:58:34:a0:c7:e2:7c:a9:83:13:e1:b6:ec:01:bf:52:
+         33:0b:c4:fe:43:d3:c6:a4:8e:2f:87:7f:7a:44:ea:ca:53:6c:
+         85:ed:65:76:73:31:03:4e:ea:bd:35:54:13:f3:64:87:6b:df:
+         34:dd:34:a1:88:3b:db:4d:af:1b:64:90:92:71:30:8e:c8:cc:
+         e5:60:24:af:31:16:39:33:91:50:f9:ab:68:42:74:7a:35:d9:
+         dd:c8:c4:52
 -----BEGIN CERTIFICATE-----
-MIIEqjCCA5KgAwIBAgIJANmAOsPS9No3MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
+MIIEqjCCA5KgAwIBAgIJAIb/9Y4Q3rj7MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTAe
-Fw0xNTA1MDcxODIxMDFaFw0xODAxMzExODIxMDFaMIGUMQswCQYDVQQGEwJVUzEQ
+Fw0xODA0MTMxNTIzMDlaFw0yMTAxMDcxNTIzMDlaMIGUMQswCQYDVQQGEwJVUzEQ
 MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
 dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
 LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZI
@@ -162,11 +162,11 @@ XDjNdyXvvYB1U5Q8PcpjW58VtdMdEy8Z0TzbdjrMuH3J5cLX2kBv2CHccxtCLVOc
 J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
 VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
 aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
-MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkA2YA6w9L02jcwDAYD
-VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAeq9EO6pvU0KyM6pDX1Yw07mW
-C5pVWjkqC07kLvGVZsmGNoKNY3xNou5IugPHkNenxnRgSF8xovlePsOC4eUvQYGD
-KSV50VMAaTztCjA7QR2SoSyonSzjI4d54FVukahQ2kYvwiBQPitHlxSwfQS6RVHQ
-buFaokuEnE3NhQT5KDGCk7zHWUmRA+jfauRWrWrLHw035F6955/V7J08GCWb8S9Q
-fesxy/FjIp1X/POEIBrGB4eSJp4VGFkzBtz7sLZ2XfHBL8gvYpzA1t7rZXfzXKbD
-iCeWdbT0VM3/LSEulvAHc0vpk5KQ3mLZozusbiRfJ0qzlHD/MBfnfjKPZbd1WA==
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAhv/1jhDeuPswDAYD
+VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAniiIcgDK5ueXysHxH54SsrjH
+Ueoo4Ta1LeYvCCPLqUqHJcZdiUXq9QCYrHb7G6/wzmSe2gi/tuu0tQyg5/ZHWRxh
+zy4OWKSCrA8/7MSugPewih6FQej//v5PGiTVSfr7/l7l05EOT04MIVFxgwRrYntP
+WXZIgR609wRHipFXoxGp8iC0eDNiPbBeDfmGOILaoZiNGQaHITm3AvfafVi6UhXY
+O8l7WDSgx+J8qYMT4bbsAb9SMwvE/kPTxqSOL4d/ekTqylNshe1ldnMxA07qvTVU
+E/Nkh2vfNN00oYg7202vG2SQknEwjsjM5WAkrzEWOTORUPmraEJ0ejXZ3cjEUg==
 -----END CERTIFICATE-----

--- a/stunnel/example/echoserver-ssl/echoserver-ssl.c
+++ b/stunnel/example/echoserver-ssl/echoserver-ssl.c
@@ -23,6 +23,7 @@
     #include <config.h>
 #endif
 
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/settings.h>
 

--- a/stunnel/example/include/test.h
+++ b/stunnel/example/include/test.h
@@ -11,6 +11,8 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/random.h>
 
+#define INLINE    WC_INLINE
+
 #ifdef ATOMIC_USER
     #include <wolfssl/wolfcrypt/aes.h>
     #include <wolfssl/wolfcrypt/arc4.h>

--- a/stunnel/src/common.h
+++ b/stunnel/src/common.h
@@ -426,6 +426,7 @@ extern char *sys_errlist[];
 #include <wolfssl/wolfcrypt/dh.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/openssl/ec.h>
+#include <wolfssl/openssl/objects.h>
 #endif /* defined(WITH_WOLFSSL) */
 
 /**************************************** OpenSSL headers */
@@ -497,6 +498,10 @@ extern char *sys_errlist[];
 #ifndef OPENSSL_NO_SSL2
 #define OPENSSL_NO_SSL2
 #endif /* !defined(OPENSSL_NO_SSL2) */
+
+#ifndef OPENSSL_NO_MD4
+#define OPENSSL_NO_MD4
+#endif /* OPENSSL_NO_MD4 */
 
 #endif /* defined (WITH_WOLFSSL) */
 

--- a/stunnel/src/prototypes.h
+++ b/stunnel/src/prototypes.h
@@ -684,15 +684,18 @@ extern STUNNEL_RWLOCK stunnel_locks[STUNNEL_LOCKS];
 #define CRYPTO_THREAD_write_unlock(type) CRYPTO_THREAD_unlock(type)
 #elif defined(WITH_WOLFSSL)
 #define CRYPTO_THREAD_read_lock(type) \
-    if(type) CRYPTO_lock(type)
+    if(type) wc_LockMutex(type)
 #define CRYPTO_THREAD_read_unlock(type) \
-    if(type) CRYPTO_lock(type)
+    if(type) wc_UnLockMutex(type)
 #define CRYPTO_THREAD_write_lock(type) \
-    if(type) CRYPTO_lock(type)
+    if(type) wc_LockMutex(type)
 #define CRYPTO_THREAD_write_unlock(type) \
-    if(type) CRYPTO_lock(type)
+    if(type) wc_UnLockMutex(type)
 #define CRYPTO_atomic_add(addr,amount,result,type) \
     *result = type ? CRYPTO_add(addr,amount,type) : (*addr+=amount)
+
+#define CRYPTO_w_lock wc_LockMutex
+#define CRYPTO_w_unlock wc_UnLockMutex
 #else
 /* Emulate the OpenSSL 1.1 locking API for older OpenSSL versions */
 #define CRYPTO_THREAD_read_lock(type) \


### PR DESCRIPTION
Update certificates in stunnel/example to be valid (before-after dates).
In stunnel, define OPENSSL_NO_MD4 to turn off support for single DES.