### PR TITLE
change order of include paths

### DIFF
--- a/stunnel/src/Makefile.am
+++ b/stunnel/src/Makefile.am
@@ -42,7 +42,7 @@ stunnel_CPPFLAGS = -I/usr/kerberos/include
 
 # Additional preprocesor definitions
 if WOLFSSL
-stunnel_CPPFLAGS += -I$(SSLDIR)/include  -I$(SSLDIR)/include/wolfssl
+stunnel_CPPFLAGS += -I$(SSLDIR)/include/wolfssl -I$(SSLDIR)/include
 else
 stunnel_CPPFLAGS += -I$(SSLDIR)/include
 endif


### PR DESCRIPTION
Fix for if OpenSSL has been installed in the directory /usr/local/ . Otherwise redefinition errors happen from including OpenSSL headers and then including the wolfSSL version of the headers.