### PR TITLE
Make lighttpd-1.4.51 work with latest wolfSSL master.

### DIFF
--- a/lighttpd/lighttpd-1.4.51/src/mod_openssl.c
+++ b/lighttpd/lighttpd-1.4.51/src/mod_openssl.c
@@ -499,7 +499,7 @@ network_openssl_load_pemfile (server *srv, plugin_config *s, size_t ndx)
 static int
 network_openssl_ssl_conf_cmd (server *srv, plugin_config *s)
 {
-  #ifdef SSL_CONF_FLAG_CMDLINE
+  #if defined(SSL_CONF_FLAG_CMDLINE) && !defined(HAVE_WOLFSSL_SSL_H)
 
     int rc = 0;
     data_string *ds;


### PR DESCRIPTION
Our integration with this version is currently broken because we now define the
macro SSL_CONF_FLAG_CMDLINE whereas we didn't in 4.7.0. That causes new code in
mod_openssl.c to be included. In that code, lighty calls SSL_CONF_CTX_set_flags
with flags we don't support. The solution for now is to ensure that this code
isn't compiled in the first place, as was the case back in 4.7.0.