### PR TITLE
Patch for NXP SE05X Middleware wolfSSL HostCrypto support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Each project port included in this repository is contained in its own subdirecto
 | mariadb | MariaDB relational database | [Link](https://mariadb.org/) | | [README](./mariadb/10.5.11/README.md) |
 | net-snmp | Simple Network Management Protocol | [Link](http://www.net-snmp.org/) | | [README](./net-snmp/README.md) |
 | ntp | Network Time Protocol | [Link](http://www.ntp.org/) | [Link](https://www.wolfssl.com/open-source-project-ports-ntp/) | [README](./ntp/4.2.8p15/README.md) |
+| NXP SE05X Middleware | wolfSSL HostCrypto support patch | [Link](https://www.nxp.com/products/security-and-authentication/authentication/edgelock-se050-plug-trust-secure-element-family-enhanced-iot-security-with-high-flexibility:SE050) | | [README](./nxp-se05x-middleware/README.md) |
 | openldap | Open source lightweight directory access protocol | [Link](https://www.openldap.org/) | [Link](https://www.wolfssl.com/open-source-project-ports-openldap/) | [README](./openldap/2.4.47/README.md) |
 | openpegasus  | Open source DMTF CIM and WBEM | [Link](https://collaboration.opengroup.org/pegasus/) | [Link](https://www.wolfssl.com/openpegasus-port-support-added-wolfssl/) | [README](./openpegasus/2.14.1/README.md) |
 | openresty | Nginx and LuaJIT-based web platform | [Link](https://openresty.org/en/) | | [README](./openresty/INSTRUCTIONS.md) |

--- a/nxp-se05x-middleware/README.md
+++ b/nxp-se05x-middleware/README.md
@@ -1,0 +1,126 @@
+# NXP SE05x Middleware HostCrypto Patch
+
+This directory contains a patch for NXP's SE05x Middleware that adds a
+HostCrypto option for using wolfSSL. The primary use case for this functionality
+at the time of writing is for users who wish to use wolfSSL to establish
+an authenticated SCP03 channel to SE050. This allows use of wolfSSL for both
+SCP03 HostCrypto authentication as well as usage of wolfSSL with SE050 support
+enabled by an application post-SCP03-authentication.
+
+## Applying the Patch
+
+This patch will apply cleanly on top of the SE05x Middleware version v04.02.00:
+
+```
+$ unzip SE05x_MW.zip -d se_mw
+$ ls se_mw
+se05x_mw_v04.02.00_20220701_151557
+
+$ cd se_mw/se05x_mw_v04.02.00_20220701_151557/simw-top
+$ cp <path/to/simw-top.patch> ./
+$ patch -p1 < simw-top.patch
+```
+
+For more complete wolfSSL SE050 documentation, refer to
+[README_SE050.md](https://github.com/wolfSSL/wolfssl/blob/master/wolfcrypt/src/port/nxp/README_SE050.md).
+
+## Building SE05x Middlware on Raspberry Pi with SE050 EdgeLock Dev Kit
+
+To build the patched SE05x Middleware linked to wolfSSL, first build wolfSSL.
+For use with SE05x Middleware HostCrypto, this requires `--enable-keygen` and
+`--enable-cmac`. `WOLFSSL_SE050_NO_TRNG` will also need to be added to CFLAGS
+in order to cause wolfSSL to fall back and use `/dev/urandom` instead of trying
+to use the SE050 TRNG before SCP03 authenticaiton has completed. You may also
+need to define `SIZEOF_LONG_LONG=8` if not correctly detected by configure.
+
+```
+$ unzip wolfssl-X.X.X.zip
+$ cd wolfssl-X.X.X
+$ ./configure --enable-keygen --enable-cmac CFLAGS="-DWOLFSSL_SE050_NO_TRNG -DSIZEOF_LONG_LONG=8"
+$ make
+$ sudo make install
+```
+
+Then, build SE05x Middleware:
+
+```
+$ cd se_mw/se05x_mw_v04.02.00_20220701_151557/simw-top
+$ cd scripts
+$ python create_cmake_projects.py rpi
+$ cd se_mw/se05x_mw_v04.02.00_20220701_151557/simw-top_build/raspbian_native_se050_t1oi2c/
+$ ccmake .
+$ Make sure the following are set:
+    "PTMW_Applet" to match your SE050 version (ex: "SE05X_C")
+    "PTMW_Host" to "Raspbian"
+    "PTMW_HostCrypto" to "WOLFSSL"
+    "PTMW_SE05X_Auth" to "PlatfSCP03"
+    "PTMW_SE05X_VER" to match your SE050 applet version (ex: "03_XX")
+    "PTMW_SMCOM" to "T1oI2C"
+$ c # to configure
+$ g # to generate
+$ q
+$ cmake --build .
+$ sudo make install
+```
+
+You can then verify some of the demos work, for example to run GetInfo:
+
+```
+$ cd se_mw/se05x_mw_v04.02.00_20220701_151557/simw-top_build/raspbian_native_se050_t1oi2c/bin
+$ ./se05x_GetInfo
+```
+
+There should be a line mentioning PlatfSCP03 keys, for example:
+
+```
+App   :INFO :Using default PlatfSCP03 keys. You can use keys from file using ENV=EX_SSS_BOOT_SCP03_PATH
+```
+
+## Building SE05X Middleware with wolfSSL HostCrypto Support and wolfSSL with SE050 Support
+
+wolfSSL can be built with SE050 support, to offload crypto operations to the
+SE050. Building this support plus using wolfSSL with HostCrypto can be done.
+On Raspberry Pi / Linux, this requires a roundabout build cycle due to circular
+dependencies of SE05X Middleware on wolfSSL, and wolfSSL on SE05X Middleware.
+
+The solution that seems to work for us is:
+
+1. Build and install wolfSSL **WITHOUT** SE050 support:
+
+```
+$ unzip wolfssl-X.X.X.zip
+$ cd wolfssl-X.X.X
+$ ./configure --enable-keygen --enable-cmac CFLAGS="-DWOLFSSL_SE050_NO_TRNG -DSIZEOF_LONG_LONG=8"
+$ make
+$ sudo make install
+```
+
+2. Build and install SE05X Middleware
+
+Follow steps above to build middleware. This will link against wolfSSL for
+HostCrypto support, but that wolfSSL will not have SE050 support enabled
+internally.
+
+3.  Re-build and install wolfSSL **WITH** SE050 support:
+
+```
+$ unzip wolfssl-X.X.X.zip
+$ cd wolfssl-X.X.X
+$ ./configure --with-se050 --enable-keygen --enable-cmac CFLAGS="-DWOLFSSL_SE050_NO_TRNG -DSIZEOF_LONG_LONG=8"
+$ make
+$ sudo make install
+```
+
+4. Re-build and install SE050 Middleware
+
+Follow the steps above again to build middleware. This time will link against
+a wolfSSL version with SE050 support enabled internally.
+
+## wolfSSL Examples for SE050
+
+For examples of wolfSSL on SE050, see the [wolfssl-examples repo](https://github.com/wolfSSL/wolfssl-examples/tree/master/SE050).
+
+## Support
+
+For support, please contact wolfSSL at support@wolfssl.com.
+

--- a/nxp-se05x-middleware/simw-top.patch
+++ b/nxp-se05x-middleware/simw-top.patch
@@ -1,0 +1,6335 @@
+diff -Naur simw-top/demos/test_Crypto/test_Crypto.h /home/pi/se_mw/simw-top/demos/test_Crypto/test_Crypto.h
+--- simw-top/demos/test_Crypto/test_Crypto.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/demos/test_Crypto/test_Crypto.h	2022-10-20 11:57:45.572291620 -0600
+@@ -12,6 +12,7 @@
+ #include "fsl_sss_api.h"
+ #include "fsl_sss_user_apis.h"
+ #include "fsl_sss_mbedtls_apis.h"
++#include "fsl_sss_wolfssl_apis.h"
+ #include "fsl_sss_openssl_apis.h"
+ #include "nxLog_App.h"
+ 
+diff -Naur simw-top/hostlib/hostLib/inc/ax_api.h /home/pi/se_mw/simw-top/hostlib/hostLib/inc/ax_api.h
+--- simw-top/hostlib/hostLib/inc/ax_api.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/hostlib/hostLib/inc/ax_api.h	2022-10-19 13:43:20.535538483 -0600
+@@ -46,7 +46,7 @@
+ #endif
+ #include "a71ch_api.h"
+ #include "ax_common_a71ch.h"
+-#elif (SSS_HAVE_HOSTCRYPTO_MBEDTLS || SSS_HAVE_HOSTCRYPTO_OPENSSL || SSS_HAVE_HOSCRYPTO_USER)
++#elif (SSS_HAVE_HOSTCRYPTO_MBEDTLS || SSS_HAVE_HOSTCRYPTO_OPENSSL || SSS_HAVE_HOSTCRYPTO_WOLFSSL || SSS_HAVE_HOSCRYPTO_USER)
+ /* Nothing specific to do */
+ #else
+ #error "Define TGT_X (the secure module target, either TGT_A71CH, TGT_A70CI or TGT_A70CM) as a preprocessor constant"
+diff -Naur simw-top/hostlib/hostLib/inc/nxScp03_Types.h /home/pi/se_mw/simw-top/hostlib/hostLib/inc/nxScp03_Types.h
+--- simw-top/hostlib/hostLib/inc/nxScp03_Types.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/hostlib/hostLib/inc/nxScp03_Types.h	2022-10-19 13:45:19.564384672 -0600
+@@ -29,6 +29,9 @@
+ #if SSS_HAVE_HOSTCRYPTO_USER
+ #   include <fsl_sss_user_apis.h>
+ #endif
++/* <fsl_sss_wolfssl_apis.h> is included in nxScp03_Com.c instead when
++ * SSS_HAVE_HOSTCRYPTO_WOLFSSL is defined, since wolfSSL proper
++ * includes SDK files that need the below struct declarations */
+ 
+ #include "sm_api.h"
+ #if SSS_HAVE_SSCP
+diff -Naur simw-top/hostlib/hostLib/libCommon/nxScp/nxScp03_Com.c /home/pi/se_mw/simw-top/hostlib/hostLib/libCommon/nxScp/nxScp03_Com.c
+--- simw-top/hostlib/hostLib/libCommon/nxScp/nxScp03_Com.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/hostlib/hostLib/libCommon/nxScp/nxScp03_Com.c	2022-10-19 13:47:51.352913956 -0600
+@@ -25,6 +25,8 @@
+ #include <fsl_sss_mbedtls_apis.h>
+ #elif SSS_HAVE_HOSTCRYPTO_OPENSSL
+ #include <fsl_sss_openssl_apis.h>
++#elif SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_apis.h>
+ #elif SSS_HAVE_HOSTCRYPTO_USER
+ #include <fsl_sss_user_apis.h>
+ #else
+diff -Naur simw-top/scripts/cmake_features.py /home/pi/se_mw/simw-top/scripts/cmake_features.py
+--- simw-top/scripts/cmake_features.py	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_features.py	2022-10-19 17:13:30.614883504 -0600
+@@ -168,6 +168,7 @@
+     + SSS_HAVE_APPLET_SE05X_IOT      \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     )
+ 
+diff -Naur simw-top/scripts/cmake_options_check.cmake /home/pi/se_mw/simw-top/scripts/cmake_options_check.cmake
+--- simw-top/scripts/cmake_options_check.cmake	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options_check.cmake	2022-10-19 17:14:53.303997526 -0600
+@@ -42,7 +42,7 @@
+ ELSE()
+     SET(SSS_HAVE_MBEDTLS_ALT OFF)
+ ENDIF()
+-IF(SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_USER)
++IF(SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_WOLFSSL OR SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_USER)
+     SET(SSS_HAVE_HOSTCRYPTO_ANY ON)
+ ELSE()
+     SET(SSS_HAVE_HOSTCRYPTO_ANY OFF)
+diff -Naur simw-top/scripts/cmake_options.h.in /home/pi/se_mw/simw-top/scripts/cmake_options.h.in
+--- simw-top/scripts/cmake_options.h.in	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options.h.in	2022-10-19 17:09:59.117173542 -0600
+@@ -118,6 +118,9 @@
+ /** Use mbedTLS as host crypto */
+ #cmakedefine01 SSS_HAVE_HOSTCRYPTO_MBEDTLS
+ 
++/** Use wolfSSL as host crypto */
++#cmakedefine01 SSS_HAVE_HOSTCRYPTO_WOLFSSL
++
+ /** Use OpenSSL as host crypto */
+ #cmakedefine01 SSS_HAVE_HOSTCRYPTO_OPENSSL
+ 
+diff -Naur simw-top/scripts/cmake_options_installed.cmake.in /home/pi/se_mw/simw-top/scripts/cmake_options_installed.cmake.in
+--- simw-top/scripts/cmake_options_installed.cmake.in	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options_installed.cmake.in	2022-10-19 17:13:06.685140763 -0600
+@@ -167,6 +167,9 @@
+ # Use mbedTLS as host crypto
+ SET(SSS_HAVE_HOSTCRYPTO_MBEDTLS ${SSS_HAVE_HOSTCRYPTO_MBEDTLS})
+ 
++# Use wolfSSL as host crypto
++SET(SSS_HAVE_HOSTCRYPTO_WOLFSSL ${SSS_HAVE_HOSTCRYPTO_WOLFSSL})
++
+ # Use OpenSSL as host crypto
+ SET(SSS_HAVE_HOSTCRYPTO_OPENSSL ${SSS_HAVE_HOSTCRYPTO_OPENSSL})
+ 
+diff -Naur simw-top/scripts/cmake_options.mak.in /home/pi/se_mw/simw-top/scripts/cmake_options.mak.in
+--- simw-top/scripts/cmake_options.mak.in	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options.mak.in	2022-10-19 17:14:19.344360855 -0600
+@@ -76,6 +76,7 @@
+ # What is being used as a cryptographic library on the host.
+ # As of now only OpenSSL / mbedTLS is supported
+ SSS_HAVE_HOSTCRYPTO_MBEDTLS := ${SSS_HAVE_HOSTCRYPTO_MBEDTLS}
++SSS_HAVE_HOSTCRYPTO_WOLFSSL := ${SSS_HAVE_HOSTCRYPTO_WOLFSSL}
+ SSS_HAVE_HOSTCRYPTO_OPENSSL := ${SSS_HAVE_HOSTCRYPTO_OPENSSL}
+ SSS_HAVE_HOSTCRYPTO_USER := ${SSS_HAVE_HOSTCRYPTO_USER}
+ SSS_HAVE_HOSTCRYPTO_NONE := ${SSS_HAVE_HOSTCRYPTO_NONE}
+@@ -292,6 +293,9 @@
+ # Use mbedTLS as host crypto
+ SSS_HAVE_HOSTCRYPTO_MBEDTLS := ${SSS_HAVE_HOSTCRYPTO_MBEDTLS}
+ 
++# Use wolfSSL as host crypto
++SSS_HAVE_HOSTCRYPTO_WOLFSSL := ${SSS_HAVE_HOSTCRYPTO_WOLFSSL}
++
+ # Use OpenSSL as host crypto
+ SSS_HAVE_HOSTCRYPTO_OPENSSL := ${SSS_HAVE_HOSTCRYPTO_OPENSSL}
+ 
+diff -Naur simw-top/scripts/cmake_options.py /home/pi/se_mw/simw-top/scripts/cmake_options.py
+--- simw-top/scripts/cmake_options.py	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options.py	2022-10-19 17:08:28.248171032 -0600
+@@ -174,6 +174,7 @@
+ 
+ LIST_HOSTCRYPTO = [
+     ("MBEDTLS", "Use mbedTLS as host crypto", True),
++    ("WOLFSSL", "Use wolfSSL as host crypto", True),
+     ("OPENSSL", "Use OpenSSL as host crypto", True),
+     ("User", (
+         "User Implementation of Host Crypto",
+@@ -282,7 +283,7 @@
+     ("PTMW_HostCrypto", "MBEDTLS",
+      ("Counterpart Crypto on Host", "",
+       "What is being used as a cryptographic library on the host.",
+-      "As of now only OpenSSL / mbedTLS is supported",
++      "As of now only OpenSSL / mbedTLS / wolfSSL are supported",
+       ), LIST_HOSTCRYPTO),
+     ("PTMW_RTOS", "Default",
+      ("Choice of Operating system", "",
+diff -Naur simw-top/scripts/cmake_options_values.cmake /home/pi/se_mw/simw-top/scripts/cmake_options_values.cmake
+--- simw-top/scripts/cmake_options_values.cmake	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options_values.cmake	2022-10-19 17:12:32.285511324 -0600
+@@ -116,14 +116,14 @@
+         CACHE PTMW_HostCrypto
+         PROPERTY
+             STRINGS
+-            "MBEDTLS;OPENSSL;User;None;"
++            "MBEDTLS;WOLFSSL;OPENSSL;User;None;"
+     )
+ ELSE()
+     SET_PROPERTY(
+         CACHE PTMW_HostCrypto
+         PROPERTY
+             STRINGS
+-            "MBEDTLS;OPENSSL;User;None;"
++            "MBEDTLS;WOLFSSL;OPENSSL;User;None;"
+     )
+ ENDIF()
+ 
+@@ -800,6 +800,14 @@
+     SET(SSS_HAVE_HOSTCRYPTO_MBEDTLS "0")
+ ENDIF()
+ 
++IF("${PTMW_HostCrypto}" STREQUAL "WOLFSSL")
++    # SET(WithPTMW_HostCrypto_WOLFSSL ON)
++    SET(SSS_HAVE_HOSTCRYPTO_WOLFSSL "1")
++ELSE()
++    # SET(WithPTMW_HostCrypto_WOLFSSL OFF)
++    SET(SSS_HAVE_HOSTCRYPTO_WOLFSSL "0")
++ENDIF()
++
+ IF("${PTMW_HostCrypto}" STREQUAL "OPENSSL")
+     # SET(WithPTMW_HostCrypto_OPENSSL ON)
+     SET(SSS_HAVE_HOSTCRYPTO_OPENSSL "1")
+@@ -826,6 +834,8 @@
+ 
+ IF("${PTMW_HostCrypto}" STREQUAL "MBEDTLS")
+     # OK
++ELSEIF("${PTMW_HostCrypto}" STREQUAL "WOLFSSL")
++    # OK
+ ELSEIF("${PTMW_HostCrypto}" STREQUAL "OPENSSL")
+     # OK
+ ELSEIF("${PTMW_HostCrypto}" STREQUAL "User")
+@@ -834,7 +844,7 @@
+     # OK
+ ELSE()
+     MESSAGE(SEND_ERROR "For 'PTMW_HostCrypto' '${PTMW_HostCrypto}' is invalid.")
+-    MESSAGE(STATUS "Only supported values are 'MBEDTLS, OPENSSL, User, None'")
++    MESSAGE(STATUS "Only supported values are 'MBEDTLS, WOLFSSL, OPENSSL, User, None'")
+ ENDIF()
+ 
+ IF("${PTMW_RTOS}" STREQUAL "Default")
+diff -Naur simw-top/scripts/cmake_options_values.rst.txt /home/pi/se_mw/simw-top/scripts/cmake_options_values.rst.txt
+--- simw-top/scripts/cmake_options_values.rst.txt	2022-07-01 15:16:00.000000000 -0600
++++ /home/pi/se_mw/simw-top/scripts/cmake_options_values.rst.txt	2022-10-19 17:10:29.746839371 -0600
+@@ -154,6 +154,8 @@
+ 
+     ``-DPTMW_HostCrypto=MBEDTLS``: Use mbedTLS as host crypto
+ 
++    ``-DPTMW_HostCrypto=WOLFSSL``: Use wolfSSL as host crypto
++
+     ``-DPTMW_HostCrypto=OPENSSL``: Use OpenSSL as host crypto
+ 
+     ``-DPTMW_HostCrypto=User``: User Implementation of Host Crypto
+diff -Naur simw-top/sss/CMakeLists.txt /home/pi/se_mw/simw-top/sss/CMakeLists.txt
+--- simw-top/sss/CMakeLists.txt	2022-07-01 15:16:00.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/CMakeLists.txt	2022-10-20 11:55:42.613483928 -0600
+@@ -26,6 +26,7 @@
+     src/mbedtls/*.c
+     src/mbedtls/*.cpp
+     src/openssl/*.c
++    src/wolfssl/*.c
+     src/keystore/*.c
+     src/a71cx_common/*.c
+     src/lpc55s/*.c
+@@ -56,6 +57,10 @@
+     TARGET_LINK_LIBRARIES(${PROJECT_NAME} mbedtls)
+ ENDIF()
+ 
++IF(SSS_HAVE_HOSTCRYPTO_WOLFSSL)
++    TARGET_LINK_LIBRARIES(${PROJECT_NAME} wolfssl)
++ENDIF()
++
+ IF((SSS_HAVE_HOST_LINUX_LIKE OR SSS_HAVE_HOST_PCWINDOWS OR SSS_HAVE_HOST_DARWIN OR SSS_HAVE_HOST_WIN10IOT))
+     TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
+ ENDIF()
+@@ -163,8 +168,10 @@
+             OR SSS_HAVE_APPLET_SE05X_IOT
+             OR SSS_HAVE_HOSTCRYPTO_MBEDTLS
+         )
+-            IF(NOT "${OPENSSL_LIBRARIES}" STREQUAL "")
+-                ADD_SUBDIRECTORY(plugin/openssl)
++            IF(NOT SSS_HAVE_HOSTCRYPTO_WOLFSSL)
++                IF(NOT "${OPENSSL_LIBRARIES}" STREQUAL "")
++                    ADD_SUBDIRECTORY(plugin/openssl)
++                ENDIF()
+             ENDIF()
+         ENDIF()
+     ENDIF()
+diff -Naur simw-top/sss/ex/attest_ecc/ex_sss_ecc_attest.c /home/pi/se_mw/simw-top/sss/ex/attest_ecc/ex_sss_ecc_attest.c
+--- simw-top/sss/ex/attest_ecc/ex_sss_ecc_attest.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/attest_ecc/ex_sss_ecc_attest.c	2022-10-20 11:33:52.917255073 -0600
+@@ -30,8 +30,8 @@
+ /* ************************************************************************** */
+ 
+ static ex_sss_boot_ctx_t gex_sss_ecc_boot_ctx;
+-sss_object_t ecc_key;
+-sss_object_t attestation_ecc_key;
++sss_object_t eccKey;
++sss_object_t attestation_eccKey;
+ sss_algorithm_t attst_algorithm = kAlgorithm_SSS_ECDSA_SHA256;
+ sss_se05x_attst_data_t attestation_data;
+ 
+@@ -150,12 +150,12 @@
+ 
+     LOG_I("Running ECC key attestation example ex_sss_attest_ecc.c ");
+ 
+-    LOG_I("Inject ECC key pair - 'ecc_key'");
++    LOG_I("Inject ECC key pair - 'eccKey'");
+ 
+-    status = sss_key_object_init(&ecc_key, &pCtx->ks);
++    status = sss_key_object_init(&eccKey, &pCtx->ks);
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+-    status = sss_key_object_allocate_handle(&ecc_key,
++    status = sss_key_object_allocate_handle(&eccKey,
+         MAKE_TEST_ID(__LINE__),
+         kSSS_KeyPart_Pair,
+         kSSS_CipherType_EC_NIST_P,
+@@ -164,15 +164,15 @@
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+     status = sss_key_store_set_key(
+-        &pCtx->ks, &ecc_key, ecc_keyPairData, sizeof(ecc_keyPairData), EC_KEY_NIST256_BIT_LEN, NULL, 0);
++        &pCtx->ks, &eccKey, ecc_keyPairData, sizeof(ecc_keyPairData), EC_KEY_NIST256_BIT_LEN, NULL, 0);
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+-    LOG_I("Create a attestation ECC key pair - 'attestation_ecc_key'");
++    LOG_I("Create a attestation ECC key pair - 'attestation_eccKey'");
+ 
+-    status = sss_key_object_init(&attestation_ecc_key, &pCtx->ks);
++    status = sss_key_object_init(&attestation_eccKey, &pCtx->ks);
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+-    status = sss_key_object_allocate_handle(&attestation_ecc_key,
++    status = sss_key_object_allocate_handle(&attestation_eccKey,
+         MAKE_TEST_ID(__LINE__),
+         kSSS_KeyPart_Pair,
+         kSSS_CipherType_EC_NIST_P,
+@@ -181,20 +181,20 @@
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+     status =
+-        sss_key_store_generate_key(&pCtx->ks, &attestation_ecc_key, EC_KEY_NIST256_BIT_LEN, &attestation_ecc_key_pol);
++        sss_key_store_generate_key(&pCtx->ks, &attestation_eccKey, EC_KEY_NIST256_BIT_LEN, &attestation_ecc_key_pol);
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+     status = ex_sss_initialise_attst_data(&attestation_data);
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+-    LOG_I("Read public key from ECC key pair 'ecc_key' with attestation");
++    LOG_I("Read public key from ECC key pair 'eccKey' with attestation");
+ 
+     status = sss_se05x_key_store_get_key_attst((sss_se05x_key_store_t *)(&pCtx->ks),
+-        (sss_se05x_object_t *)(&ecc_key),
++        (sss_se05x_object_t *)(&eccKey),
+         publicKey,
+         &publicKeyByteLen,
+         &publicKeyBitLen,
+-        (sss_se05x_object_t *)(&attestation_ecc_key),
++        (sss_se05x_object_t *)(&attestation_eccKey),
+         attst_algorithm,
+         random,
+         sizeof(random),
+@@ -212,7 +212,7 @@
+     LOG_MAU8_I("Signature", attestation_data.data[0].signature, attestation_data.data[0].signatureLen);
+ 
+     /********* Verify attestation signature *********/
+-    LOG_I("Verify attestation signature using 'attestation_ecc_key' key");
++    LOG_I("Verify attestation signature using 'attestation_eccKey' key");
+ 
+     /* Singing is done on public key without header */
+     status = ex_sss_verify_attested_key(
+@@ -361,7 +361,7 @@
+     /* verify the attestation signature */
+ 
+     status = sss_asymmetric_context_init(
+-        &asymVerifyCtx, &pCtx->session, &attestation_ecc_key, attst_algorithm, kMode_SSS_Verify);
++        &asymVerifyCtx, &pCtx->session, &attestation_eccKey, attst_algorithm, kMode_SSS_Verify);
+     ENSURE_OR_GO_CLEANUP(status == kStatus_SSS_Success);
+ 
+     status = sss_asymmetric_verify_digest(
+diff -Naur simw-top/sss/ex/CMakeLists.txt /home/pi/se_mw/simw-top/sss/ex/CMakeLists.txt
+--- simw-top/sss/ex/CMakeLists.txt	2022-07-01 15:16:00.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/CMakeLists.txt	2022-10-21 10:35:20.069305686 -0600
+@@ -35,9 +35,9 @@
+         ADD_SUBDIRECTORY(hmac)
+     ENDIF()
+ 
+-    IF(SSS_HAVE_ECC OR (SSS_HAVE_APPLET_NONE AND (SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_MBEDTLS)))
++    IF(SSS_HAVE_ECC OR (SSS_HAVE_APPLET_NONE AND (SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_WOLFSSL)))
+         ADD_SUBDIRECTORY(ecc)
+-        IF(SSS_HAVE_TPM_BN OR (SSS_HAVE_APPLET_NONE AND (SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_MBEDTLS)))
++        IF(SSS_HAVE_TPM_BN OR (SSS_HAVE_APPLET_NONE AND (SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_WOLFSSL)))
+             IF(NXPInternal)
+                 ADD_SUBDIRECTORY(ecdaa)
+             ENDIF()
+@@ -52,7 +52,7 @@
+             ENDIF()
+         ENDIF()
+     ENDIF()
+-    IF(SSS_HAVE_RSA OR (SSS_HAVE_APPLET_NONE AND (SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_MBEDTLS)))
++    IF(SSS_HAVE_RSA OR (SSS_HAVE_APPLET_NONE AND (SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_WOLFSSL)))
+         IF(NOT SSS_HAVE_APPLET_SE051_UWB)
+             ADD_SUBDIRECTORY(rsa)
+         ENDIF()
+diff -Naur simw-top/sss/ex/inc/ex_sss.h /home/pi/se_mw/simw-top/sss/ex/inc/ex_sss.h
+--- simw-top/sss/ex/inc/ex_sss.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/inc/ex_sss.h	2022-10-20 11:30:40.729454999 -0600
+@@ -25,6 +25,9 @@
+ #if SSS_HAVE_HOSTCRYPTO_MBEDTLS
+ #include <fsl_sss_mbedtls_apis.h>
+ #endif
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_apis.h>
++#endif
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ #include <fsl_sss_openssl_apis.h>
+ #endif
+diff -Naur simw-top/sss/ex/src/CMakeLists.txt /home/pi/se_mw/simw-top/sss/ex/src/CMakeLists.txt
+--- simw-top/sss/ex/src/CMakeLists.txt	2022-07-01 15:16:00.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/src/CMakeLists.txt	2022-10-21 10:36:57.108447042 -0600
+@@ -56,7 +56,7 @@
+     )
+ ENDIF()
+ 
+-IF(SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_OPENSSL)
++IF(SSS_HAVE_HOSTCRYPTO_MBEDTLS OR SSS_HAVE_HOSTCRYPTO_OPENSSL OR SSS_HAVE_HOSTCRYPTO_WOLFSSL)
+     FILE(
+         GLOB
+         mbedtls_files
+diff -Naur simw-top/sss/ex/src/ex_sss_boot.c /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_boot.c
+--- simw-top/sss/ex/src/ex_sss_boot.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_boot.c	2022-10-19 13:50:09.401576858 -0600
+@@ -79,6 +79,8 @@
+     status = ex_sss_boot_se_open(pCtx, portName);
+ #elif SSS_HAVE_HOSTCRYPTO_MBEDTLS
+     status = ex_sss_boot_mbedtls_open(pCtx, portName);
++#elif SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    status = ex_sss_boot_wolfssl_open(pCtx, portName);
+ #elif SSS_HAVE_HOSTCRYPTO_OPENSSL
+     status = ex_sss_boot_openssl_open(pCtx, portName);
+ #endif
+@@ -119,6 +121,8 @@
+ 
+ #elif SSS_HAVE_HOSTCRYPTO_MBEDTLS
+     status = kStatus_SSS_Success;
++#elif SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    status = kStatus_SSS_Success;
+ #elif SSS_HAVE_HOSTCRYPTO_OPENSSL
+     status = kStatus_SSS_Success;
+ #else
+diff -Naur simw-top/sss/ex/src/ex_sss_boot_int.h /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_boot_int.h
+--- simw-top/sss/ex/src/ex_sss_boot_int.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_boot_int.h	2022-10-19 13:51:57.610529029 -0600
+@@ -55,6 +55,10 @@
+ sss_status_t ex_sss_boot_mbedtls_open(ex_sss_boot_ctx_t *pCtx, const char *portName);
+ #endif
+ 
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++sss_status_t ex_sss_boot_wolfssl_open(ex_sss_boot_ctx_t *pCtx, const char *portName);
++#endif
++
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ sss_status_t ex_sss_boot_openssl_open(ex_sss_boot_ctx_t *pCtx, const char *portName);
+ #endif
+diff -Naur simw-top/sss/ex/src/ex_sss_boot_sw.c /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_boot_sw.c
+--- simw-top/sss/ex/src/ex_sss_boot_sw.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_boot_sw.c	2022-10-21 10:38:57.947349107 -0600
+@@ -69,6 +69,30 @@
+ }
+ #endif
+ 
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++sss_status_t ex_sss_boot_wolfssl_open(ex_sss_boot_ctx_t *pCtx, const char *portName)
++{
++    sss_status_t status = kStatus_SSS_Fail;
++#ifdef NO_FILESYSTEM
++    portName = NULL;
++#else
++    if (portName == NULL) {
++        portName = TEST_ROOT_FOLDER;
++    }
++#endif
++    if (pCtx != NULL) {
++        status = sss_session_open(&pCtx->session, kType_SSS_wolfSSL, 0, kSSS_ConnectionType_Plain, (void *)portName);
++        if (status != kStatus_SSS_Success) {
++            LOG_E("wolfSSL Session open failed...");
++            goto cleanup;
++        }
++    }
++
++cleanup:
++    return status;
++}
++#endif
++
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ sss_status_t ex_sss_boot_openssl_open(ex_sss_boot_ctx_t *pCtx, const char *portName)
+ {
+diff -Naur simw-top/sss/ex/src/ex_sss_se05x_auth.c /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_se05x_auth.c
+--- simw-top/sss/ex/src/ex_sss_se05x_auth.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/ex/src/ex_sss_se05x_auth.c	2022-10-21 10:41:15.556068003 -0600
+@@ -151,6 +151,8 @@
+ 
+ #if SSS_HAVE_HOSTCRYPTO_MBEDTLS
+         hostsubsystem = kType_SSS_mbedTLS;
++#elif SSS_HAVE_HOSTCRYPTO_WOLFSSL
++        hostsubsystem = kType_SSS_wolfSSL;
+ #elif SSS_HAVE_HOSTCRYPTO_OPENSSL
+         hostsubsystem = kType_SSS_OpenSSL;
+ #elif SSS_HAVE_HOSTCRYPTO_USER
+@@ -237,6 +239,8 @@
+ 
+ #if SSS_HAVE_HOSTCRYPTO_MBEDTLS
+     hostsubsystem = kType_SSS_mbedTLS;
++#elif SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    hostsubsystem = kType_SSS_wolfSSL;
+ #elif SSS_HAVE_HOSTCRYPTO_OPENSSL
+     hostsubsystem = kType_SSS_OpenSSL;
+ #elif SSS_HAVE_HOSTCRYPTO_USER
+diff -Naur simw-top/sss/inc/fsl_sss_api.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_api.h
+--- simw-top/sss/inc/fsl_sss_api.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_api.h	2022-10-19 13:54:38.258991604 -0600
+@@ -66,6 +66,7 @@
+     kType_SSS_Software = SSS_ENUM(0x01 << 8, 0x00),
+     kType_SSS_mbedTLS  = SSS_ENUM(kType_SSS_Software, 0x01),
+     kType_SSS_OpenSSL  = SSS_ENUM(kType_SSS_Software, 0x02),
++    kType_SSS_wolfSSL  = SSS_ENUM(kType_SSS_Software, 0x03),
+     // LCOV_EXCL_START
+     /** HOST HW Based */
+     kType_SSS_HW   = SSS_ENUM(0x02 << 8, 0x00),
+diff -Naur simw-top/sss/inc/fsl_sss_ftr_default.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_ftr_default.h
+--- simw-top/sss/inc/fsl_sss_ftr_default.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_ftr_default.h	2022-10-19 13:58:18.087385515 -0600
+@@ -145,6 +145,9 @@
+ /** Use mbedTLS as host crypto */
+ #define SSS_HAVE_HOSTCRYPTO_MBEDTLS 1
+ 
++/** Use wolfSSL as host crypto */
++#define SSS_HAVE_HOSTCRYPTO_WOLFSSL 0
++
+ /** Use OpenSSL as host crypto */
+ #define SSS_HAVE_HOSTCRYPTO_OPENSSL 0
+ 
+@@ -165,6 +168,7 @@
+ 
+ #if (( 0                             \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     + SSS_HAVE_HOSTCRYPTO_NONE       \
+@@ -175,6 +179,7 @@
+ 
+ #if (( 0                             \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     + SSS_HAVE_HOSTCRYPTO_NONE       \
+@@ -512,7 +517,7 @@
+  (SSS_HAVE_MBEDTLS_ALT_SSS | SSS_HAVE_MBEDTLS_ALT_A71CH | SSS_HAVE_MBEDTLS_ALT_PSA)
+ 
+ #define SSS_HAVE_HOSTCRYPTO_ANY \
+- (SSS_HAVE_HOSTCRYPTO_MBEDTLS | SSS_HAVE_HOSTCRYPTO_OPENSSL | SSS_HAVE_HOSTCRYPTO_USER)
++ (SSS_HAVE_HOSTCRYPTO_MBEDTLS | SSS_HAVE_HOSTCRYPTO_WOLFSSL || SSS_HAVE_HOSTCRYPTO_OPENSSL | SSS_HAVE_HOSTCRYPTO_USER)
+ 
+ #define SSS_HAVE_FIPS \
+  (SSS_HAVE_FIPS_SE050 | SSS_HAVE_FIPS_140_2 | SSS_HAVE_FIPS_140_3)
+@@ -616,6 +621,7 @@
+     + SSS_HAVE_APPLET_SE05X_IOT      \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     )
+ 
+diff -Naur simw-top/sss/inc/fsl_sss_ftr.h.in /home/pi/se_mw/simw-top/sss/inc/fsl_sss_ftr.h.in
+--- simw-top/sss/inc/fsl_sss_ftr.h.in	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_ftr.h.in	2022-10-20 10:16:56.640122715 -0600
+@@ -145,6 +145,9 @@
+ /** Use mbedTLS as host crypto */
+ #cmakedefine01 SSS_HAVE_HOSTCRYPTO_MBEDTLS
+ 
++/** Use wolfSSL as host crypto */
++#cmakedefine01 SSS_HAVE_HOSTCRYPTO_WOLFSSL
++
+ /** Use OpenSSL as host crypto */
+ #cmakedefine01 SSS_HAVE_HOSTCRYPTO_OPENSSL
+ 
+@@ -165,6 +168,7 @@
+ 
+ #if (( 0                             \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     + SSS_HAVE_HOSTCRYPTO_NONE       \
+@@ -175,6 +179,7 @@
+ 
+ #if (( 0                             \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     + SSS_HAVE_HOSTCRYPTO_NONE       \
+@@ -512,7 +517,7 @@
+  (SSS_HAVE_MBEDTLS_ALT_SSS | SSS_HAVE_MBEDTLS_ALT_A71CH | SSS_HAVE_MBEDTLS_ALT_PSA)
+ 
+ #define SSS_HAVE_HOSTCRYPTO_ANY \
+- (SSS_HAVE_HOSTCRYPTO_MBEDTLS | SSS_HAVE_HOSTCRYPTO_OPENSSL | SSS_HAVE_HOSTCRYPTO_USER)
++ (SSS_HAVE_HOSTCRYPTO_MBEDTLS | SSS_HAVE_HOSTCRYPTO_WOLFSSL | SSS_HAVE_HOSTCRYPTO_OPENSSL | SSS_HAVE_HOSTCRYPTO_USER)
+ 
+ #define SSS_HAVE_FIPS \
+  (SSS_HAVE_FIPS_SE050 | SSS_HAVE_FIPS_140_2 | SSS_HAVE_FIPS_140_3)
+@@ -616,6 +621,7 @@
+     + SSS_HAVE_APPLET_SE05X_IOT      \
+     + SSS_HAVE_HOSTCRYPTO_OPENSSL    \
+     + SSS_HAVE_HOSTCRYPTO_MBEDTLS    \
++    + SSS_HAVE_HOSTCRYPTO_WOLFSSL    \
+     + SSS_HAVE_HOSTCRYPTO_USER       \
+     )
+ 
+diff -Naur simw-top/sss/inc/fsl_sss_mbedtls_apis.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_mbedtls_apis.h
+--- simw-top/sss/inc/fsl_sss_mbedtls_apis.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_mbedtls_apis.h	2022-10-19 13:59:24.346867563 -0600
+@@ -695,7 +695,7 @@
+ #       define sss_rng_context_free(context) \
+             sss_mbedtls_rng_context_free(((sss_mbedtls_rng_context_t * ) context))
+ #   endif /* (SSS_HAVE_SSS == 1) */
+-#   if (SSS_HAVE_HOSTCRYPTO_OPENSSL == 0)
++#   if (SSS_HAVE_HOSTCRYPTO_OPENSSL == 0) && (SSS_HAVE_HOSTCRYPTO_WOLFSSL == 0)
+         /* Host Call : session */
+ #       define sss_host_session_create(session,subsystem,application_id,connection_type,connectionData) \
+             sss_mbedtls_session_create(((sss_mbedtls_session_t * ) session),(subsystem),(application_id),(connection_type),(connectionData))
+diff -Naur simw-top/sss/inc/fsl_sss_openssl_apis.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_openssl_apis.h
+--- simw-top/sss/inc/fsl_sss_openssl_apis.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_openssl_apis.h	2022-10-19 14:00:19.616425974 -0600
+@@ -695,7 +695,7 @@
+ #       define sss_rng_context_free(context) \
+             sss_openssl_rng_context_free(((sss_openssl_rng_context_t * ) context))
+ #   endif /* (SSS_HAVE_SSS == 1) */
+-#   if (SSS_HAVE_HOSTCRYPTO_MBEDTLS == 0)
++#   if (SSS_HAVE_HOSTCRYPTO_MBEDTLS == 0) && (SSS_HAVE_HOSTCRYPTO_WOLFSSL == 0)
+         /* Host Call : session */
+ #       define sss_host_session_create(session,subsystem,application_id,connection_type,connectionData) \
+             sss_openssl_session_create(((sss_openssl_session_t * ) session),(subsystem),(application_id),(connection_type),(connectionData))
+diff -Naur simw-top/sss/inc/fsl_sss_se05x_scp03.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_se05x_scp03.h
+--- simw-top/sss/inc/fsl_sss_se05x_scp03.h	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_se05x_scp03.h	2022-10-19 14:01:31.135843191 -0600
+@@ -24,6 +24,9 @@
+ #if SSS_HAVE_HOSTCRYPTO_MBEDTLS
+ #include <fsl_sss_mbedtls_apis.h>
+ #endif
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_apis.h>
++#endif
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ #include <fsl_sss_openssl_apis.h>
+ #endif
+diff -Naur simw-top/sss/inc/fsl_sss_wolfssl_apis.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_wolfssl_apis.h
+--- simw-top/sss/inc/fsl_sss_wolfssl_apis.h	1969-12-31 17:00:00.000000000 -0700
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_wolfssl_apis.h	2022-10-19 13:34:24.150747751 -0600
+@@ -0,0 +1,894 @@
++/*
++ *
++ * Copyright 2018-2020 NXP
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++#ifndef FSL_SSS_WOLFSSL_APIS_H
++#define FSL_SSS_WOLFSSL_APIS_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif /* __cplusplus */
++
++#if defined(SSS_USE_FTR_FILE)
++#include "fsl_sss_ftr.h"
++#else
++#include "fsl_sss_ftr_default.h"
++#endif
++
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_types.h>
++
++/* ************************************************************************** */
++/* Functions                                                                  */
++/* ************************************************************************** */
++/**
++ * @addtogroup sss_wolfssl_session
++ * @{
++ */
++/** @copydoc sss_session_create
++ *
++ */
++sss_status_t sss_wolfssl_session_create(sss_wolfssl_session_t *session,
++    sss_type_t subsystem,
++    uint32_t application_id,
++    sss_connection_type_t connection_type,
++    void *connectionData);
++
++/** @copydoc sss_session_open
++ *
++ */
++sss_status_t sss_wolfssl_session_open(sss_wolfssl_session_t *session,
++    sss_type_t subsystem,
++    uint32_t application_id,
++    sss_connection_type_t connection_type,
++    void *connectionData);
++
++/** @copydoc sss_session_prop_get_u32
++ *
++ */
++sss_status_t sss_wolfssl_session_prop_get_u32(sss_wolfssl_session_t *session,
++    uint32_t property, uint32_t *pValue);
++
++/** @copydoc sss_session_prop_get_au8
++ *
++ */
++sss_status_t sss_wolfssl_session_prop_get_au8(
++    sss_wolfssl_session_t *session, uint32_t property, uint8_t *pValue,
++    size_t *pValueLen);
++
++/** @copydoc sss_session_close
++ *
++ */
++void sss_wolfssl_session_close(sss_wolfssl_session_t *session);
++
++/** @copydoc sss_session_delete
++ *
++ */
++void sss_wolfssl_session_delete(sss_wolfssl_session_t *session);
++
++/*! @} */ /* end of : sss_wolfssl_session */
++
++/**
++ * @addtogroup sss_wolfssl_keyobj
++ * @{
++ */
++/** @copydoc sss_key_object_init
++ *
++ */
++sss_status_t sss_wolfssl_key_object_init(sss_wolfssl_object_t *keyObject,
++    sss_wolfssl_key_store_t *keyStore);
++
++/** @copydoc sss_key_object_allocate_handle
++ *
++ */
++sss_status_t sss_wolfssl_key_object_allocate_handle(sss_wolfssl_object_t *keyObject,
++    uint32_t keyId,
++    sss_key_part_t keyPart,
++    sss_cipher_type_t cipherType,
++    size_t keyByteLenMax,
++    uint32_t options);
++
++/** @copydoc sss_key_object_get_handle
++ *
++ */
++sss_status_t sss_wolfssl_key_object_get_handle(sss_wolfssl_object_t *keyObject,
++    uint32_t keyId);
++
++/** @copydoc sss_key_object_set_user
++ *
++ */
++sss_status_t sss_wolfssl_key_object_set_user(sss_wolfssl_object_t *keyObject,
++    uint32_t user, uint32_t options);
++
++/** @copydoc sss_key_object_set_purpose
++ *
++ */
++sss_status_t sss_wolfssl_key_object_set_purpose(sss_wolfssl_object_t *keyObject,
++    sss_mode_t purpose, uint32_t options);
++
++/** @copydoc sss_key_object_set_access
++ *
++ */
++sss_status_t sss_wolfssl_key_object_set_access(sss_wolfssl_object_t *keyObject,
++    uint32_t access, uint32_t options);
++
++/** @copydoc sss_key_object_set_eccgfp_group
++ *
++ */
++sss_status_t sss_wolfssl_key_object_set_eccgfp_group(
++    sss_wolfssl_object_t *keyObject, sss_eccgfp_group_t *group);
++
++/** @copydoc sss_key_object_get_user
++ *
++ */
++sss_status_t sss_wolfssl_key_object_get_user(sss_wolfssl_object_t *keyObject,
++    uint32_t *user);
++
++/** @copydoc sss_key_object_get_purpose
++ *
++ */
++sss_status_t sss_wolfssl_key_object_get_purpose(sss_wolfssl_object_t *keyObject,
++    sss_mode_t *purpose);
++
++/** @copydoc sss_key_object_get_access
++ *
++ */
++sss_status_t sss_wolfssl_key_object_get_access(sss_wolfssl_object_t *keyObject,
++    uint32_t *access);
++
++/** @copydoc sss_key_object_free
++ *
++ */
++void sss_wolfssl_key_object_free(sss_wolfssl_object_t *keyObject);
++
++/*! @} */ /* end of : sss_wolfssl_keyobj */
++
++/**
++ * @addtogroup sss_wolfssl_keyderive
++ * @{
++ */
++/** @copydoc sss_derive_key_context_init
++ *
++ */
++sss_status_t sss_wolfssl_derive_key_context_init(
++    sss_wolfssl_derive_key_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode);
++
++/** @copydoc sss_derive_key_one_go
++*
++*/
++sss_status_t sss_wolfssl_derive_key_one_go(sss_wolfssl_derive_key_t *context,
++    const uint8_t *saltData,
++    size_t saltLen,
++    const uint8_t *info,
++    size_t infoLen,
++    sss_wolfssl_object_t *derivedKeyObject,
++    uint16_t deriveDataLen);
++
++/** @copydoc sss_derive_key_sobj_one_go
++*
++*/
++sss_status_t sss_wolfssl_derive_key_sobj_one_go(
++    sss_wolfssl_derive_key_t *context,
++    sss_wolfssl_object_t *saltKeyObject,
++    const uint8_t *info,
++    size_t infoLen,
++    sss_wolfssl_object_t *derivedKeyObject,
++    uint16_t deriveDataLen);
++
++/** @copydoc sss_derive_key_go
++ *
++ */
++sss_status_t sss_wolfssl_derive_key_go(sss_wolfssl_derive_key_t *context,
++    const uint8_t *saltData,
++    size_t saltLen,
++    const uint8_t *info,
++    size_t infoLen,
++    sss_wolfssl_object_t *derivedKeyObject,
++    uint16_t deriveDataLen,
++    uint8_t *hkdfOutput,
++    size_t *hkdfOutputLen);
++
++/** @copydoc sss_derive_key_dh
++ *
++ */
++sss_status_t sss_wolfssl_derive_key_dh(sss_wolfssl_derive_key_t *context,
++    sss_wolfssl_object_t *otherPartyKeyObject,
++    sss_wolfssl_object_t *derivedKeyObject);
++
++/** @copydoc sss_derive_key_context_free
++ *
++ */
++void sss_wolfssl_derive_key_context_free(sss_wolfssl_derive_key_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_keyderive */
++
++/**
++ * @addtogroup sss_wolfssl_keystore
++ * @{
++ */
++/** @copydoc sss_key_store_context_init
++ *
++ */
++sss_status_t sss_wolfssl_key_store_context_init(
++    sss_wolfssl_key_store_t *keyStore, sss_wolfssl_session_t *session);
++
++/** @copydoc sss_key_store_allocate
++ *
++ */
++sss_status_t sss_wolfssl_key_store_allocate(
++    sss_wolfssl_key_store_t *keyStore, uint32_t keyStoreId);
++
++/** @copydoc sss_key_store_save
++ *
++ */
++sss_status_t sss_wolfssl_key_store_save(sss_wolfssl_key_store_t *keyStore);
++
++/** @copydoc sss_key_store_load
++ *
++ */
++sss_status_t sss_wolfssl_key_store_load(sss_wolfssl_key_store_t *keyStore);
++
++/** @copydoc sss_key_store_set_key
++ *
++ */
++sss_status_t sss_wolfssl_key_store_set_key(sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject,
++    const uint8_t *data,
++    size_t dataLen,
++    size_t keyBitLen,
++    void *options,
++    size_t optionsLen);
++
++/** @copydoc sss_key_store_generate_key
++ *
++ */
++sss_status_t sss_wolfssl_key_store_generate_key(
++    sss_wolfssl_key_store_t *keyStore, sss_wolfssl_object_t *keyObject,
++    size_t keyBitLen, void *options);
++
++/** @copydoc sss_key_store_get_key
++ *
++ */
++sss_status_t sss_wolfssl_key_store_get_key(sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject,
++    uint8_t *data,
++    size_t *dataLen,
++    size_t *pKeyBitLen);
++
++/** @copydoc sss_key_store_open_key
++ *
++ */
++sss_status_t sss_wolfssl_key_store_open_key(sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject);
++
++/** @copydoc sss_key_store_freeze_key
++ *
++ */
++sss_status_t sss_wolfssl_key_store_freeze_key(sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject);
++
++/** @copydoc sss_key_store_erase_key
++ *
++ */
++sss_status_t sss_wolfssl_key_store_erase_key(sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject);
++
++/** @copydoc sss_key_store_context_free
++ *
++ */
++void sss_wolfssl_key_store_context_free(sss_wolfssl_key_store_t *keyStore);
++
++/*! @} */ /* end of : sss_wolfssl_keystore */
++
++/**
++ * @addtogroup sss_wolfssl_asym
++ * @{
++ */
++/** @copydoc sss_asymmetric_context_init
++ *
++ */
++sss_status_t sss_wolfssl_asymmetric_context_init(
++    sss_wolfssl_asymmetric_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode);
++
++/** @copydoc sss_asymmetric_encrypt
++ *
++ */
++sss_status_t sss_wolfssl_asymmetric_encrypt(
++    sss_wolfssl_asymmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen);
++
++/** @copydoc sss_asymmetric_decrypt
++ *
++ */
++sss_status_t sss_wolfssl_asymmetric_decrypt(
++    sss_wolfssl_asymmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen);
++
++/** @copydoc sss_asymmetric_sign_digest
++ *
++ */
++sss_status_t sss_wolfssl_asymmetric_sign_digest(
++    sss_wolfssl_asymmetric_t *context, uint8_t *digest, size_t digestLen,
++    uint8_t *signature, size_t *signatureLen);
++
++/** @copydoc sss_asymmetric_verify_digest
++ *
++ */
++sss_status_t sss_wolfssl_asymmetric_verify_digest(
++    sss_wolfssl_asymmetric_t *context, uint8_t *digest, size_t digestLen,
++    uint8_t *signature, size_t signatureLen);
++
++/** @copydoc sss_asymmetric_context_free
++ *
++ */
++void sss_wolfssl_asymmetric_context_free(sss_wolfssl_asymmetric_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_asym */
++
++/**
++ * @addtogroup sss_wolfssl_symm
++ * @{
++ */
++/** @copydoc sss_symmetric_context_init
++ *
++ */
++sss_status_t sss_wolfssl_symmetric_context_init(
++    sss_wolfssl_symmetric_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode);
++
++/** @copydoc sss_cipher_one_go
++ *
++ */
++sss_status_t sss_wolfssl_cipher_one_go(sss_wolfssl_symmetric_t *context,
++    uint8_t *iv,
++    size_t ivLen,
++    const uint8_t *srcData,
++    uint8_t *destData,
++    size_t dataLen);
++
++/** @copydoc sss_cipher_one_go_v2
++ *
++ */
++sss_status_t sss_wolfssl_cipher_one_go_v2(sss_wolfssl_symmetric_t *context,
++    uint8_t *iv,
++    size_t ivLen,
++    const uint8_t *srcData,
++    const size_t srcLen,
++    uint8_t *destData,
++    size_t *pDataLen);
++
++/** @copydoc sss_cipher_init
++ *
++ */
++sss_status_t sss_wolfssl_cipher_init(sss_wolfssl_symmetric_t *context,
++    uint8_t *iv, size_t ivLen);
++
++/** @copydoc sss_cipher_update
++ *
++ */
++sss_status_t sss_wolfssl_cipher_update(
++    sss_wolfssl_symmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen);
++
++/** @copydoc sss_cipher_finish
++ *
++ */
++sss_status_t sss_wolfssl_cipher_finish(
++    sss_wolfssl_symmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen);
++
++/** @copydoc sss_cipher_crypt_ctr
++ *
++ */
++sss_status_t sss_wolfssl_cipher_crypt_ctr(sss_wolfssl_symmetric_t *context,
++    const uint8_t *srcData,
++    uint8_t *destData,
++    size_t size,
++    uint8_t *initialCounter,
++    uint8_t *lastEncryptedCounter,
++    size_t *szLeft);
++
++/** @copydoc sss_symmetric_context_free
++ *
++ */
++void sss_wolfssl_symmetric_context_free(sss_wolfssl_symmetric_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_symm */
++
++/**
++ * @addtogroup sss_wolfssl_aead
++ * @{
++ */
++/** @copydoc sss_aead_context_init
++ *
++ */
++sss_status_t sss_wolfssl_aead_context_init(sss_wolfssl_aead_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode);
++
++/** @copydoc sss_aead_one_go
++ *
++ */
++sss_status_t sss_wolfssl_aead_one_go(sss_wolfssl_aead_t *context,
++    const uint8_t *srcData,
++    uint8_t *destData,
++    size_t size,
++    uint8_t *nonce,
++    size_t nonceLen,
++    const uint8_t *aad,
++    size_t aadLen,
++    uint8_t *tag,
++    size_t *tagLen);
++
++/** @copydoc sss_aead_init
++ *
++ */
++sss_status_t sss_wolfssl_aead_init(
++    sss_wolfssl_aead_t *context, uint8_t *nonce, size_t nonceLen, size_t tagLen,
++    size_t aadLen, size_t payloadLen);
++
++/** @copydoc sss_aead_update_aad
++ *
++ */
++sss_status_t sss_wolfssl_aead_update_aad(sss_wolfssl_aead_t *context,
++    const uint8_t *aadData, size_t aadDataLen);
++
++/** @copydoc sss_aead_update
++ *
++ */
++sss_status_t sss_wolfssl_aead_update(
++    sss_wolfssl_aead_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen);
++
++/** @copydoc sss_aead_finish
++ *
++ */
++sss_status_t sss_wolfssl_aead_finish(sss_wolfssl_aead_t *context,
++    const uint8_t *srcData,
++    size_t srcLen,
++    uint8_t *destData,
++    size_t *destLen,
++    uint8_t *tag,
++    size_t *tagLen);
++
++/** @copydoc sss_aead_context_free
++ *
++ */
++void sss_wolfssl_aead_context_free(sss_wolfssl_aead_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_aead */
++
++/**
++ * @addtogroup sss_wolfssl_mac
++ * @{
++ */
++/** @copydoc sss_mac_context_init
++ *
++ */
++sss_status_t sss_wolfssl_mac_context_init(sss_wolfssl_mac_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode);
++
++/** @copydoc sss_mac_one_go
++ *
++ */
++sss_status_t sss_wolfssl_mac_one_go(
++    sss_wolfssl_mac_t *context, const uint8_t *message, size_t messageLen,
++    uint8_t *mac, size_t *macLen);
++
++/** @copydoc sss_mac_init
++ *
++ */
++sss_status_t sss_wolfssl_mac_init(sss_wolfssl_mac_t *context);
++
++/** @copydoc sss_mac_update
++ *
++ */
++sss_status_t sss_wolfssl_mac_update(sss_wolfssl_mac_t *context,
++    const uint8_t *message, size_t messageLen);
++
++/** @copydoc sss_mac_finish
++ *
++ */
++sss_status_t sss_wolfssl_mac_finish(sss_wolfssl_mac_t *context, uint8_t *mac,
++    size_t *macLen);
++
++/** @copydoc sss_mac_context_free
++ *
++ */
++void sss_wolfssl_mac_context_free(sss_wolfssl_mac_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_mac */
++
++/**
++ * @addtogroup sss_wolfssl_md
++ * @{
++ */
++/** @copydoc sss_digest_context_init
++ *
++ */
++sss_status_t sss_wolfssl_digest_context_init(
++    sss_wolfssl_digest_t *context, sss_wolfssl_session_t *session,
++    sss_algorithm_t algorithm, sss_mode_t mode);
++
++/** @copydoc sss_digest_one_go
++ *
++ */
++sss_status_t sss_wolfssl_digest_one_go(
++    sss_wolfssl_digest_t *context, const uint8_t *message, size_t messageLen,
++    uint8_t *digest, size_t *digestLen);
++
++/** @copydoc sss_digest_init
++ *
++ */
++sss_status_t sss_wolfssl_digest_init(sss_wolfssl_digest_t *context);
++
++/** @copydoc sss_digest_update
++ *
++ */
++sss_status_t sss_wolfssl_digest_update(sss_wolfssl_digest_t *context,
++    const uint8_t *message, size_t messageLen);
++
++/** @copydoc sss_digest_finish
++ *
++ */
++sss_status_t sss_wolfssl_digest_finish(sss_wolfssl_digest_t *context,
++    uint8_t *digest, size_t *digestLen);
++
++/** @copydoc sss_digest_context_free
++ *
++ */
++void sss_wolfssl_digest_context_free(sss_wolfssl_digest_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_md */
++
++/**
++ * @addtogroup sss_wolfssl_rng
++ * @{
++ */
++/** @copydoc sss_rng_context_init
++ *
++ */
++sss_status_t sss_wolfssl_rng_context_init(sss_wolfssl_rng_context_t *context,
++    sss_wolfssl_session_t *session);
++
++/** @copydoc sss_rng_get_random
++ *
++ */
++sss_status_t sss_wolfssl_rng_get_random(sss_wolfssl_rng_context_t *context,
++    uint8_t *random_data, size_t dataLen);
++
++/** @copydoc sss_rng_context_free
++ *
++ */
++sss_status_t sss_wolfssl_rng_context_free(sss_wolfssl_rng_context_t *context);
++
++/*! @} */ /* end of : sss_wolfssl_rng */
++
++/* clang-format off */
++#   if (SSS_HAVE_SSS == 1)
++        /* Direct Call : session */
++#       define sss_session_create(session,subsystem,application_id,connection_type,connectionData) \
++            sss_wolfssl_session_create(((sss_wolfssl_session_t * ) session),(subsystem),(application_id),(connection_type),(connectionData))
++#       define sss_session_open(session,subsystem,application_id,connection_type,connectionData) \
++            sss_wolfssl_session_open(((sss_wolfssl_session_t * ) session),(subsystem),(application_id),(connection_type),(connectionData))
++#       define sss_session_prop_get_u32(session,property,pValue) \
++            sss_wolfssl_session_prop_get_u32(((sss_wolfssl_session_t * ) session),(property),(pValue))
++#       define sss_session_prop_get_au8(session,property,pValue,pValueLen) \
++            sss_wolfssl_session_prop_get_au8(((sss_wolfssl_session_t * ) session),(property),(pValue),(pValueLen))
++#       define sss_session_close(session) \
++            sss_wolfssl_session_close(((sss_wolfssl_session_t * ) session))
++#       define sss_session_delete(session) \
++            sss_wolfssl_session_delete(((sss_wolfssl_session_t * ) session))
++        /* Direct Call : keyobj */
++#       define sss_key_object_init(keyObject,keyStore) \
++            sss_wolfssl_key_object_init(((sss_wolfssl_object_t * ) keyObject),((sss_wolfssl_key_store_t * ) keyStore))
++#       define sss_key_object_allocate_handle(keyObject,keyId,keyPart,cipherType,keyByteLenMax,options) \
++            sss_wolfssl_key_object_allocate_handle(((sss_wolfssl_object_t * ) keyObject),(keyId),(keyPart),(cipherType),(keyByteLenMax),(options))
++#       define sss_key_object_get_handle(keyObject,keyId) \
++            sss_wolfssl_key_object_get_handle(((sss_wolfssl_object_t * ) keyObject),(keyId))
++#       define sss_key_object_set_user(keyObject,user,options) \
++            sss_wolfssl_key_object_set_user(((sss_wolfssl_object_t * ) keyObject),(user),(options))
++#       define sss_key_object_set_purpose(keyObject,purpose,options) \
++            sss_wolfssl_key_object_set_purpose(((sss_wolfssl_object_t * ) keyObject),(purpose),(options))
++#       define sss_key_object_set_access(keyObject,access,options) \
++            sss_wolfssl_key_object_set_access(((sss_wolfssl_object_t * ) keyObject),(access),(options))
++#       define sss_key_object_set_eccgfp_group(keyObject,group) \
++            sss_wolfssl_key_object_set_eccgfp_group(((sss_wolfssl_object_t * ) keyObject),(group))
++#       define sss_key_object_get_user(keyObject,user) \
++            sss_wolfssl_key_object_get_user(((sss_wolfssl_object_t * ) keyObject),(user))
++#       define sss_key_object_get_purpose(keyObject,purpose) \
++            sss_wolfssl_key_object_get_purpose(((sss_wolfssl_object_t * ) keyObject),(purpose))
++#       define sss_key_object_get_access(keyObject,access) \
++            sss_wolfssl_key_object_get_access(((sss_wolfssl_object_t * ) keyObject),(access))
++#       define sss_key_object_free(keyObject) \
++            sss_wolfssl_key_object_free(((sss_wolfssl_object_t * ) keyObject))
++        /* Direct Call : keyderive */
++#       define sss_derive_key_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_derive_key_context_init(((sss_wolfssl_derive_key_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_derive_key_one_go(context,saltData,saltLen,info,infoLen,derivedKeyObject,deriveDataLen) \
++            sss_wolfssl_derive_key_one_go(((sss_wolfssl_derive_key_t * ) context),(saltData),(saltLen),(info),(infoLen),((sss_wolfssl_object_t * ) derivedKeyObject),(deriveDataLen))
++#       define sss_derive_key_sobj_one_go(context,saltKeyObject,info,infoLen,derivedKeyObject,deriveDataLen) \
++            sss_wolfssl_derive_key_sobj_one_go(((sss_wolfssl_derive_key_t * ) context),((sss_wolfssl_object_t *)saltKeyObject),(info),(infoLen),((sss_wolfssl_object_t * ) derivedKeyObject),(deriveDataLen))
++#       define sss_derive_key_go(context,saltData,saltLen,info,infoLen,derivedKeyObject,deriveDataLen,hkdfOutput,hkdfOutputLen) \
++            sss_wolfssl_derive_key_go(((sss_wolfssl_derive_key_t * ) context),(saltData),(saltLen),(info),(infoLen),((sss_wolfssl_object_t * ) derivedKeyObject),(deriveDataLen),(hkdfOutput),(hkdfOutputLen))
++#       define sss_derive_key_dh(context,otherPartyKeyObject,derivedKeyObject) \
++            sss_wolfssl_derive_key_dh(((sss_wolfssl_derive_key_t * ) context),((sss_wolfssl_object_t * ) otherPartyKeyObject),((sss_wolfssl_object_t * ) derivedKeyObject))
++#       define sss_derive_key_context_free(context) \
++            sss_wolfssl_derive_key_context_free(((sss_wolfssl_derive_key_t * ) context))
++        /* Direct Call : keystore */
++#       define sss_key_store_context_init(keyStore,session) \
++            sss_wolfssl_key_store_context_init(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_session_t * ) session))
++#       define sss_key_store_allocate(keyStore,keyStoreId) \
++            sss_wolfssl_key_store_allocate(((sss_wolfssl_key_store_t * ) keyStore),(keyStoreId))
++#       define sss_key_store_save(keyStore) \
++            sss_wolfssl_key_store_save(((sss_wolfssl_key_store_t * ) keyStore))
++#       define sss_key_store_load(keyStore) \
++            sss_wolfssl_key_store_load(((sss_wolfssl_key_store_t * ) keyStore))
++#       define sss_key_store_set_key(keyStore,keyObject,data,dataLen,keyBitLen,options,optionsLen) \
++            sss_wolfssl_key_store_set_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject),(data),(dataLen),(keyBitLen),(options),(optionsLen))
++#       define sss_key_store_generate_key(keyStore,keyObject,keyBitLen,options) \
++            sss_wolfssl_key_store_generate_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject),(keyBitLen),(options))
++#       define sss_key_store_get_key(keyStore,keyObject,data,dataLen,pKeyBitLen) \
++            sss_wolfssl_key_store_get_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject),(data),(dataLen),(pKeyBitLen))
++#       define sss_key_store_open_key(keyStore,keyObject) \
++            sss_wolfssl_key_store_open_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject))
++#       define sss_key_store_freeze_key(keyStore,keyObject) \
++            sss_wolfssl_key_store_freeze_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject))
++#       define sss_key_store_erase_key(keyStore,keyObject) \
++            sss_wolfssl_key_store_erase_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject))
++#       define sss_key_store_context_free(keyStore) \
++            sss_wolfssl_key_store_context_free(((sss_wolfssl_key_store_t * ) keyStore))
++        /* Direct Call : asym */
++#       define sss_asymmetric_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_asymmetric_context_init(((sss_wolfssl_asymmetric_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_asymmetric_encrypt(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_asymmetric_encrypt(((sss_wolfssl_asymmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_asymmetric_decrypt(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_asymmetric_decrypt(((sss_wolfssl_asymmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_asymmetric_sign_digest(context,digest,digestLen,signature,signatureLen) \
++            sss_wolfssl_asymmetric_sign_digest(((sss_wolfssl_asymmetric_t * ) context),(digest),(digestLen),(signature),(signatureLen))
++#       define sss_asymmetric_verify_digest(context,digest,digestLen,signature,signatureLen) \
++            sss_wolfssl_asymmetric_verify_digest(((sss_wolfssl_asymmetric_t * ) context),(digest),(digestLen),(signature),(signatureLen))
++#       define sss_asymmetric_context_free(context) \
++            sss_wolfssl_asymmetric_context_free(((sss_wolfssl_asymmetric_t * ) context))
++        /* Direct Call : symm */
++#       define sss_symmetric_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_symmetric_context_init(((sss_wolfssl_symmetric_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_cipher_one_go(context,iv,ivLen,srcData,destData,dataLen) \
++            sss_wolfssl_cipher_one_go(((sss_wolfssl_symmetric_t * ) context),(iv),(ivLen),(srcData),(destData),(dataLen))
++#       define sss_cipher_one_go_v2(context,iv,ivLen,srcData,srcLen,destData,pDataLen) \
++            sss_wolfssl_cipher_one_go_v2(((sss_wolfssl_symmetric_t * ) context),(iv),(ivLen),(srcData),(srcLen),(destData),(pDataLen))
++#       define sss_cipher_init(context,iv,ivLen) \
++            sss_wolfssl_cipher_init(((sss_wolfssl_symmetric_t * ) context),(iv),(ivLen))
++#       define sss_cipher_update(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_cipher_update(((sss_wolfssl_symmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_cipher_finish(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_cipher_finish(((sss_wolfssl_symmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_cipher_crypt_ctr(context,srcData,destData,size,initialCounter,lastEncryptedCounter,szLeft) \
++            sss_wolfssl_cipher_crypt_ctr(((sss_wolfssl_symmetric_t * ) context),(srcData),(destData),(size),(initialCounter),(lastEncryptedCounter),(szLeft))
++#       define sss_symmetric_context_free(context) \
++            sss_wolfssl_symmetric_context_free(((sss_wolfssl_symmetric_t * ) context))
++        /* Direct Call : aead */
++#       define sss_aead_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_aead_context_init(((sss_wolfssl_aead_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_aead_one_go(context,srcData,destData,size,nonce,nonceLen,aad,aadLen,tag,tagLen) \
++            sss_wolfssl_aead_one_go(((sss_wolfssl_aead_t * ) context),(srcData),(destData),(size),(nonce),(nonceLen),(aad),(aadLen),(tag),(tagLen))
++#       define sss_aead_init(context,nonce,nonceLen,tagLen,aadLen,payloadLen) \
++            sss_wolfssl_aead_init(((sss_wolfssl_aead_t * ) context),(nonce),(nonceLen),(tagLen),(aadLen),(payloadLen))
++#       define sss_aead_update_aad(context,aadData,aadDataLen) \
++            sss_wolfssl_aead_update_aad(((sss_wolfssl_aead_t * ) context),(aadData),(aadDataLen))
++#       define sss_aead_update(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_aead_update(((sss_wolfssl_aead_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_aead_finish(context,srcData,srcLen,destData,destLen,tag,tagLen) \
++            sss_wolfssl_aead_finish(((sss_wolfssl_aead_t * ) context),(srcData),(srcLen),(destData),(destLen),(tag),(tagLen))
++#       define sss_aead_context_free(context) \
++            sss_wolfssl_aead_context_free(((sss_wolfssl_aead_t * ) context))
++        /* Direct Call : mac */
++#       define sss_mac_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_mac_context_init(((sss_wolfssl_mac_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_mac_one_go(context,message,messageLen,mac,macLen) \
++            sss_wolfssl_mac_one_go(((sss_wolfssl_mac_t * ) context),(message),(messageLen),(mac),(macLen))
++#       define sss_mac_init(context) \
++            sss_wolfssl_mac_init(((sss_wolfssl_mac_t * ) context))
++#       define sss_mac_update(context,message,messageLen) \
++            sss_wolfssl_mac_update(((sss_wolfssl_mac_t * ) context),(message),(messageLen))
++#       define sss_mac_finish(context,mac,macLen) \
++            sss_wolfssl_mac_finish(((sss_wolfssl_mac_t * ) context),(mac),(macLen))
++#       define sss_mac_context_free(context) \
++            sss_wolfssl_mac_context_free(((sss_wolfssl_mac_t * ) context))
++        /* Direct Call : md */
++#       define sss_digest_context_init(context,session,algorithm,mode) \
++            sss_wolfssl_digest_context_init(((sss_wolfssl_digest_t * ) context),((sss_wolfssl_session_t * ) session),(algorithm),(mode))
++#       define sss_digest_one_go(context,message,messageLen,digest,digestLen) \
++            sss_wolfssl_digest_one_go(((sss_wolfssl_digest_t * ) context),(message),(messageLen),(digest),(digestLen))
++#       define sss_digest_init(context) \
++            sss_wolfssl_digest_init(((sss_wolfssl_digest_t * ) context))
++#       define sss_digest_update(context,message,messageLen) \
++            sss_wolfssl_digest_update(((sss_wolfssl_digest_t * ) context),(message),(messageLen))
++#       define sss_digest_finish(context,digest,digestLen) \
++            sss_wolfssl_digest_finish(((sss_wolfssl_digest_t * ) context),(digest),(digestLen))
++#       define sss_digest_context_free(context) \
++            sss_wolfssl_digest_context_free(((sss_wolfssl_digest_t * ) context))
++        /* Direct Call : rng */
++#       define sss_rng_context_init(context,session) \
++            sss_wolfssl_rng_context_init(((sss_wolfssl_rng_context_t * ) context),((sss_wolfssl_session_t * ) session))
++#       define sss_rng_get_random(context,random_data,dataLen) \
++            sss_wolfssl_rng_get_random(((sss_wolfssl_rng_context_t * ) context),(random_data),(dataLen))
++#       define sss_rng_context_free(context) \
++            sss_wolfssl_rng_context_free(((sss_wolfssl_rng_context_t * ) context))
++#   endif /* (SSS_HAVE_SSS == 1) */
++#   if (SSS_HAVE_HOSTCRYPTO_MBEDTLS == 0) && (SSS_HAVE_HOSTCRYPTO_OPENSSL == 0)
++        /* Host Call : session */
++#       define sss_host_session_create(session,subsystem,application_id,connection_type,connectionData) \
++            sss_wolfssl_session_create(((sss_wolfssl_session_t * ) session),(subsystem),(application_id),(connection_type),(connectionData))
++#       define sss_host_session_open(session,subsystem,application_id,connection_type,connectionData) \
++            sss_wolfssl_session_open(((sss_wolfssl_session_t * ) session),(subsystem),(application_id),(connection_type),(connectionData))
++#       define sss_host_session_prop_get_u32(session,property,pValue) \
++            sss_wolfssl_session_prop_get_u32(((sss_wolfssl_session_t * ) session),(property),(pValue))
++#       define sss_host_session_prop_get_au8(session,property,pValue,pValueLen) \
++            sss_wolfssl_session_prop_get_au8(((sss_wolfssl_session_t * ) session),(property),(pValue),(pValueLen))
++#       define sss_host_session_close(session) \
++            sss_wolfssl_session_close(((sss_wolfssl_session_t * ) session))
++#       define sss_host_session_delete(session) \
++            sss_wolfssl_session_delete(((sss_wolfssl_session_t * ) session))
++        /* Host Call : keyobj */
++#       define sss_host_key_object_init(keyObject,keyStore) \
++            sss_wolfssl_key_object_init(((sss_wolfssl_object_t * ) keyObject),((sss_wolfssl_key_store_t * ) keyStore))
++#       define sss_host_key_object_allocate_handle(keyObject,keyId,keyPart,cipherType,keyByteLenMax,options) \
++            sss_wolfssl_key_object_allocate_handle(((sss_wolfssl_object_t * ) keyObject),(keyId),(keyPart),(cipherType),(keyByteLenMax),(options))
++#       define sss_host_key_object_get_handle(keyObject,keyId) \
++            sss_wolfssl_key_object_get_handle(((sss_wolfssl_object_t * ) keyObject),(keyId))
++#       define sss_host_key_object_set_user(keyObject,user,options) \
++            sss_wolfssl_key_object_set_user(((sss_wolfssl_object_t * ) keyObject),(user),(options))
++#       define sss_host_key_object_set_purpose(keyObject,purpose,options) \
++            sss_wolfssl_key_object_set_purpose(((sss_wolfssl_object_t * ) keyObject),(purpose),(options))
++#       define sss_host_key_object_set_access(keyObject,access,options) \
++            sss_wolfssl_key_object_set_access(((sss_wolfssl_object_t * ) keyObject),(access),(options))
++#       define sss_host_key_object_set_eccgfp_group(keyObject,group) \
++            sss_wolfssl_key_object_set_eccgfp_group(((sss_wolfssl_object_t * ) keyObject),(group))
++#       define sss_host_key_object_get_user(keyObject,user) \
++            sss_wolfssl_key_object_get_user(((sss_wolfssl_object_t * ) keyObject),(user))
++#       define sss_host_key_object_get_purpose(keyObject,purpose) \
++            sss_wolfssl_key_object_get_purpose(((sss_wolfssl_object_t * ) keyObject),(purpose))
++#       define sss_host_key_object_get_access(keyObject,access) \
++            sss_wolfssl_key_object_get_access(((sss_wolfssl_object_t * ) keyObject),(access))
++#       define sss_host_key_object_free(keyObject) \
++            sss_wolfssl_key_object_free(((sss_wolfssl_object_t * ) keyObject))
++        /* Host Call : keyderive */
++#       define sss_host_derive_key_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_derive_key_context_init(((sss_wolfssl_derive_key_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_host_derive_key_one_go(context,saltData,saltLen,saltKeyObject,info,infoLen,derivedKeyObject,deriveDataLen) \
++            sss_wolfssl_derive_key_go(((sss_wolfssl_derive_key_t * ) context),(saltData),(saltLen),((sss_wolfssl_object_t *)saltKeyObject),(info),(infoLen),((sss_wolfssl_object_t * ) derivedKeyObject),(deriveDataLen))
++#       define sss_host_derive_key_go(context,saltData,saltLen,info,infoLen,derivedKeyObject,deriveDataLen,hkdfOutput,hkdfOutputLen) \
++            sss_wolfssl_derive_key_go(((sss_wolfssl_derive_key_t * ) context),(saltData),(saltLen),(info),(infoLen),((sss_wolfssl_object_t * ) derivedKeyObject),(deriveDataLen),(hkdfOutput),(hkdfOutputLen))
++#       define sss_host_derive_key_dh(context,otherPartyKeyObject,derivedKeyObject) \
++            sss_wolfssl_derive_key_dh(((sss_wolfssl_derive_key_t * ) context),((sss_wolfssl_object_t * ) otherPartyKeyObject),((sss_wolfssl_object_t * ) derivedKeyObject))
++#       define sss_host_derive_key_context_free(context) \
++            sss_wolfssl_derive_key_context_free(((sss_wolfssl_derive_key_t * ) context))
++        /* Host Call : keystore */
++#       define sss_host_key_store_context_init(keyStore,session) \
++            sss_wolfssl_key_store_context_init(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_session_t * ) session))
++#       define sss_host_key_store_allocate(keyStore,keyStoreId) \
++            sss_wolfssl_key_store_allocate(((sss_wolfssl_key_store_t * ) keyStore),(keyStoreId))
++#       define sss_host_key_store_save(keyStore) \
++            sss_wolfssl_key_store_save(((sss_wolfssl_key_store_t * ) keyStore))
++#       define sss_host_key_store_load(keyStore) \
++            sss_wolfssl_key_store_load(((sss_wolfssl_key_store_t * ) keyStore))
++#       define sss_host_key_store_set_key(keyStore,keyObject,data,dataLen,keyBitLen,options,optionsLen) \
++            sss_wolfssl_key_store_set_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject),(data),(dataLen),(keyBitLen),(options),(optionsLen))
++#       define sss_host_key_store_generate_key(keyStore,keyObject,keyBitLen,options) \
++            sss_wolfssl_key_store_generate_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject),(keyBitLen),(options))
++#       define sss_host_key_store_get_key(keyStore,keyObject,data,dataLen,pKeyBitLen) \
++            sss_wolfssl_key_store_get_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject),(data),(dataLen),(pKeyBitLen))
++#       define sss_host_key_store_open_key(keyStore,keyObject) \
++            sss_wolfssl_key_store_open_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject))
++#       define sss_host_key_store_freeze_key(keyStore,keyObject) \
++            sss_wolfssl_key_store_freeze_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject))
++#       define sss_host_key_store_erase_key(keyStore,keyObject) \
++            sss_wolfssl_key_store_erase_key(((sss_wolfssl_key_store_t * ) keyStore),((sss_wolfssl_object_t * ) keyObject))
++#       define sss_host_key_store_context_free(keyStore) \
++            sss_wolfssl_key_store_context_free(((sss_wolfssl_key_store_t * ) keyStore))
++        /* Host Call : asym */
++#       define sss_host_asymmetric_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_asymmetric_context_init(((sss_wolfssl_asymmetric_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_host_asymmetric_encrypt(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_asymmetric_encrypt(((sss_wolfssl_asymmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_host_asymmetric_decrypt(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_asymmetric_decrypt(((sss_wolfssl_asymmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_host_asymmetric_sign_digest(context,digest,digestLen,signature,signatureLen) \
++            sss_wolfssl_asymmetric_sign_digest(((sss_wolfssl_asymmetric_t * ) context),(digest),(digestLen),(signature),(signatureLen))
++#       define sss_host_asymmetric_verify_digest(context,digest,digestLen,signature,signatureLen) \
++            sss_wolfssl_asymmetric_verify_digest(((sss_wolfssl_asymmetric_t * ) context),(digest),(digestLen),(signature),(signatureLen))
++#       define sss_host_asymmetric_context_free(context) \
++            sss_wolfssl_asymmetric_context_free(((sss_wolfssl_asymmetric_t * ) context))
++        /* Host Call : symm */
++#       define sss_host_symmetric_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_symmetric_context_init(((sss_wolfssl_symmetric_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_host_cipher_one_go(context,iv,ivLen,srcData,destData,dataLen) \
++            sss_wolfssl_cipher_one_go(((sss_wolfssl_symmetric_t * ) context),(iv),(ivLen),(srcData),(destData),(dataLen))
++#       define sss_host_cipher_one_go_v2(context,iv,ivLen,srcData,srcLen,destData,pDataLen) \
++            sss_wolfssl_cipher_one_go_v2(((sss_wolfssl_symmetric_t * ) context),(iv),(ivLen),(srcData),(srcLen),(destData),(pDataLen))
++#       define sss_host_cipher_init(context,iv,ivLen) \
++            sss_wolfssl_cipher_init(((sss_wolfssl_symmetric_t * ) context),(iv),(ivLen))
++#       define sss_host_cipher_update(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_cipher_update(((sss_wolfssl_symmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_host_cipher_finish(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_cipher_finish(((sss_wolfssl_symmetric_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_host_cipher_crypt_ctr(context,srcData,destData,size,initialCounter,lastEncryptedCounter,szLeft) \
++            sss_wolfssl_cipher_crypt_ctr(((sss_wolfssl_symmetric_t * ) context),(srcData),(destData),(size),(initialCounter),(lastEncryptedCounter),(szLeft))
++#       define sss_host_symmetric_context_free(context) \
++            sss_wolfssl_symmetric_context_free(((sss_wolfssl_symmetric_t * ) context))
++        /* Host Call : aead */
++#       define sss_host_aead_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_aead_context_init(((sss_wolfssl_aead_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_host_aead_one_go(context,srcData,destData,size,nonce,nonceLen,aad,aadLen,tag,tagLen) \
++            sss_wolfssl_aead_one_go(((sss_wolfssl_aead_t * ) context),(srcData),(destData),(size),(nonce),(nonceLen),(aad),(aadLen),(tag),(tagLen))
++#       define sss_host_aead_init(context,nonce,nonceLen,tagLen,aadLen,payloadLen) \
++            sss_wolfssl_aead_init(((sss_wolfssl_aead_t * ) context),(nonce),(nonceLen),(tagLen),(aadLen),(payloadLen))
++#       define sss_host_aead_update_aad(context,aadData,aadDataLen) \
++            sss_wolfssl_aead_update_aad(((sss_wolfssl_aead_t * ) context),(aadData),(aadDataLen))
++#       define sss_host_aead_update(context,srcData,srcLen,destData,destLen) \
++            sss_wolfssl_aead_update(((sss_wolfssl_aead_t * ) context),(srcData),(srcLen),(destData),(destLen))
++#       define sss_host_aead_finish(context,srcData,srcLen,destData,destLen,tag,tagLen) \
++            sss_wolfssl_aead_finish(((sss_wolfssl_aead_t * ) context),(srcData),(srcLen),(destData),(destLen),(tag),(tagLen))
++#       define sss_host_aead_context_free(context) \
++            sss_wolfssl_aead_context_free(((sss_wolfssl_aead_t * ) context))
++        /* Host Call : mac */
++#       define sss_host_mac_context_init(context,session,keyObject,algorithm,mode) \
++            sss_wolfssl_mac_context_init(((sss_wolfssl_mac_t * ) context),((sss_wolfssl_session_t * ) session),((sss_wolfssl_object_t * ) keyObject),(algorithm),(mode))
++#       define sss_host_mac_one_go(context,message,messageLen,mac,macLen) \
++            sss_wolfssl_mac_one_go(((sss_wolfssl_mac_t * ) context),(message),(messageLen),(mac),(macLen))
++#       define sss_host_mac_init(context) \
++            sss_wolfssl_mac_init(((sss_wolfssl_mac_t * ) context))
++#       define sss_host_mac_update(context,message,messageLen) \
++            sss_wolfssl_mac_update(((sss_wolfssl_mac_t * ) context),(message),(messageLen))
++#       define sss_host_mac_finish(context,mac,macLen) \
++            sss_wolfssl_mac_finish(((sss_wolfssl_mac_t * ) context),(mac),(macLen))
++#       define sss_host_mac_context_free(context) \
++            sss_wolfssl_mac_context_free(((sss_wolfssl_mac_t * ) context))
++        /* Host Call : md */
++#       define sss_host_digest_context_init(context,session,algorithm,mode) \
++            sss_wolfssl_digest_context_init(((sss_wolfssl_digest_t * ) context),((sss_wolfssl_session_t * ) session),(algorithm),(mode))
++#       define sss_host_digest_one_go(context,message,messageLen,digest,digestLen) \
++            sss_wolfssl_digest_one_go(((sss_wolfssl_digest_t * ) context),(message),(messageLen),(digest),(digestLen))
++#       define sss_host_digest_init(context) \
++            sss_wolfssl_digest_init(((sss_wolfssl_digest_t * ) context))
++#       define sss_host_digest_update(context,message,messageLen) \
++            sss_wolfssl_digest_update(((sss_wolfssl_digest_t * ) context),(message),(messageLen))
++#       define sss_host_digest_finish(context,digest,digestLen) \
++            sss_wolfssl_digest_finish(((sss_wolfssl_digest_t * ) context),(digest),(digestLen))
++#       define sss_host_digest_context_free(context) \
++            sss_wolfssl_digest_context_free(((sss_wolfssl_digest_t * ) context))
++        /* Host Call : rng */
++#       define sss_host_rng_context_init(context,session) \
++            sss_wolfssl_rng_context_init(((sss_wolfssl_rng_context_t * ) context),((sss_wolfssl_session_t * ) session))
++#       define sss_host_rng_get_random(context,random_data,dataLen) \
++            sss_wolfssl_rng_get_random(((sss_wolfssl_rng_context_t * ) context),(random_data),(dataLen))
++#       define sss_host_rng_context_free(context) \
++            sss_wolfssl_rng_context_free(((sss_wolfssl_rng_context_t * ) context))
++#   endif /* (SSS_HAVE_SSS == 1) */
++/* clang-format on */
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
++#ifdef __cplusplus
++} // extern "C"
++#endif /* __cplusplus */
++
++#endif /* FSL_SSS_WOLFSSL_APIS_H */
+diff -Naur simw-top/sss/inc/fsl_sss_wolfssl_types.h /home/pi/se_mw/simw-top/sss/inc/fsl_sss_wolfssl_types.h
+--- simw-top/sss/inc/fsl_sss_wolfssl_types.h	1969-12-31 17:00:00.000000000 -0700
++++ /home/pi/se_mw/simw-top/sss/inc/fsl_sss_wolfssl_types.h	2022-10-20 10:47:34.472444046 -0600
+@@ -0,0 +1,256 @@
++/*
++ *
++ * Copyright 2018-2020 NXP
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++#ifndef SSS_APIS_INC_FSL_SSS_WOLFSSL_TYPES_H_
++#define SSS_APIS_INC_FSL_SSS_WOLFSSL_TYPES_H_
++
++/* ************************************************************************** */
++/* Includes                                                                   */
++/* ************************************************************************** */
++
++#include <fsl_sss_api.h>
++
++#if defined(SSS_USE_FTR_FILE)
++#include "fsl_sss_ftr.h"
++#else
++#include "fsl_sss_ftr_default.h"
++#endif
++
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++
++#include <fsl_sss_keyid_map.h>
++#include <wolfssl/options.h>
++#include <wolfssl/wolfcrypt/random.h>
++#include <wolfssl/wolfcrypt/sha.h>
++#include <wolfssl/wolfcrypt/sha256.h>
++#include <wolfssl/wolfcrypt/sha512.h>
++#include <wolfssl/wolfcrypt/rsa.h>
++#include <wolfssl/wolfcrypt/ecc.h>
++#include <wolfssl/wolfcrypt/curve25519.h>
++#include <wolfssl/wolfcrypt/curve448.h>
++#include <wolfssl/wolfcrypt/ed25519.h>
++#include <wolfssl/wolfcrypt/aes.h>
++#include <wolfssl/wolfcrypt/hash.h>
++#include <wolfssl/wolfcrypt/hmac.h>
++#include <wolfssl/wolfcrypt/cmac.h>
++
++#if !defined(NO_AES) && (defined(HAVE_AESGCM) || defined(HAVE_AESCCM))
++typedef struct Aes Aes;
++#endif
++
++/**
++ * @addtogroup sss_sw_wolfssl
++ * @{
++ */
++
++/* ************************************************************************** */
++/* Defines                                                                    */
++/* ************************************************************************** */
++
++#define SSS_SUBSYSTEM_TYPE_IS_WOLFSSL(subsystem) (subsystem == kType_SSS_wolfSSL)
++
++#define SSS_SESSION_TYPE_IS_WOLFSSL(session) (session && SSS_SUBSYSTEM_TYPE_IS_WOLFSSL(session->subsystem))
++
++#define SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore) (keyStore && SSS_SESSION_TYPE_IS_WOLFSSL(keyStore->session))
++
++#define SSS_OBJECT_TYPE_IS_WOLFSSL(pObject) (pObject && SSS_KEY_STORE_TYPE_IS_WOLFSSL(pObject->keyStore))
++
++#define SSS_ASYMMETRIC_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++#define SSS_DERIVE_KEY_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++#define SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++#define SSS_MAC_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++#define SSS_RNG_CONTEXT_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++#define SSS_DIGEST_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++#define SSS_AEAD_TYPE_IS_WOLFSSL(context) (context && SSS_SESSION_TYPE_IS_WOLFSSL(context->session))
++
++/* ************************************************************************** */
++/* Structures and Typedefs                                                    */
++/* ************************************************************************** */
++
++struct _sss_wolfssl_session;
++
++typedef struct _sss_wolfssl_session
++{
++    /*! Indicates which security subsystem is selected to be used. */
++    sss_type_t subsystem;
++
++#ifndef NO_FILESYSTEM
++    /* Root Path for persitant key store */
++    const char *szRootPath;
++#endif
++} sss_wolfssl_session_t;
++
++struct _sss_wolfssl_object;
++
++typedef struct _sss_wolfssl_key_store
++{
++    sss_wolfssl_session_t *session;
++
++#ifndef NO_FILESYSTEM
++    /*! Implementation specific part */
++    struct _sss_wolfssl_object **objects;
++    uint32_t max_object_count;
++
++    keyStoreTable_t *keystore_shadow;
++#endif
++} sss_wolfssl_key_store_t;
++
++typedef struct _sss_wolfssl_object
++{
++    /*! key store holding the data and other properties */
++    sss_wolfssl_key_store_t *keyStore;
++    /*! Object types */
++    uint32_t objectType;
++    uint32_t cipherType;
++    /*! Application specific key identifier. The keyId is kept in the key  store
++     * along with the key data and other properties. */
++    uint32_t keyId;
++
++    /*! Implementation specific part */
++    /** Contents are malloced, so must be freed */
++    uint32_t contents_must_free : 1;
++    /** Type of key. Persistent/transient @ref sss_key_object_mode_t */
++    uint32_t keyMode : 3;
++    /** Max size allocated */
++    size_t contents_max_size;
++    size_t contents_size;
++    size_t keyBitLen;
++    uint32_t user_id;
++    sss_mode_t purpose;
++    sss_access_permission_t accessRights;
++    /* malloced / referenced contents */
++    void *contents;
++    int wcPkAlgoType; /* wolfCrypt PK key algo type (wc_PkType, types.h) */
++} sss_wolfssl_object_t;
++
++typedef struct _sss_wolfssl_derive_key
++{
++    sss_wolfssl_session_t *session;
++    sss_wolfssl_object_t *keyObject;
++    sss_algorithm_t algorithm; /*!  */
++    sss_mode_t mode;           /*!  */
++
++} sss_wolfssl_derive_key_t;
++
++typedef struct _sss_wolfssl_asymmetric
++{
++    sss_wolfssl_session_t *session;
++    sss_wolfssl_object_t *keyObject;
++    sss_algorithm_t algorithm; /*!  */
++    sss_mode_t mode;           /*!  */
++
++} sss_wolfssl_asymmetric_t;
++
++typedef struct _sss_wolfssl_symmetric
++{
++    /*! Virtual connection between application (user context) and specific
++     * security subsystem and function thereof. */
++    sss_wolfssl_session_t *session;
++    sss_wolfssl_object_t *keyObject; /*!< Reference to key and it's properties. */
++    sss_algorithm_t algorithm;       /*!  */
++    sss_mode_t mode;                 /*!  */
++    uint8_t cache_data[16];
++    size_t cache_data_len;
++} sss_wolfssl_symmetric_t;
++
++typedef struct
++{
++    sss_wolfssl_session_t *session;
++    sss_wolfssl_object_t *keyObject; /*!< Reference to key and it's properties. */
++    sss_algorithm_t algorithm;       /*!  */
++    sss_mode_t mode;                 /*!  */
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++    Cmac* cmac;
++#endif
++#ifndef NO_HMAC
++    Hmac* hmac;
++#endif
++} sss_wolfssl_mac_t;
++
++typedef struct _sss_wolfssl_aead
++{
++    /*! Virtual connection between application (user context) and specific
++     * security subsystem and function thereof. */
++    sss_wolfssl_session_t *session;
++    sss_wolfssl_object_t *keyObject; /*!< Reference to key and it's properties. */
++    sss_algorithm_t algorithm;       /*!<  */
++    sss_mode_t mode;                 /*!<  */
++
++    /*! Implementation specific part */
++#if !defined(NO_AES) && (defined(HAVE_AESGCM) || defined(HAVE_AESCCM))
++    Aes* aes;
++#endif
++    uint8_t cache_data[16];   /*!< Cache for GCM data  */
++    size_t cache_data_len;    /*!< Store GCM Cache len*/
++    uint8_t *pCcm_data;       /*!< Ref to CCM data dynamic allocated.. */
++    size_t ccm_dataTotalLen;  /*!< Store CCM data total len. */
++    size_t ccm_dataoffset;    /*!< Store CCM data offset. */
++    uint8_t *pCcm_tag;        /*!< Reference to tag. */
++    size_t ccm_tagLen;        /*!< Store tag len. */
++    const uint8_t *pCcm_aad;  /*!< Reference to AAD */
++    size_t ccm_aadLen;        /*!< Store AAD len. */
++    const uint8_t *pCcm_iv;   /*!< Reference to IV. */
++    size_t ccm_ivLen;         /*!< Store IV len. */
++} sss_wolfssl_aead_t;
++
++typedef struct _sss_wolfssl_digest
++{
++    /*! Virtual connection between application (user context) and specific
++     * security subsystem and function thereof. */
++    sss_wolfssl_session_t *session;
++    sss_algorithm_t algorithm; /*!<  */
++    sss_mode_t mode;           /*!<  */
++    /*! Full digest length per algorithm definition. This field is initialized along with algorithm. */
++    size_t digestFullLen;
++    /*! Implementation specific part */
++    wc_HashAlg* hash;
++} sss_wolfssl_digest_t;
++
++typedef struct
++{
++    sss_wolfssl_session_t *session;
++    WC_RNG* rng;
++} sss_wolfssl_rng_context_t;
++
++/* ************************************************************************** */
++/* Global Variables                                                           */
++/* ************************************************************************** */
++
++/* ************************************************************************** */
++/* Functions                                                                  */
++/* ************************************************************************** */
++
++#ifndef NO_FILESYSTEM
++
++/** Store key inside persistant key store */
++sss_status_t ks_wolfssl_store_key(const sss_wolfssl_object_t *sss_key);
++
++sss_status_t ks_wolfssl_load_key(sss_wolfssl_object_t *sss_key, keyStoreTable_t *keystore_shadow, uint32_t extKeyId);
++
++sss_status_t ks_wolfssl_fat_update(sss_wolfssl_key_store_t *keyStore);
++
++sss_status_t ks_wolfssl_remove_key(const sss_wolfssl_object_t *sss_key);
++
++#endif
++
++sss_status_t sss_wolfssl_key_object_allocate(sss_wolfssl_object_t *keyObject,
++    uint32_t keyId,
++    sss_key_part_t keyPart,
++    sss_cipher_type_t cipherType,
++    size_t keyByteLenMax,
++    uint32_t keyMode);
++
++/** @} */
++
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
++
++#endif /* SSS_APIS_INC_FSL_SSS_WOLFSSL_TYPES_H_ */
+diff -Naur simw-top/sss/src/fsl_sss_apis.c /home/pi/se_mw/simw-top/sss/src/fsl_sss_apis.c
+--- simw-top/sss/src/fsl_sss_apis.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/src/fsl_sss_apis.c	2022-10-20 10:48:25.331967814 -0600
+@@ -23,6 +23,10 @@
+ #include <fsl_sss_mbedtls_apis.h>
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
+ 
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_apis.h>
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
++
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ #include <fsl_sss_openssl_apis.h>
+ #endif /* SSS_HAVE_HOSTCRYPTO_OPENSSL */
+@@ -58,6 +62,10 @@
+         /* if I have mbed TLS */
+         subsystem = kType_SSS_mbedTLS;
+ #endif
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++        /* if I have wolfSSL */
++        subsystem = kType_SSS_wolfSSL;
++#endif
+     }
+     else if (kType_SSS_SecureElement == subsystem) {
+ #if SSS_HAVE_APPLET_SE05X_IOT
+@@ -83,6 +91,11 @@
+         return kStatus_SSS_Success; /* Nothing special to be handled yet */
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SUBSYSTEM_TYPE_IS_WOLFSSL(subsystem)) {
++        return kStatus_SSS_Success; /* Nothing special to be handled yet */
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SUBSYSTEM_TYPE_IS_OPENSSL(subsystem)) {
+         return kStatus_SSS_Success; /* Nothing special to be handled yet */
+@@ -106,6 +119,10 @@
+         /* if I have mbed TLS */
+         subsystem = kType_SSS_mbedTLS;
+ #endif
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++        /* if I have wolfSSL */
++        subsystem = kType_SSS_wolfSSL;
++#endif
+     }
+     else if (kType_SSS_SecureElement == subsystem) {
+ #if SSS_HAVE_APPLET
+@@ -135,6 +152,12 @@
+         return sss_mbedtls_session_open(mbedtls_session, subsystem, application_id, connection_type, connectionData);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SUBSYSTEM_TYPE_IS_WOLFSSL(subsystem)) {
++        sss_wolfssl_session_t *wolfssl_session = (sss_wolfssl_session_t *)session;
++        return sss_wolfssl_session_open(wolfssl_session, subsystem, application_id, connection_type, connectionData);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SUBSYSTEM_TYPE_IS_OPENSSL(subsystem)) {
+         sss_openssl_session_t *openssl_session = (sss_openssl_session_t *)session;
+@@ -170,6 +193,12 @@
+         return sss_mbedtls_session_prop_get_u32(mbedtls_session, property, pValue);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_session_t *wolfssl_session = (sss_wolfssl_session_t *)session;
++        return sss_wolfssl_session_prop_get_u32(wolfssl_session, property, pValue);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_session_t *openssl_session = (sss_openssl_session_t *)session;
+@@ -199,6 +228,12 @@
+         return sss_mbedtls_session_prop_get_au8(mbedtls_session, property, pValue, pValueLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_session_t *wolfssl_session = (sss_wolfssl_session_t *)session;
++        return sss_wolfssl_session_prop_get_au8(wolfssl_session, property, pValue, pValueLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_session_t *openssl_session = (sss_openssl_session_t *)session;
+@@ -228,6 +263,12 @@
+         sss_mbedtls_session_close(mbedtls_session);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_session_t *wolfssl_session = (sss_wolfssl_session_t *)session;
++        sss_wolfssl_session_close(wolfssl_session);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_session_t *openssl_session = (sss_openssl_session_t *)session;
+@@ -259,6 +300,11 @@
+         /* Nothing special to be handled */
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        /* Nothing special to be handled */
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         /* Nothing special to be handled */
+@@ -295,6 +341,15 @@
+         return sss_mbedtls_key_object_init(mbedtls_keyObject, mbedtls_keyStore);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        SSS_ASSERT(sizeof(*wolfssl_keyObject) <= sizeof(*keyObject));
++        SSS_ASSERT(sizeof(*wolfssl_keyStore) <= sizeof(*keyStore));
++        return sss_wolfssl_key_object_init(wolfssl_keyObject, wolfssl_keyStore);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_object_t *openssl_keyObject   = (sss_openssl_object_t *)keyObject;
+@@ -343,6 +398,13 @@
+             mbedtls_keyObject, keyId, keyPart, cipherType, keyByteLenMax, options);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_allocate_handle(
++            wolfssl_keyObject, keyId, keyPart, cipherType, keyByteLenMax, options);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -380,6 +442,12 @@
+         return sss_mbedtls_key_object_get_handle(mbedtls_keyObject, keyId);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_get_handle(wolfssl_keyObject, keyId);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -409,6 +477,12 @@
+         return sss_mbedtls_key_object_set_user(mbedtls_keyObject, user, options);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_set_user(wolfssl_keyObject, user, options);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -438,6 +512,12 @@
+         return sss_mbedtls_key_object_set_purpose(mbedtls_keyObject, purpose, options);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_set_purpose(wolfssl_keyObject, purpose, options);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -467,6 +547,12 @@
+         return sss_mbedtls_key_object_set_access(mbedtls_keyObject, access, options);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_set_access(wolfssl_keyObject, access, options);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -496,6 +582,12 @@
+         return sss_mbedtls_key_object_set_eccgfp_group(mbedtls_keyObject, group);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_set_eccgfp_group(wolfssl_keyObject, group);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -525,6 +617,12 @@
+         return sss_mbedtls_key_object_get_user(mbedtls_keyObject, user);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_get_user(wolfssl_keyObject, user);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -554,6 +652,12 @@
+         return sss_mbedtls_key_object_get_purpose(mbedtls_keyObject, purpose);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_get_purpose(wolfssl_keyObject, purpose);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -583,6 +687,12 @@
+         return sss_mbedtls_key_object_get_access(mbedtls_keyObject, access);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_object_get_access(wolfssl_keyObject, access);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -612,6 +722,12 @@
+         sss_mbedtls_key_object_free(mbedtls_keyObject);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_OBJECT_TYPE_IS_WOLFSSL(keyObject)) {
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        sss_wolfssl_key_object_free(wolfssl_keyObject);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_OBJECT_TYPE_IS_OPENSSL(keyObject)) {
+         sss_openssl_object_t *openssl_keyObject = (sss_openssl_object_t *)keyObject;
+@@ -666,6 +782,18 @@
+             mbedtls_context, mbedtls_session, mbedtls_keyObject, algorithm, mode);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_derive_key_t *wolfssl_context = (sss_wolfssl_derive_key_t *)context;
++        sss_wolfssl_session_t *wolfssl_session    = (sss_wolfssl_session_t *)session;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        SSS_ASSERT(sizeof(*wolfssl_keyObject) <= sizeof(*keyObject));
++        return sss_wolfssl_derive_key_context_init(
++            wolfssl_context, wolfssl_session, wolfssl_keyObject, algorithm, mode);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_derive_key_t *openssl_context = (sss_openssl_derive_key_t *)context;
+@@ -736,6 +864,21 @@
+             hkdfOutputLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DERIVE_KEY_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_derive_key_t *wolfssl_context      = (sss_wolfssl_derive_key_t *)context;
++        sss_wolfssl_object_t *wolfssl_derivedKeyObject = (sss_wolfssl_object_t *)derivedKeyObject;
++        return sss_wolfssl_derive_key_go(wolfssl_context,
++            saltData,
++            saltLen,
++            info,
++            infoLen,
++            wolfssl_derivedKeyObject,
++            deriveDataLen,
++            hkdfOutput,
++            hkdfOutputLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DERIVE_KEY_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_derive_key_t *openssl_context      = (sss_openssl_derive_key_t *)context;
+@@ -789,6 +932,14 @@
+             mbedtls_context, saltData, saltLen, info, infoLen, mbedtls_derivedKeyObject, deriveDataLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DERIVE_KEY_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_derive_key_t *wolfssl_context      = (sss_wolfssl_derive_key_t *)context;
++        sss_wolfssl_object_t *wolfssl_derivedKeyObject = (sss_wolfssl_object_t *)derivedKeyObject;
++        return sss_wolfssl_derive_key_one_go(
++            wolfssl_context, saltData, saltLen, info, infoLen, wolfssl_derivedKeyObject, deriveDataLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DERIVE_KEY_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_derive_key_t *openssl_context      = (sss_openssl_derive_key_t *)context;
+@@ -834,6 +985,15 @@
+             mbedtls_context, mbedtls_saltKeyObject, info, infoLen, mbedtls_derivedKeyObject, deriveDataLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DERIVE_KEY_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_derive_key_t *wolfssl_context      = (sss_wolfssl_derive_key_t *)context;
++        sss_wolfssl_object_t *wolfssl_derivedKeyObject = (sss_wolfssl_object_t *)derivedKeyObject;
++        sss_wolfssl_object_t *wolfssl_saltKeyObject    = (sss_wolfssl_object_t *)saltKeyObject;
++        return sss_wolfssl_derive_key_sobj_one_go(
++            wolfssl_context, wolfssl_saltKeyObject, info, infoLen, wolfssl_derivedKeyObject, deriveDataLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DERIVE_KEY_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_derive_key_t *openssl_context      = (sss_openssl_derive_key_t *)context;
+@@ -873,6 +1033,14 @@
+         return sss_mbedtls_derive_key_dh(mbedtls_context, mbedtls_otherPartyKeyObject, mbedtls_derivedKeyObject);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DERIVE_KEY_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_derive_key_t *wolfssl_context         = (sss_wolfssl_derive_key_t *)context;
++        sss_wolfssl_object_t *wolfssl_otherPartyKeyObject = (sss_wolfssl_object_t *)otherPartyKeyObject;
++        sss_wolfssl_object_t *wolfssl_derivedKeyObject    = (sss_wolfssl_object_t *)derivedKeyObject;
++        return sss_wolfssl_derive_key_dh(wolfssl_context, wolfssl_otherPartyKeyObject, wolfssl_derivedKeyObject);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DERIVE_KEY_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_derive_key_t *openssl_context         = (sss_openssl_derive_key_t *)context;
+@@ -904,6 +1072,12 @@
+         sss_mbedtls_derive_key_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DERIVE_KEY_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_derive_key_t *wolfssl_context = (sss_wolfssl_derive_key_t *)context;
++        sss_wolfssl_derive_key_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DERIVE_KEY_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_derive_key_t *openssl_context = (sss_openssl_derive_key_t *)context;
+@@ -941,6 +1115,15 @@
+         return sss_mbedtls_key_store_context_init(mbedtls_keyStore, mbedtls_session);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_session_t *wolfssl_session    = (sss_wolfssl_session_t *)session;
++        SSS_ASSERT(sizeof(*wolfssl_keyStore) <= sizeof(*keyStore));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        return sss_wolfssl_key_store_context_init(wolfssl_keyStore, wolfssl_session);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -982,6 +1165,12 @@
+         return sss_mbedtls_key_store_allocate(mbedtls_keyStore, keyStoreId);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        return sss_wolfssl_key_store_allocate(wolfssl_keyStore, keyStoreId);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1017,6 +1206,12 @@
+         return sss_mbedtls_key_store_save(mbedtls_keyStore);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        return sss_wolfssl_key_store_save(wolfssl_keyStore);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1046,6 +1241,12 @@
+         return sss_mbedtls_key_store_load(mbedtls_keyStore);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        return sss_wolfssl_key_store_load(wolfssl_keyStore);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1090,6 +1291,14 @@
+             mbedtls_keyStore, mbedtls_keyObject, data, dataLen, keyBitLen, options, optionsLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_store_set_key(
++            wolfssl_keyStore, wolfssl_keyObject, data, dataLen, keyBitLen, options, optionsLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1137,6 +1346,13 @@
+         return sss_mbedtls_key_store_generate_key(mbedtls_keyStore, mbedtls_keyObject, keyBitLen, options);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_store_generate_key(wolfssl_keyStore, wolfssl_keyObject, keyBitLen, options);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1171,6 +1387,13 @@
+         return sss_mbedtls_key_store_get_key(mbedtls_keyStore, mbedtls_keyObject, data, dataLen, pKeyBitLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_store_get_key(wolfssl_keyStore, wolfssl_keyObject, data, dataLen, pKeyBitLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1211,6 +1434,13 @@
+         return sss_mbedtls_key_store_open_key(mbedtls_keyStore, mbedtls_keyObject);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_store_open_key(wolfssl_keyStore, wolfssl_keyObject);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1244,6 +1474,13 @@
+         return sss_mbedtls_key_store_freeze_key(mbedtls_keyStore, mbedtls_keyObject);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_store_freeze_key(wolfssl_keyStore, wolfssl_keyObject);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1277,6 +1514,13 @@
+         return sss_mbedtls_key_store_erase_key(mbedtls_keyStore, mbedtls_keyObject);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        return sss_wolfssl_key_store_erase_key(wolfssl_keyStore, wolfssl_keyObject);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1307,6 +1551,12 @@
+         sss_mbedtls_key_store_context_free(mbedtls_keyStore);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_KEY_STORE_TYPE_IS_WOLFSSL(keyStore)) {
++        sss_wolfssl_key_store_t *wolfssl_keyStore = (sss_wolfssl_key_store_t *)keyStore;
++        sss_wolfssl_key_store_context_free(wolfssl_keyStore);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_KEY_STORE_TYPE_IS_OPENSSL(keyStore)) {
+         sss_openssl_key_store_t *openssl_keyStore = (sss_openssl_key_store_t *)keyStore;
+@@ -1355,6 +1605,18 @@
+             mbedtls_context, mbedtls_session, mbedtls_keyObject, algorithm, mode);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_asymmetric_t *wolfssl_context = (sss_wolfssl_asymmetric_t *)context;
++        sss_wolfssl_session_t *wolfssl_session    = (sss_wolfssl_session_t *)session;
++        sss_wolfssl_object_t *wolfssl_keyObject   = (sss_wolfssl_object_t *)keyObject;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        SSS_ASSERT(sizeof(*wolfssl_keyObject) <= sizeof(*keyObject));
++        return sss_wolfssl_asymmetric_context_init(
++            wolfssl_context, wolfssl_session, wolfssl_keyObject, algorithm, mode);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_asymmetric_t *openssl_context = (sss_openssl_asymmetric_t *)context;
+@@ -1391,6 +1653,12 @@
+         return sss_mbedtls_asymmetric_encrypt(mbedtls_context, srcData, srcLen, destData, destLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_ASYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_asymmetric_t *wolfssl_context = (sss_wolfssl_asymmetric_t *)context;
++        return sss_wolfssl_asymmetric_encrypt(wolfssl_context, srcData, srcLen, destData, destLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_ASYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_asymmetric_t *openssl_context = (sss_openssl_asymmetric_t *)context;
+@@ -1421,6 +1689,12 @@
+         return sss_mbedtls_asymmetric_decrypt(mbedtls_context, srcData, srcLen, destData, destLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_ASYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_asymmetric_t *wolfssl_context = (sss_wolfssl_asymmetric_t *)context;
++        return sss_wolfssl_asymmetric_decrypt(wolfssl_context, srcData, srcLen, destData, destLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_ASYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_asymmetric_t *openssl_context = (sss_openssl_asymmetric_t *)context;
+@@ -1451,6 +1725,12 @@
+         return sss_mbedtls_asymmetric_sign_digest(mbedtls_context, digest, digestLen, signature, signatureLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_ASYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_asymmetric_t *wolfssl_context = (sss_wolfssl_asymmetric_t *)context;
++        return sss_wolfssl_asymmetric_sign_digest(wolfssl_context, digest, digestLen, signature, signatureLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_ASYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_asymmetric_t *openssl_context = (sss_openssl_asymmetric_t *)context;
+@@ -1481,6 +1761,12 @@
+         return sss_mbedtls_asymmetric_verify_digest(mbedtls_context, digest, digestLen, signature, signatureLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_ASYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_asymmetric_t *wolfssl_context = (sss_wolfssl_asymmetric_t *)context;
++        return sss_wolfssl_asymmetric_verify_digest(wolfssl_context, digest, digestLen, signature, signatureLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_ASYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_asymmetric_t *openssl_context = (sss_openssl_asymmetric_t *)context;
+@@ -1510,6 +1796,12 @@
+         sss_mbedtls_asymmetric_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_ASYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_asymmetric_t *wolfssl_context = (sss_wolfssl_asymmetric_t *)context;
++        sss_wolfssl_asymmetric_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_ASYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_asymmetric_t *openssl_context = (sss_openssl_asymmetric_t *)context;
+@@ -1561,6 +1853,17 @@
+         return sss_mbedtls_symmetric_context_init(mbedtls_context, mbedtls_session, mbedtls_keyObject, algorithm, mode);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        sss_wolfssl_session_t *wolfssl_session   = (sss_wolfssl_session_t *)session;
++        sss_wolfssl_object_t *wolfssl_keyObject  = (sss_wolfssl_object_t *)keyObject;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        SSS_ASSERT(sizeof(*wolfssl_keyObject) <= sizeof(*keyObject));
++        return sss_wolfssl_symmetric_context_init(wolfssl_context, wolfssl_session, wolfssl_keyObject, algorithm, mode);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1599,6 +1902,12 @@
+         return sss_mbedtls_cipher_one_go(mbedtls_context, iv, ivLen, srcData, destData, dataLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        return sss_wolfssl_cipher_one_go(wolfssl_context, iv, ivLen, srcData, destData, dataLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1635,6 +1944,12 @@
+         return sss_mbedtls_cipher_one_go_v2(mbedtls_context, iv, ivLen, srcData, srcLen, destData, pDataLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        return sss_wolfssl_cipher_one_go_v2(wolfssl_context, iv, ivLen, srcData, srcLen, destData, pDataLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1667,6 +1982,13 @@
+         return sss_mbedtls_cipher_init(mbedtls_context, iv, ivLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        return sss_wolfssl_cipher_init(wolfssl_context, iv, ivLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1698,6 +2020,12 @@
+         return sss_mbedtls_cipher_update(mbedtls_context, srcData, srcLen, destData, destLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        return sss_wolfssl_cipher_update(wolfssl_context, srcData, srcLen, destData, destLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1728,6 +2056,12 @@
+         return sss_mbedtls_cipher_finish(mbedtls_context, srcData, srcLen, destData, destLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        return sss_wolfssl_cipher_finish(wolfssl_context, srcData, srcLen, destData, destLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1766,6 +2100,13 @@
+             mbedtls_context, srcData, destData, size, initialCounter, lastEncryptedCounter, szLeft);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        return sss_wolfssl_cipher_crypt_ctr(
++            wolfssl_context, srcData, destData, size, initialCounter, lastEncryptedCounter, szLeft);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1797,6 +2138,12 @@
+         sss_mbedtls_symmetric_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SYMMETRIC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_symmetric_t *wolfssl_context = (sss_wolfssl_symmetric_t *)context;
++        sss_wolfssl_symmetric_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SYMMETRIC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_symmetric_t *openssl_context = (sss_openssl_symmetric_t *)context;
+@@ -1841,6 +2188,17 @@
+         return sss_mbedtls_aead_context_init(mbedtls_context, mbedtls_session, mbedtls_keyObject, algorithm, mode);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_aead_t *wolfssl_context     = (sss_wolfssl_aead_t *)context;
++        sss_wolfssl_session_t *wolfssl_session  = (sss_wolfssl_session_t *)session;
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        SSS_ASSERT(sizeof(*wolfssl_keyObject) <= sizeof(*keyObject));
++        return sss_wolfssl_aead_context_init(wolfssl_context, wolfssl_session, wolfssl_keyObject, algorithm, mode);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_aead_t *openssl_context     = (sss_openssl_aead_t *)context;
+@@ -1885,6 +2243,13 @@
+             mbedtls_context, srcData, destData, size, nonce, nonceLen, aad, aadLen, tag, tagLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_AEAD_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_aead_t *wolfssl_context = (sss_wolfssl_aead_t *)context;
++        return sss_wolfssl_aead_one_go(
++            wolfssl_context, srcData, destData, size, nonce, nonceLen, aad, aadLen, tag, tagLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_AEAD_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_aead_t *openssl_context = (sss_openssl_aead_t *)context;
+@@ -1919,6 +2284,13 @@
+         return sss_mbedtls_aead_init(mbedtls_context, nonce, nonceLen, tagLen, aadLen, payloadLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_AEAD_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_aead_t *wolfssl_context = (sss_wolfssl_aead_t *)context;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        return sss_wolfssl_aead_init(wolfssl_context, nonce, nonceLen, tagLen, aadLen, payloadLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_AEAD_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_aead_t *openssl_context = (sss_openssl_aead_t *)context;
+@@ -1949,6 +2321,12 @@
+         return sss_mbedtls_aead_update_aad(mbedtls_context, aadData, aadDataLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_AEAD_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_aead_t *wolfssl_context = (sss_wolfssl_aead_t *)context;
++        return sss_wolfssl_aead_update_aad(wolfssl_context, aadData, aadDataLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_AEAD_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_aead_t *openssl_context = (sss_openssl_aead_t *)context;
+@@ -1979,6 +2357,12 @@
+         return sss_mbedtls_aead_update(mbedtls_context, srcData, srcLen, destData, destLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_AEAD_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_aead_t *wolfssl_context = (sss_wolfssl_aead_t *)context;
++        return sss_wolfssl_aead_update(wolfssl_context, srcData, srcLen, destData, destLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_AEAD_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_aead_t *openssl_context = (sss_openssl_aead_t *)context;
+@@ -2014,6 +2398,12 @@
+         return sss_mbedtls_aead_finish(mbedtls_context, srcData, srcLen, destData, destLen, tag, tagLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_AEAD_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_aead_t *wolfssl_context = (sss_wolfssl_aead_t *)context;
++        return sss_wolfssl_aead_finish(wolfssl_context, srcData, srcLen, destData, destLen, tag, tagLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_AEAD_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_aead_t *openssl_context = (sss_openssl_aead_t *)context;
+@@ -2043,6 +2433,12 @@
+         sss_mbedtls_aead_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_AEAD_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_aead_t *wolfssl_context = (sss_wolfssl_aead_t *)context;
++        sss_wolfssl_aead_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_AEAD_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_aead_t *openssl_context = (sss_openssl_aead_t *)context;
+@@ -2090,6 +2486,17 @@
+         return sss_mbedtls_mac_context_init(mbedtls_context, mbedtls_session, mbedtls_keyObject, algorithm, mode);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_mac_t *wolfssl_context      = (sss_wolfssl_mac_t *)context;
++        sss_wolfssl_session_t *wolfssl_session  = (sss_wolfssl_session_t *)session;
++        sss_wolfssl_object_t *wolfssl_keyObject = (sss_wolfssl_object_t *)keyObject;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        SSS_ASSERT(sizeof(*wolfssl_keyObject) <= sizeof(*keyObject));
++        return sss_wolfssl_mac_context_init(wolfssl_context, wolfssl_session, wolfssl_keyObject, algorithm, mode);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_mac_t *openssl_context      = (sss_openssl_mac_t *)context;
+@@ -2127,6 +2534,12 @@
+         return sss_mbedtls_mac_one_go(mbedtls_context, message, messageLen, mac, macLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_MAC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_mac_t *wolfssl_context = (sss_wolfssl_mac_t *)context;
++        return sss_wolfssl_mac_one_go(wolfssl_context, message, messageLen, mac, macLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_MAC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_mac_t *openssl_context = (sss_openssl_mac_t *)context;
+@@ -2160,6 +2573,13 @@
+         return sss_mbedtls_mac_init(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_MAC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_mac_t *wolfssl_context = (sss_wolfssl_mac_t *)context;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        return sss_wolfssl_mac_init(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_MAC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_mac_t *openssl_context = (sss_openssl_mac_t *)context;
+@@ -2193,6 +2613,12 @@
+         return sss_mbedtls_mac_update(mbedtls_context, message, messageLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_MAC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_mac_t *wolfssl_context = (sss_wolfssl_mac_t *)context;
++        return sss_wolfssl_mac_update(wolfssl_context, message, messageLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_MAC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_mac_t *openssl_context = (sss_openssl_mac_t *)context;
+@@ -2223,6 +2649,12 @@
+         return sss_mbedtls_mac_finish(mbedtls_context, mac, macLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_MAC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_mac_t *wolfssl_context = (sss_wolfssl_mac_t *)context;
++        return sss_wolfssl_mac_finish(wolfssl_context, mac, macLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_MAC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_mac_t *openssl_context = (sss_openssl_mac_t *)context;
+@@ -2253,6 +2685,12 @@
+         sss_mbedtls_mac_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_MAC_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_mac_t *wolfssl_context = (sss_wolfssl_mac_t *)context;
++        sss_wolfssl_mac_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_MAC_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_mac_t *openssl_context = (sss_openssl_mac_t *)context;
+@@ -2291,6 +2729,15 @@
+         return sss_mbedtls_digest_context_init(mbedtls_context, mbedtls_session, algorithm, mode);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_digest_t *wolfssl_context  = (sss_wolfssl_digest_t *)context;
++        sss_wolfssl_session_t *wolfssl_session = (sss_wolfssl_session_t *)session;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        return sss_wolfssl_digest_context_init(wolfssl_context, wolfssl_session, algorithm, mode);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_digest_t *openssl_context  = (sss_openssl_digest_t *)context;
+@@ -2324,6 +2771,12 @@
+         return sss_mbedtls_digest_one_go(mbedtls_context, message, messageLen, digest, digestLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DIGEST_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_digest_t *wolfssl_context = (sss_wolfssl_digest_t *)context;
++        return sss_wolfssl_digest_one_go(wolfssl_context, message, messageLen, digest, digestLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DIGEST_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_digest_t *openssl_context = (sss_openssl_digest_t *)context;
+@@ -2356,6 +2809,13 @@
+         return sss_mbedtls_digest_init(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DIGEST_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_digest_t *wolfssl_context = (sss_wolfssl_digest_t *)context;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        return sss_wolfssl_digest_init(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DIGEST_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_digest_t *openssl_context = (sss_openssl_digest_t *)context;
+@@ -2386,6 +2846,12 @@
+         return sss_mbedtls_digest_update(mbedtls_context, message, messageLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DIGEST_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_digest_t *wolfssl_context = (sss_wolfssl_digest_t *)context;
++        return sss_wolfssl_digest_update(wolfssl_context, message, messageLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DIGEST_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_digest_t *openssl_context = (sss_openssl_digest_t *)context;
+@@ -2415,6 +2881,12 @@
+         return sss_mbedtls_digest_finish(mbedtls_context, digest, digestLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DIGEST_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_digest_t *wolfssl_context = (sss_wolfssl_digest_t *)context;
++        return sss_wolfssl_digest_finish(wolfssl_context, digest, digestLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DIGEST_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_digest_t *openssl_context = (sss_openssl_digest_t *)context;
+@@ -2444,6 +2916,12 @@
+         sss_mbedtls_digest_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_DIGEST_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_digest_t *wolfssl_context = (sss_wolfssl_digest_t *)context;
++        sss_wolfssl_digest_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_DIGEST_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_digest_t *openssl_context = (sss_openssl_digest_t *)context;
+@@ -2482,6 +2960,15 @@
+         return sss_mbedtls_rng_context_init(mbedtls_context, mbedtls_session);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_SESSION_TYPE_IS_WOLFSSL(session)) {
++        sss_wolfssl_rng_context_t *wolfssl_context = (sss_wolfssl_rng_context_t *)context;
++        sss_wolfssl_session_t *wolfssl_session     = (sss_wolfssl_session_t *)session;
++        SSS_ASSERT(sizeof(*wolfssl_context) <= sizeof(*context));
++        SSS_ASSERT(sizeof(*wolfssl_session) <= sizeof(*session));
++        return sss_wolfssl_rng_context_init(wolfssl_context, wolfssl_session);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_SESSION_TYPE_IS_OPENSSL(session)) {
+         sss_openssl_rng_context_t *openssl_context = (sss_openssl_rng_context_t *)context;
+@@ -2515,6 +3002,12 @@
+         return sss_mbedtls_rng_get_random(mbedtls_context, random_data, dataLen);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_RNG_CONTEXT_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_rng_context_t *wolfssl_context = (sss_wolfssl_rng_context_t *)context;
++        return sss_wolfssl_rng_get_random(wolfssl_context, random_data, dataLen);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_RNG_CONTEXT_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_rng_context_t *openssl_context = (sss_openssl_rng_context_t *)context;
+@@ -2545,6 +3038,12 @@
+         return sss_mbedtls_rng_context_free(mbedtls_context);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_RNG_CONTEXT_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_rng_context_t *wolfssl_context = (sss_wolfssl_rng_context_t *)context;
++        return sss_wolfssl_rng_context_free(wolfssl_context);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_RNG_CONTEXT_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_rng_context_t *openssl_context = (sss_openssl_rng_context_t *)context;
+@@ -2573,6 +3072,9 @@
+ #if SSS_HAVE_HOSTCRYPTO_MBEDTLS
+     /* NA */
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    /* NA */
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     /* NA */
+ #endif /* SSS_HAVE_HOSTCRYPTO_OPENSSL */
+@@ -2630,6 +3132,19 @@
+             tunnelType);
+     }
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if 0 && SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    if (SSS_TUNNEL_TYPE_IS_WOLFSSL(context)) {
++        sss_wolfssl_tunnel_t *wolfssl_context = (sss_wolfssl_tunnel_t *)context;
++        sss_wolfssl_object_t *wolfssl_keyObjects =
++            (sss_wolfssl_object_t *)keyObjects;
++        return sss_wolfssl_tunnel(wolfssl_context,
++            data,
++            dataLen,
++            wolfssl_keyObjects,
++            keyObjectCount,
++            tunnelType);
++    }
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if 0 && SSS_HAVE_HOSTCRYPTO_OPENSSL
+     if (SSS_TUNNEL_TYPE_IS_OPENSSL(context)) {
+         sss_openssl_tunnel_t *openssl_context = (sss_openssl_tunnel_t *)context;
+@@ -2660,6 +3175,9 @@
+ #if SSS_HAVE_HOSTCRYPTO_MBEDTLS
+     /* NA */
+ #endif /* SSS_HAVE_HOSTCRYPTO_MBEDTLS */
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++    /* NA */
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+     /* NA */
+ #endif /* SSS_HAVE_HOSTCRYPTO_OPENSSL */
+diff -Naur simw-top/sss/src/fsl_sss_util_asn1_der.c /home/pi/se_mw/simw-top/sss/src/fsl_sss_util_asn1_der.c
+--- simw-top/sss/src/fsl_sss_util_asn1_der.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/src/fsl_sss_util_asn1_der.c	2022-10-20 11:29:47.909931928 -0600
+@@ -18,6 +18,10 @@
+ #include <fsl_sss_mbedtls_apis.h>
+ #endif
+ 
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_apis.h>
++#endif
++
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ #include <fsl_sss_openssl_apis.h>
+ #include <openssl/pem.h>
+diff -Naur simw-top/sss/src/keystore/keystore_pc.c /home/pi/se_mw/simw-top/sss/src/keystore/keystore_pc.c
+--- simw-top/sss/src/keystore/keystore_pc.c	2022-07-01 15:15:58.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/src/keystore/keystore_pc.c	2022-10-20 11:24:23.652855819 -0600
+@@ -22,6 +22,10 @@
+ #include <fsl_sss_mbedtls_apis.h>
+ #endif
+ 
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++#include <fsl_sss_wolfssl_apis.h>
++#endif
++
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ #include <fsl_sss_openssl_types.h>
+ #endif
+@@ -34,7 +38,8 @@
+ #include "nxLog_sss.h"
+ #include "sm_types.h"
+ 
+-#if (defined(MBEDTLS_FS_IO) && !AX_EMBEDDED) || SSS_HAVE_HOSTCRYPTO_OPENSSL
++#if (defined(MBEDTLS_FS_IO) && !AX_EMBEDDED) || SSS_HAVE_HOSTCRYPTO_OPENSSL || \
++    (defined(SSS_HAVE_HOSTCRYPTO_WOLFSSL) && !defined(NO_FILESYSTEM))
+ 
+ /* ************************************************************************** */
+ /* Local Defines                                                              */
+@@ -155,6 +160,13 @@
+ }
+ #endif
+ 
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL && !defined(NO_FILESYSTEM)
++sss_status_t ks_wolfssl_fat_update(sss_wolfssl_key_store_t *keyStore)
++{
++    return ks_sw_fat_update(keyStore->keystore_shadow, keyStore->session->szRootPath);
++}
++#endif
++
+ #if SSS_HAVE_HOSTCRYPTO_OPENSSL
+ sss_status_t ks_openssl_fat_update(sss_openssl_key_store_t *keyStore)
+ {
+@@ -337,8 +349,148 @@
+     }
+     return retval;
+ }
++#endif /* MBEDTLS_FS_IO */
++
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL && !defined(NO_FILESYSTEM)
++sss_status_t ks_wolfssl_load_key(sss_wolfssl_object_t *sss_key,
++    keyStoreTable_t *keystore_shadow, uint32_t extKeyId)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    char file_name[MAX_FILE_NAME_SIZE];
++    FILE *fp = NULL;
++    size_t size = 0;
++    uint32_t i;
++    keyIdAndTypeIndexLookup_t *shadowEntry = NULL;
++
++    for (i = 0; i < sss_key->keyStore->max_object_count; i++) {
++        if (keystore_shadow->entries[i].extKeyId == extKeyId) {
++            shadowEntry         = &keystore_shadow->entries[i];
++            sss_key->keyId      = shadowEntry->extKeyId;
++            sss_key->cipherType = shadowEntry->cipherType;
++            sss_key->objectType = (shadowEntry->keyPart & 0x0F);
++
++            ks_sw_getKeyFileName(
++                file_name, sizeof(file_name), (const sss_object_t *)sss_key,
++                sss_key->keyStore->session->szRootPath);
++            retval = kStatus_SSS_Success;
++            break;
++        }
++    }
++    if (retval == kStatus_SSS_Success) {
++        fp = fopen(file_name, "rb");
++        if (fp == NULL) {
++            LOG_E("Can not open file");
++            retval = kStatus_SSS_Fail;
++        }
++        else {
++            /* Buffer to hold max RSA Key*/
++            uint8_t *keyBuf = NULL;
++            int signed_val  = 0;
++            fseek(fp, 0, SEEK_END);
++            signed_val = ftell(fp);
++            if (signed_val < 0) {
++                LOG_E("File does not contain any data");
++                retval = kStatus_SSS_Fail;
++                fclose(fp);
++                return retval;
++            }
++            size = (size_t)signed_val;
++            fseek(fp, 0, SEEK_SET);
++            keyBuf = SSS_CALLOC(1, size);
++            if (keyBuf == NULL) {
++                fclose(fp);
++                return kStatus_SSS_Fail;
++            }
++            signed_val = (int)fread(keyBuf, size, 1, fp);
++            if (signed_val < 0) {
++                LOG_E("fread failed");
++                retval = kStatus_SSS_Fail;
++                fclose(fp);
++                if (keyBuf != NULL) {
++                    SSS_FREE(keyBuf);
++                }
++                return retval;
++            }
++            fclose(fp);
++            retval = sss_wolfssl_key_object_allocate(sss_key,
++                shadowEntry->extKeyId,
++                (sss_key_part_t)(shadowEntry->keyPart & 0x0F),
++                (sss_cipher_type_t)(shadowEntry->cipherType),
++                size, kKeyObject_Mode_Persistent);
++            if (retval == kStatus_SSS_Success) {
++                retval = sss_wolfssl_key_store_set_key(
++                    sss_key->keyStore, sss_key, keyBuf, size, size * 8,
++                    NULL, 0);
++            }
++            if (keyBuf != NULL) {
++                SSS_FREE(keyBuf);
++            }
++        }
++    }
++    return retval;
++}
++
++sss_status_t ks_wolfssl_store_key(const sss_wolfssl_object_t *sss_key)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    char file_name[MAX_FILE_NAME_SIZE];
++    FILE *fp = NULL;
++
++    /* Buffer to hold max RSA Key, matches mbedTLS size above */
++    uint8_t key_buf[3000];
++    size_t  bufLen = sizeof(key_buf);
++    size_t  bitLen = 0;
++
++    ks_sw_getKeyFileName(
++        file_name, sizeof(file_name), (const sss_object_t *)sss_key,
++        sss_key->keyStore->session->szRootPath);
++
++    fp = fopen(file_name, "wb+");
++    if (fp == NULL) {
++        LOG_E(" Can not open the file");
++        retval = kStatus_SSS_Fail;
++    }
++    else {
++        memset(key_buf, 0, sizeof(key_buf));
++
++        retval = sss_wolfssl_key_store_get_key(
++                    NULL, (sss_wolfssl_object_t*)sss_key, key_buf,
++                    &bufLen, &bitLen);
++        if (retval != kStatus_SSS_Success) {
++            LOG_E("Failed to convert key to DER for writing to file");
++        }
++        else {
++            fwrite(key_buf, bufLen, 1, fp);
++            retval = kStatus_SSS_Success;
++        }
++
++        fflush(fp);
++        fclose(fp);
++    }
++
++    return retval;
++}
++
++#ifdef _MSC_VER
++#define UNLINK _unlink
++#else
++#define UNLINK unlink
+ #endif
+ 
++sss_status_t ks_wolfssl_remove_key(const sss_wolfssl_object_t *sss_key)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    char file_name[MAX_FILE_NAME_SIZE];
++    ks_sw_getKeyFileName(
++        file_name, sizeof(file_name), (const sss_object_t *)sss_key,
++        sss_key->keyStore->session->szRootPath);
++    if (0 == UNLINK(file_name)) {
++        retval = kStatus_SSS_Success;
++    }
++    return retval;
++}
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL && !NO_FILESYSTEM */
++
+ /* ************************************************************************** */
+ /* Private Functions                                                          */
+ /* ************************************************************************** */
+diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
+--- simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	1969-12-31 17:00:00.000000000 -0700
++++ /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	2022-11-11 10:27:06.335662156 -0700
+@@ -0,0 +1,3298 @@
++/*
++ *
++ * Copyright 2018-2020 NXP
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++#include <fsl_sss_wolfssl_apis.h>
++
++#if SSS_HAVE_HOSTCRYPTO_WOLFSSL
++
++#include <inttypes.h>
++#include <memory.h>
++#include <nxEnsure.h>
++#include <wolfssl/wolfcrypt/settings.h>
++#include <wolfssl/wolfcrypt/random.h>
++#include <wolfssl/wolfcrypt/sha.h>
++#include <wolfssl/wolfcrypt/sha256.h>
++#include <wolfssl/wolfcrypt/sha512.h>
++#include <wolfssl/wolfcrypt/rsa.h>
++#include <wolfssl/wolfcrypt/ecc.h>
++#include <wolfssl/wolfcrypt/curve25519.h>
++#include <wolfssl/wolfcrypt/curve448.h>
++#include <wolfssl/wolfcrypt/ed25519.h>
++#include <wolfssl/wolfcrypt/aes.h>
++#include <wolfssl/wolfcrypt/des3.h>
++#include <wolfssl/wolfcrypt/hash.h>
++#include <wolfssl/wolfcrypt/hmac.h>
++#include <wolfssl/wolfcrypt/cmac.h>
++#include <wolfssl/wolfcrypt/asn_public.h>
++#include <wolfssl/wolfcrypt/types.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include "nxLog_sss.h"
++
++#define MAX_KEY_OBJ_COUNT KS_N_ENTIRES
++#define MAX_FILE_NAME_SIZE 255
++#define MAX_SHARED_SECRET_DERIVED_DATA 255
++
++/* ************************************************************************** */
++/* Functions : Private sss wolfSSL declaration                                */
++/* ************************************************************************** */
++
++static sss_status_t sss_wolfssl_generate_rsa_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++static sss_status_t sss_wolfssl_generate_ecc_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++static sss_status_t sss_wolfssl_generate_ec_mont_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++static sss_status_t sss_wolfssl_generate_ed_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++
++#ifndef NO_HMAC
++static int sss_wolfssl_get_hmac_type_from_algo(int algo);
++#endif
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_session                                            */
++/* ************************************************************************** */
++
++// LCOV_EXCL_START
++sss_status_t sss_wolfssl_session_create(sss_wolfssl_session_t *session,
++    sss_type_t subsystem,
++    uint32_t application_id,
++    sss_connection_type_t connection_type,
++    void *connectionData)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    return retval;
++}
++// LCOV_EXCL_STOP
++
++sss_status_t sss_wolfssl_session_open(sss_wolfssl_session_t *session,
++    sss_type_t subsystem,
++    uint32_t application_id,
++    sss_connection_type_t connection_type,
++    void *connectionData)
++{
++    sss_status_t retval = kStatus_SSS_InvalidArgument;
++    memset(session, 0, sizeof(*session));
++
++    if (connectionData == NULL) {
++        session->subsystem = subsystem;
++        retval = kStatus_SSS_Success;
++    }
++    else {
++#ifndef NO_FILESYSTEM
++        const char* szRootPath = (const char*)connectionData;
++        session->szRootPath = szRootPath;
++        session->subsystem  = subsystem;
++        retval              = kStatus_SSS_Success;
++#else
++        /* Can't support connectionData != NULL for wolfSSL without
++         * a filesystem */
++        LOG_E("No connectionData support without filesystem available");
++#endif /* !NO_FILESYSTEM */
++    }
++
++    return retval;
++}
++
++// LCOV_EXCL_START
++sss_status_t sss_wolfssl_session_prop_get_u32(sss_wolfssl_session_t *session,
++    uint32_t property, uint32_t *pValue)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    /* TBU */
++    return retval;
++}
++
++sss_status_t sss_wolfssl_session_prop_get_au8(
++    sss_wolfssl_session_t *session, uint32_t property, uint8_t *pValue,
++    size_t *pValueLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    /* TBU */
++    return retval;
++}
++// LCOV_EXCL_STOP
++
++void sss_wolfssl_session_close(sss_wolfssl_session_t *session)
++{
++    memset(session, 0, sizeof(*session));
++}
++
++void sss_wolfssl_session_delete(sss_wolfssl_session_t *session)
++{
++    ;
++}
++
++/* End: wolfssl_session */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_keyobj                                             */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_key_object_init(sss_wolfssl_object_t *keyObject,
++                                         sss_wolfssl_key_store_t *keyStore)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyStore);
++    memset(keyObject, 0, sizeof(*keyObject));
++    keyObject->keyStore = keyStore;
++    retval              = kStatus_SSS_Success;
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_allocate(sss_wolfssl_object_t *keyObject,
++    uint32_t keyId,
++    sss_key_part_t keyPart,
++    sss_cipher_type_t cipherType,
++    size_t keyByteLenMax,
++    uint32_t keyMode)
++{
++    int ret = 0;
++    size_t size         = 0;
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyObject);
++
++    keyObject->keyId              = keyId;
++    keyObject->objectType         = keyPart;
++    keyObject->cipherType         = cipherType;
++    keyObject->contents_max_size  = keyByteLenMax;
++    keyObject->contents_must_free = 1;
++    keyObject->keyMode            = keyMode;
++    /* Bitwise OR of all sss_access_permission. */
++    keyObject->accessRights = kAccessPermission_SSS_All_Permission;
++    switch (keyPart) {
++        case kSSS_KeyPart_Default:
++            size = keyByteLenMax;
++            if (size != 0) {
++                keyObject->contents = SSS_MALLOC(size);
++                ENSURE_OR_GO_CLEANUP(keyObject->contents);
++                memset(keyObject->contents, 0, size);
++                retval = kStatus_SSS_Success;
++            }
++            break;
++        case kSSS_KeyPart_Pair:
++        case kSSS_KeyPart_Private:
++        case kSSS_KeyPart_Public:
++            if (cipherType == kSSS_CipherType_RSA) {
++#ifndef NO_RSA
++                size = sizeof(RsaKey);
++                keyObject->wcPkAlgoType = WC_PK_TYPE_RSA;
++                keyObject->contents = SSS_MALLOC(size);
++                keyObject->contents_must_free = 1;
++                ENSURE_OR_GO_CLEANUP(keyObject->contents);
++                memset(keyObject->contents, 0, size);
++                ret = wc_InitRsaKey((RsaKey*)keyObject->contents, NULL);
++#else
++                LOG_E("wolfSSL not compiled with RSA support");
++#endif /* NO_RSA */
++            }
++            else if (cipherType == kSSS_CipherType_EC_NIST_P ||
++                     cipherType == kSSS_CipherType_EC_NIST_K ||
++                     cipherType == kSSS_CipherType_EC_BRAINPOOL) {
++#ifdef HAVE_ECC
++                size = sizeof(ecc_key);
++                keyObject->wcPkAlgoType = WC_PK_TYPE_ECDSA_SIGN;
++                keyObject->contents = SSS_MALLOC(size);
++                keyObject->contents_must_free = 1;
++                ENSURE_OR_GO_CLEANUP(keyObject->contents);
++                memset(keyObject->contents, 0, size);
++                ret = wc_ecc_init((ecc_key*)keyObject->contents);
++#else
++                LOG_E("wolfSSL not compiled with ECC support");
++#endif /* HAVE_ECC */
++            }
++            else if (cipherType == kSSS_CipherType_EC_MONTGOMERY) {
++#if defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)
++        #ifdef HAVE_CURVE25519
++                if (keyByteLenMax == CURVE25519_KEYSIZE) {
++                    size = sizeof(curve25519_key);
++                    keyObject->wcPkAlgoType = WC_PK_TYPE_CURVE25519;
++                    keyObject->contents = SSS_MALLOC(size);
++                    keyObject->contents_must_free = 1;
++                    ENSURE_OR_GO_CLEANUP(keyObject->contents);
++                    memset(keyObject->contents, 0, size);
++                    ret = wc_curve25519_init(
++                            (curve25519_key*)keyObject->contents);
++                    break;
++                }
++        #endif /* HAVE_CURVE25519 */
++        #ifdef HAVE_CURVE448
++                if (keyByteLenMax == CURVE448_KEY_SIZE) {
++                    size = sizeof(curve448_key);
++                    keyObject->wcPkAlgoType = WC_PK_TYPE_CURVE448;
++                    keyObject->contents = SSS_MALLOC(size);
++                    keyObject->contents_must_free = 1;
++                    ENSURE_OR_GO_CLEANUP(keyObject->contents);
++                    memset(keyObject->contents, 0, size);
++                    ret = wc_curve448_init((curve448_key*)keyObject->contents);
++                    break;
++                }
++        #endif /* HAVE_CURVE448 */
++#else
++                LOG_E("wolfSSL not compiled with Curve25519/448 support");
++#endif /* HAVE_CURVE25519 || HAVE_CURVE448 */
++            }
++            else if (cipherType == kSSS_CipherType_EC_TWISTED_ED) {
++#ifdef HAVE_ED25519
++                size = sizeof(ed25519_key);
++                keyObject->wcPkAlgoType = WC_PK_TYPE_ED25519_SIGN;
++                keyObject->contents = SSS_MALLOC(size);
++                keyObject->contents_must_free = 1;
++                ENSURE_OR_GO_CLEANUP(keyObject->contents);
++                memset(keyObject->contents, 0, size);
++                ret = wc_ed25519_init((ed25519_key*)keyObject->contents);
++#else
++                LOG_E("wolfSSL not compiled with Ed25519 support");
++#endif /* HAVE_ED25519 */
++            }
++            break;
++        default:
++            keyObject->wcPkAlgoType = WC_PK_TYPE_NONE;
++            break;
++    }
++    if ((ret == 0) && (size != 0)) {
++        retval = kStatus_SSS_Success;
++    }
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_allocate_handle(
++    sss_wolfssl_object_t *keyObject,
++    uint32_t keyId,
++    sss_key_part_t keyPart,
++    sss_cipher_type_t cipherType,
++    size_t keyByteLenMax,
++    uint32_t options)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyId != 0);
++    ENSURE_OR_GO_CLEANUP(keyId != 0xFFFFFFFFu);
++
++    if (options != kKeyObject_Mode_Persistent &&
++        options != kKeyObject_Mode_Transient) {
++        LOG_E("sss_wolfssl_key_object_allocate_handle option invalid 0x%X",
++              options);
++        goto cleanup;
++    }
++    ENSURE_OR_GO_CLEANUP((size_t)keyPart < UINT8_MAX);
++#ifndef NO_FILESYSTEM
++    if (options == kKeyObject_Mode_Persistent) {
++        uint32_t i;
++        sss_wolfssl_object_t **ks;
++        ENSURE_OR_GO_CLEANUP(keyObject->keyStore);
++        ENSURE_OR_GO_CLEANUP(keyObject->keyStore->max_object_count > 0);
++        retval = ks_common_update_fat(
++            keyObject->keyStore->keystore_shadow, keyId, keyPart, cipherType,
++            0, 0, (uint16_t)keyByteLenMax);
++        ENSURE_OR_GO_CLEANUP(retval == kStatus_SSS_Success);
++        ks     = keyObject->keyStore->objects;
++        retval = kStatus_SSS_Fail;
++        for (i = 0; i < keyObject->keyStore->max_object_count; i++) {
++            if (ks[i] == NULL) {
++                ks[i]  = keyObject;
++                retval = sss_wolfssl_key_object_allocate(
++                            keyObject, keyId, keyPart, cipherType,
++                            keyByteLenMax, options);
++                break;
++            }
++        }
++    }
++    else
++#endif /* NO_FILESYSTEM */
++    {
++        retval = sss_wolfssl_key_object_allocate(keyObject, keyId, keyPart,
++                    cipherType, keyByteLenMax, options);
++    }
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_get_handle(sss_wolfssl_object_t *keyObject,
++                                               uint32_t keyId)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++#ifndef NO_FILESYSTEM
++    uint32_t i;
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyObject->keyStore);
++    retval = kStatus_SSS_Success;
++    /* If key store already has loaded this and shared this - fail */
++    for (i = 0; i < keyObject->keyStore->max_object_count; i++) {
++        if (keyObject->keyStore->objects[i] != NULL &&
++            keyObject->keyStore->objects[i]->keyId == keyId) {
++            /* Key Object already loaded and shared in another instance */
++            LOG_W("KeyID 0x%X already loaded / shared", keyId);
++            retval = kStatus_SSS_Fail;
++            break;
++        }
++    }
++    if (retval == kStatus_SSS_Success) {
++        for (i = 0; i < keyObject->keyStore->max_object_count; i++) {
++            if (keyObject->keyStore->objects[i] == NULL) {
++                retval = ks_wolfssl_load_key(keyObject,
++                            keyObject->keyStore->keystore_shadow, keyId);
++                if (retval == kStatus_SSS_Success) {
++                    keyObject->keyStore->objects[i] = keyObject;
++                }
++                break;
++            }
++        }
++    }
++cleanup:
++#endif /* NO_FILESYSTEM */
++    return retval;
++}
++
++// LCOV_EXCL_START
++sss_status_t sss_wolfssl_key_object_set_user(sss_wolfssl_object_t *keyObject,
++                                             uint32_t user, uint32_t options)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    if (!(keyObject->accessRights & kAccessPermission_SSS_ChangeAttributes)) {
++        LOG_E(" Don't have access rights to change the attributes");
++        return kStatus_SSS_Fail;
++    }
++    keyObject->user_id = user;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_set_purpose(sss_wolfssl_object_t *keyObject,
++                                           sss_mode_t purpose, uint32_t options)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    if (!(keyObject->accessRights & kAccessPermission_SSS_ChangeAttributes)) {
++        LOG_E(" Don't have access rights to change the attributes");
++        return kStatus_SSS_Fail;
++    }
++    keyObject->purpose = purpose;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_set_access(sss_wolfssl_object_t *keyObject,
++                                              uint32_t access, uint32_t options)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    if (!(keyObject->accessRights & kAccessPermission_SSS_ChangeAttributes)) {
++        LOG_E(" Don't have access rights to use the key");
++
++        return kStatus_SSS_Fail;
++    }
++    keyObject->accessRights = access;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_set_eccgfp_group(
++    sss_wolfssl_object_t *keyObject, sss_eccgfp_group_t *group)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_get_user(sss_wolfssl_object_t *keyObject,
++                                             uint32_t *user)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    *user               = keyObject->user_id;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_get_purpose(sss_wolfssl_object_t *keyObject,
++                                                sss_mode_t *purpose)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    *purpose            = keyObject->purpose;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_object_get_access(sss_wolfssl_object_t *keyObject,
++                                               uint32_t *access)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    *access             = keyObject->accessRights;
++    return retval;
++}
++// LCOV_EXCL_STOP
++
++void sss_wolfssl_key_object_free(sss_wolfssl_object_t *keyObject)
++{
++#ifndef NO_RSA
++    RsaKey* rsa = NULL;
++#endif
++#ifdef HAVE_ECC
++    ecc_key* ecc = NULL;
++#endif
++#ifdef HAVE_ED25519
++    ed25519_key* ed25519 = NULL;
++#endif
++
++    ENSURE_OR_GO_EXIT(keyObject)
++#ifndef NO_FILESYSTEM
++    if (keyObject->keyStore != NULL && keyObject->objectType != 0) {
++        unsigned int i = 0;
++        for (i = 0; i < keyObject->keyStore->max_object_count; i++) {
++            if (keyObject->keyStore->objects[i] == keyObject) {
++                keyObject->keyStore->objects[i] = NULL;
++                break;
++            }
++        }
++    }
++#endif /* NO_FILESYSTEM */
++    if (keyObject->contents != NULL && keyObject->contents_must_free) {
++        switch (keyObject->cipherType) {
++        case kSSS_CipherType_RSA:
++#ifndef NO_RSA
++            rsa = (RsaKey*)keyObject->contents;
++            wc_FreeRsaKey(rsa);
++            SSS_FREE(rsa);
++#endif
++            break;
++        case kSSS_CipherType_EC_NIST_P:
++        case kSSS_CipherType_EC_NIST_K:
++        case kSSS_CipherType_EC_BRAINPOOL:
++        case kSSS_CipherType_EC_MONTGOMERY:
++#ifdef HAVE_ECC
++            ecc = (ecc_key*)keyObject->contents;
++            wc_ecc_free(ecc);
++            SSS_FREE(ecc);
++#endif
++            break;
++        case kSSS_CipherType_EC_TWISTED_ED:
++#ifdef HAVE_ED25519
++            ed25519 = (ed25519_key*)keyObject->contents;
++            wc_ed25519_free(ed25519);
++            SSS_FREE(ed25519);
++#endif
++            break;
++        default:
++            SSS_FREE(keyObject->contents);
++        }
++    }
++    memset(keyObject, 0, sizeof(*keyObject));
++exit:
++    return;
++}
++
++/* End: wolfssl_keyobj */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_keyderive                                          */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_derive_key_context_init(
++    sss_wolfssl_derive_key_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++#if SSSFTR_SW_ECC
++    ENSURE_OR_GO_CLEANUP(context);
++    ENSURE_OR_GO_CLEANUP(session);
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyObject->contents);
++
++    context->session   = session;
++    context->keyObject = keyObject;
++    context->algorithm = algorithm;
++    context->mode      = mode;
++    retval             = kStatus_SSS_Success;
++cleanup:
++#endif
++    return retval;
++}
++
++sss_status_t sss_wolfssl_derive_key_one_go(sss_wolfssl_derive_key_t *context,
++    const uint8_t *saltData,
++    size_t saltLen,
++    const uint8_t *info,
++    size_t infoLen,
++    sss_wolfssl_object_t *derivedKeyObject,
++    uint16_t deriveDataLen)
++{
++    size_t adjustedSaltLen = saltLen;
++
++    if (context->mode == kMode_SSS_HKDF_ExpandOnly) {
++        adjustedSaltLen = 0;
++    }
++
++    return sss_wolfssl_derive_key_go(
++        context, saltData, adjustedSaltLen, info, infoLen, derivedKeyObject,
++        deriveDataLen, NULL, NULL);
++}
++
++sss_status_t sss_wolfssl_derive_key_sobj_one_go(
++    sss_wolfssl_derive_key_t *context,
++    sss_wolfssl_object_t *saltKeyObject,
++    const uint8_t *info,
++    size_t infoLen,
++    sss_wolfssl_object_t *derivedKeyObject,
++    uint16_t deriveDataLen)
++{
++    uint8_t saltData[1024] = {0};
++    size_t saltLen         = sizeof(saltData);
++    size_t dummySize;
++    sss_status_t status;
++
++    if (context == NULL) {
++        return kStatus_SSS_Fail;
++    }
++
++    if (context->mode != kMode_SSS_HKDF_ExpandOnly) {
++        status = sss_wolfssl_key_store_get_key(saltKeyObject->keyStore,
++                    saltKeyObject, saltData, &saltLen, &dummySize);
++        if (status != kStatus_SSS_Success) {
++            return kStatus_SSS_Fail;
++        }
++    }
++    else {
++        saltLen = 0;
++    }
++
++    return sss_wolfssl_derive_key_go(
++        context, saltData, saltLen, info, infoLen, derivedKeyObject,
++        deriveDataLen, NULL, NULL);
++}
++
++// In HKDF Expand only mode PRK is unbounded, we set a maximum of 256 byte
++// RFC5869 Section 2.3
++#define HKDF_PRK_MAX 256
++sss_status_t sss_wolfssl_derive_key_go(sss_wolfssl_derive_key_t *context,
++    const uint8_t *saltData,
++    size_t saltLen,
++    const uint8_t *info,
++    size_t infoLen,
++    sss_wolfssl_object_t *derivedKeyObject,
++    uint16_t deriveDataLen,
++    uint8_t *hkdfOutput,
++    size_t *hkdfOutputLen)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++#ifdef HAVE_HKDF
++    uint8_t *secret     = NULL;
++    size_t secretLen    = 0;
++    secret              = context->keyObject->contents;
++    secretLen           = context->keyObject->contents_size;
++    uint8_t prk[HKDF_PRK_MAX] = { 0, };
++    unsigned int prk_len = 0;
++    int md  = 0;
++    int ret = 0;
++
++    /* Initialize the MD */
++    switch (context->algorithm) {
++        case kAlgorithm_SSS_SHA1:
++        case kAlgorithm_SSS_HMAC_SHA1:
++#ifndef NO_SHA
++            md = WC_SHA;
++#endif
++            break;
++        case kAlgorithm_SSS_SHA256:
++        case kAlgorithm_SSS_HMAC_SHA256:
++#ifndef NO_SHA256
++            md = WC_SHA256;
++#endif
++            break;
++        case kAlgorithm_SSS_SHA384:
++        case kAlgorithm_SSS_HMAC_SHA384:
++#ifdef WOLFSSL_SHA384
++            md = WC_SHA384;
++#endif
++            break;
++        case kAlgorithm_SSS_SHA512:
++        case kAlgorithm_SSS_HMAC_SHA512:
++#ifdef WOLFSSL_SHA512
++            md = WC_SHA512;
++#endif
++            break;
++        default:
++            return kStatus_SSS_Fail;
++    }
++
++    if (saltLen == 0) {
++        /* Copy key as is */
++        if (HKDF_PRK_MAX >= secretLen) {
++            memcpy(prk, secret, secretLen);
++            prk_len = secretLen;
++        }
++        else {
++            LOG_E("HKDF Expand only (wolfSSL impl): buffer too small");
++            return kStatus_SSS_Fail;
++        }
++    }
++    else {
++        ret = wc_HKDF_Extract(md, saltData, saltLen, secret, secretLen, prk);
++        if (ret != 0) {
++            retval = kStatus_SSS_Fail;
++        }
++    }
++
++    if (retval == kStatus_SSS_Success) {
++        prk_len = wc_HmacSizeByType(md);
++        ret = wc_HKDF_Expand(md, prk, prk_len, info, infoLen,
++                             derivedKeyObject->contents,
++                             deriveDataLen);
++        if (ret != 0) {
++            retval = kStatus_SSS_Fail;
++        }
++        derivedKeyObject->contents_size = deriveDataLen;
++    }
++#else
++    LOG_E("wolfSSL not compiled with HAVE_HKDF");
++#endif /* HAVE_HKDF */
++    return retval;
++}
++
++sss_status_t sss_wolfssl_derive_key_dh(sss_wolfssl_derive_key_t *context,
++    sss_wolfssl_object_t *otherPartyKeyObject,
++    sss_wolfssl_object_t *derivedKeyObject)
++{
++    int ret = 0;
++    sss_status_t retval = kStatus_SSS_Fail;
++#ifdef HAVE_ECC
++    ecc_key* ecKeyPrv = NULL;
++    ecc_key* ecKeyExt = NULL;
++#endif
++#ifdef HAVE_CURVE25519
++   curve25519_key* keyPrv25519 = NULL; 
++   curve25519_key* keyExt25519 = NULL; 
++#endif
++#ifdef HAVE_CURVE448
++   curve448_key* keyPrv448 = NULL;
++   curve448_key* keyExt448 = NULL;
++#endif
++    size_t sharedSecretLen;
++    unsigned int sharedSecretLen_Derived;
++    uint8_t *secret     = NULL;
++
++    if (otherPartyKeyObject == NULL || derivedKeyObject == NULL) {
++        return kStatus_SSS_Fail;
++    }
++
++    if (context->keyObject->cipherType == kSSS_CipherType_EC_NIST_P ||
++        context->keyObject->cipherType == kSSS_CipherType_EC_NIST_K ||
++        context->keyObject->cipherType == kSSS_CipherType_EC_BRAINPOOL) {
++#ifdef HAVE_ECC
++        ecKeyPrv = (ecc_key*)context->keyObject->contents;
++        ecKeyExt = (ecc_key*)otherPartyKeyObject->contents;
++
++        sharedSecretLen = wc_ecc_size(ecKeyPrv);
++        if (sharedSecretLen > 0) {
++            secret = (uint8_t*)SSS_MALLOC(sharedSecretLen);
++            sharedSecretLen_Derived = sharedSecretLen;
++
++            ret = wc_ecc_shared_secret(ecKeyPrv, ecKeyExt, secret,
++                                       &sharedSecretLen_Derived);
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++        }
++#else
++        LOG_E("wolfSSL not compiled with ECC support");
++#endif /* HAVE_ECC */
++
++    } else if (context->keyObject->cipherType ==
++                kSSS_CipherType_EC_MONTGOMERY) {
++#if defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)
++    #ifdef HAVE_CURVE25519
++       if (context->keyObject->wcPkAlgoType == WC_PK_TYPE_CURVE25519) {
++
++           keyPrv25519 = (curve25519_key*)context->keyObject->contents;
++           keyExt25519 = (curve25519_key*)otherPartyKeyObject->contents;
++
++           sharedSecretLen = CURVE25519_KEYSIZE;
++           secret = (uint8_t*)SSS_MALLOC(sharedSecretLen);
++           sharedSecretLen_Derived = sharedSecretLen;
++
++           ret = wc_curve25519_shared_secret(keyPrv25519, keyExt25519,
++                                             secret, &sharedSecretLen_Derived);
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++       }
++    #endif
++    #ifdef HAVE_CURVE448
++       if (context->keyObject->wcPkAlgoType == WC_PK_TYPE_CURVE448) {
++
++           keyPrv448 = (curve448_key*)context->keyObject->contents;
++           keyExt448 = (curve448_key*)otherPartyKeyObject->contents;
++
++           sharedSecretLen = CURVE448_KEY_SIZE;
++           secret = (uint8_t*)SSS_MALLOC(sharedSecretLen);
++           sharedSecretLen_Derived = sharedSecretLen;
++
++           ret = wc_curve448_shared_secret(keyPrv448, keyExt448,
++                                           secret, &sharedSecretLen_Derived);
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++       }
++    #endif
++#endif /* HAVE_CURVE25519 || HAVE_CURVE448 */
++    }
++
++    if (retval == kStatus_SSS_Success) {
++        memcpy(derivedKeyObject->contents, secret, sharedSecretLen_Derived);
++        derivedKeyObject->contents_size = sharedSecretLen_Derived;
++    }
++
++    if (secret != NULL) {
++        SSS_FREE(secret);
++    }
++
++    return retval;
++}
++
++void sss_wolfssl_derive_key_context_free(sss_wolfssl_derive_key_t *context)
++{
++    if (context->keyObject) {
++        sss_wolfssl_key_object_free(context->keyObject);
++    }
++    memset(context, 0, sizeof(*context));
++}
++
++/* End: wolfssl_keyderive */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_keystore                                           */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_key_store_context_init(
++    sss_wolfssl_key_store_t *keyStore, sss_wolfssl_session_t *session)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyStore);
++    ENSURE_OR_GO_CLEANUP(session);
++    memset(keyStore, 0, sizeof(*keyStore));
++    keyStore->session = session;
++    retval            = kStatus_SSS_Success;
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_allocate(sss_wolfssl_key_store_t *keyStore,
++                                            uint32_t keyStoreId)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyStore);
++    ENSURE_OR_GO_CLEANUP(keyStore->session);
++
++#ifndef NO_FILESYSTEM
++    if (keyStore->objects == NULL) {
++        keyStore->max_object_count = MAX_KEY_OBJ_COUNT;
++        keyStore->objects = (sss_wolfssl_object_t **)SSS_MALLOC(
++                MAX_KEY_OBJ_COUNT * sizeof(sss_wolfssl_object_t *));
++        if (keyStore->objects == NULL) {
++            LOG_E("Could not allocate key store");
++            retval = kStatus_SSS_Fail;
++        }
++        else {
++            memset(keyStore->objects, 0,
++                   (MAX_KEY_OBJ_COUNT * sizeof(sss_wolfssl_object_t *)));
++            ks_sw_fat_allocate(&keyStore->keystore_shadow);
++            if (keyStore->session->szRootPath != NULL) {
++                ks_sw_fat_load(keyStore->session->szRootPath,
++                               keyStore->keystore_shadow);
++            }
++            retval = kStatus_SSS_Success;
++        }
++    }
++    else {
++        LOG_E("Keystore already allocated");
++        retval = kStatus_SSS_Fail;
++    }
++#else
++    retval = kStatus_SSS_Success;
++#endif /* NO_FILESYSTEM */
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_save(sss_wolfssl_key_store_t *keyStore)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyStore);
++    ENSURE_OR_GO_CLEANUP(keyStore->session);
++
++#ifndef NO_FILESYSTEM
++    ENSURE_OR_GO_CLEANUP(keyStore->session->szRootPath);
++    ENSURE_OR_GO_CLEANUP(keyStore->objects);
++    uint32_t i;
++    for (i = 0; i < keyStore->max_object_count; i++) {
++        if (NULL != keyStore->objects[i]) {
++            retval = ks_wolfssl_store_key(keyStore->objects[i]);
++            ENSURE_OR_GO_CLEANUP(retval == kStatus_SSS_Success);
++        }
++    }
++    retval = ks_wolfssl_fat_update(keyStore);
++#endif /* NO_FILESYSTEM */
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_load(sss_wolfssl_key_store_t *keyStore)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(keyStore);
++    ENSURE_OR_GO_CLEANUP(keyStore->session);
++#ifndef NO_FILESYSTEM
++    if (keyStore->objects == NULL) {
++        retval = sss_wolfssl_key_store_allocate(keyStore, 0);
++        ENSURE_OR_GO_CLEANUP(retval == kStatus_SSS_Success);
++    }
++    if (keyStore->session->szRootPath) {
++        if (NULL == keyStore->keystore_shadow) {
++            ks_sw_fat_allocate(&keyStore->keystore_shadow);
++        }
++        retval= ks_sw_fat_load(keyStore->session->szRootPath,
++                               keyStore->keystore_shadow);
++        keyStore->max_object_count = keyStore->keystore_shadow->maxEntries;
++    }
++#endif /* NO_FILESYSTEM */
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_set_key(sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject,
++    const uint8_t *data,
++    size_t dataLen,
++    size_t keyBitLen,
++    void *options,
++    size_t optionsLen)
++{
++    int ret = -1;
++    sss_status_t retval = kStatus_SSS_Fail;
++#if !defined(NO_RSA) || defined(HAVE_ECC) || \
++    (defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_IMPORT)) || \
++    (defined(HAVE_CURVE448) && defined(HAVE_CURVE448_KEY_IMPORT)) || \
++    (defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT))
++    unsigned int idx = 0;
++#endif
++#ifndef NO_RSA
++    RsaKey* rsaKey = NULL;
++#endif
++#ifdef HAVE_ECC
++    ecc_key* eccKey = NULL;
++#endif
++#if defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_IMPORT)
++    curve25519_key* key25519 = NULL;
++#endif
++#if defined(HAVE_CURVE448) && defined(HAVE_CURVE448_KEY_IMPORT)
++    curve448_key* key448 = NULL;
++#endif
++#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
++    ed25519_key* edKey = NULL;
++#endif
++
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyObject->contents);
++
++    if (!(keyObject->accessRights & kAccessPermission_SSS_Write)) {
++        return retval;
++    }
++
++    if (keyObject->objectType != kSSS_KeyPart_Default &&
++        keyObject->objectType != kSSS_KeyPart_Private &&
++        keyObject->objectType != kSSS_KeyPart_Public &&
++        keyObject->objectType != kSSS_KeyPart_Pair) {
++        return retval;
++    }
++
++    /* handle Default case first, copy over data into keyObject */
++    if (keyObject->objectType == kSSS_KeyPart_Default) {
++        if (dataLen > keyObject->contents_max_size) {
++            LOG_E("Not enough memory in keyObject for key size");
++        }
++        else {
++            if (data != NULL) { /* for empty certificates */
++                memcpy(keyObject->contents, data, dataLen);
++            }
++            keyObject->contents_size = dataLen;
++            keyObject->keyBitLen = keyBitLen;
++            retval = kStatus_SSS_Success;
++        }
++        return retval;
++    }
++
++    switch (keyObject->cipherType) {
++        case kSSS_CipherType_RSA:
++#ifndef NO_RSA
++            rsaKey = (RsaKey*)keyObject->contents;
++
++            if (keyObject->objectType == kSSS_KeyPart_Private ||
++                keyObject->objectType == kSSS_KeyPart_Pair) {
++
++                ret = wc_RsaPrivateKeyDecode(data, &idx, rsaKey, dataLen);
++
++            } else if (keyObject->objectType == kSSS_KeyPart_Public) {
++
++                ret = wc_RsaPublicKeyDecode(data, &idx, rsaKey, dataLen);
++            }
++#endif /* NO_RSA */
++            break;
++
++        case kSSS_CipherType_EC_NIST_P:
++        case kSSS_CipherType_EC_NIST_K:
++        case kSSS_CipherType_EC_BRAINPOOL:
++#ifdef HAVE_ECC
++            eccKey = (ecc_key*)keyObject->contents;
++
++            if (keyObject->objectType == kSSS_KeyPart_Private ||
++                keyObject->objectType == kSSS_KeyPart_Pair) {
++
++                ret = wc_EccPrivateKeyDecode(data, &idx, eccKey, dataLen);
++
++            } else if (keyObject->objectType == kSSS_KeyPart_Public) {
++
++                ret = wc_EccPublicKeyDecode(data, &idx, eccKey, dataLen);
++            }
++#endif /* HAVE_ECC */
++            break;
++
++        case kSSS_CipherType_EC_MONTGOMERY:
++            if (keyObject->wcPkAlgoType == WC_PK_TYPE_CURVE25519) {
++#if defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_IMPORT)
++                key25519 = (curve25519_key*)keyObject->contents;
++
++                if (keyObject->objectType == kSSS_KeyPart_Private ||
++                    keyObject->objectType == kSSS_KeyPart_Pair) {
++
++                    ret = wc_Curve25519PrivateKeyDecode(data, &idx,
++                                                        key25519, dataLen);
++
++                } else if (keyObject->objectType == kSSS_KeyPart_Public) {
++
++                    ret = wc_Curve25519PublicKeyDecode(data, &idx,
++                                                       key25519, dataLen);
++                }
++#endif /* HAVE_CURVE25519 && HAVE_CURVE25519_KEY_IMPORT */
++            }
++            else if (keyObject->wcPkAlgoType == WC_PK_TYPE_CURVE448) {
++#if defined(HAVE_CURVE448) && defined(HAVE_CURVE448_KEY_IMPORT)
++                key448 = (curve448_key*)keyObject->contents;
++
++                if (keyObject->objectType == kSSS_KeyPart_Private ||
++                    keyObject->objectType == kSSS_KeyPart_Pair) {
++
++                    ret = wc_Curve448PrivateKeyDecode(data, &idx,
++                                                      key448, dataLen);
++
++                } else if (keyObject->objectType == kSSS_KeyPart_Public) {
++
++                    ret = wc_Curve448PublicKeyDecode(data, &idx,
++                                                     key448, dataLen);
++                }
++#endif /* HAVE_CURVE448 && HAVE_CURVE448_KEY_IMPORT */
++            }
++            else {
++                LOG_E("Unsupported montgomery key type");
++            }
++            break;
++
++        case kSSS_CipherType_EC_TWISTED_ED:
++#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
++            edKey = (ed25519_key*)keyObject->contents;
++
++            if (keyObject->objectType == kSSS_KeyPart_Private ||
++                keyObject->objectType == kSSS_KeyPart_Pair) {
++
++                ret = wc_Ed25519PrivateKeyDecode(data, &idx, edKey, dataLen);
++
++            } else if (keyObject->objectType == kSSS_KeyPart_Public) {
++
++                ret = wc_Ed25519PublicKeyDecode(data, &idx, edKey, dataLen);
++            }
++#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_IMPORT */
++            break;
++
++        default:
++            break;
++    }
++
++    if (ret != 0) {
++        retval = kStatus_SSS_Fail;
++    } else {
++        retval = kStatus_SSS_Success;
++    }
++
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_generate_key(
++    sss_wolfssl_key_store_t *keyStore, sss_wolfssl_object_t *keyObject,
++    size_t keyBitLen, void *options)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    sss_cipher_type_t cipher_type;
++
++    ENSURE_OR_GO_EXIT(keyStore);
++    ENSURE_OR_GO_EXIT(keyObject);
++
++    cipher_type = keyObject->cipherType;
++
++    switch (cipher_type) {
++#if SSSFTR_SW_ECC
++        case kSSS_CipherType_EC_NIST_P:
++        case kSSS_CipherType_EC_NIST_K:
++        case kSSS_CipherType_EC_BRAINPOOL:
++            retval = sss_wolfssl_generate_ecc_key(keyObject, keyBitLen);
++            break;
++        case kSSS_CipherType_EC_MONTGOMERY:
++            retval = sss_wolfssl_generate_ec_mont_key(keyObject, keyBitLen);
++            break;
++        case kSSS_CipherType_EC_TWISTED_ED:
++            retval = sss_wolfssl_generate_ed_key(keyObject, keyBitLen);
++            break;
++#endif
++#if SSSFTR_SW_RSA
++        case kSSS_CipherType_RSA:
++            retval = sss_wolfssl_generate_rsa_key(keyObject, keyBitLen);
++            break;
++#endif
++        default:
++            break;
++    }
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_get_key(
++    sss_wolfssl_key_store_t *keyStore,
++    sss_wolfssl_object_t *keyObject,
++    uint8_t *data,
++    size_t *dataLen,
++    size_t *pKeyBitLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++#ifndef NO_RSA
++    RsaKey* rsaKey = NULL;
++#endif
++#ifdef HAVE_ECC
++    ecc_key* ecKey = NULL;
++#endif
++#ifdef HAVE_CURVE25519
++    curve25519_key* key25519 = NULL;
++#endif
++#ifdef HAVE_CURVE448
++    curve448_key* key448 = NULL;
++#endif
++#ifdef HAVE_ED25519
++    ed25519_key* edKey = NULL;
++#endif
++
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyObject->contents);
++    ENSURE_OR_GO_CLEANUP(data);
++    ENSURE_OR_GO_CLEANUP(dataLen);
++
++    if (!(keyObject->accessRights & kAccessPermission_SSS_Read)) {
++        return kStatus_SSS_Fail;
++    }
++
++    switch (keyObject->objectType) {
++        case kSSS_KeyPart_Default:
++            memcpy(data, keyObject->contents, keyObject->contents_size);
++            *dataLen = keyObject->contents_size;
++            retval = kStatus_SSS_Success;
++            break;
++
++        case kSSS_KeyPart_Public:
++        case kSSS_KeyPart_Pair:
++            if (keyObject->cipherType == kSSS_CipherType_RSA) {
++#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
++                rsaKey = (RsaKey*)keyObject->contents;
++
++                ret = wc_RsaPublicKeyDerSize(rsaKey, 1);
++                if (ret < (int)(*dataLen)) {
++                    LOG_E("Not enough buffer space to write RSA key");
++                } else {
++                    ret = 0;
++                }
++
++                if (ret == 0) {
++                    ret = wc_RsaKeyToPublicDer(rsaKey, data, (*dataLen));
++                    if (ret > 0) {
++                        *dataLen = ret;
++                        *pKeyBitLen = ret * 8;
++                        retval = kStatus_SSS_Success;
++                    }
++                    else {
++                        LOG_E("Failed to write RSA public key");
++                    }
++                }
++#endif /* NO_RSA || WOLFSSL_KEY_GEN */
++            }
++            else if (keyObject->cipherType == kSSS_CipherType_EC_NIST_P ||
++                     keyObject->cipherType == kSSS_CipherType_EC_NIST_K ||
++                     keyObject->cipherType == kSSS_CipherType_EC_BRAINPOOL) {
++#ifdef HAVE_ECC
++                ecKey = (ecc_key*)keyObject->contents;
++
++                ret = wc_EccPublicKeyDerSize(ecKey, 1);
++                if (ret < (int)(*dataLen)) {
++                    LOG_E("Not enough buffer space to write ECC key");
++                } else {
++                    ret = 0;
++                }
++
++                if (ret == 0) {
++                    ret = wc_EccPublicKeyToDer_ex(ecKey, data,(*dataLen), 1, 0);
++                    if (ret > 0) {
++                        *dataLen = ret;
++                        *pKeyBitLen = ret * 8;
++                        retval = kStatus_SSS_Success;
++                    }
++                    else {
++                        LOG_E("Failed to write ECC public key");
++                    }
++                }
++#endif /* HAVE_ECC */
++            }
++            else if (keyObject->cipherType == kSSS_CipherType_EC_MONTGOMERY) {
++                if (keyObject->wcPkAlgoType == WC_PK_TYPE_CURVE25519) {
++#ifdef HAVE_CURVE25519
++                    key25519 = (curve25519_key*)keyObject->contents;
++
++                    ret = wc_Curve25519PublicKeyToDer(key25519, data,
++                                                      (*dataLen), 1);
++                    if (ret > 0) {
++                        *dataLen = ret;
++                        *pKeyBitLen = ret * 8;
++                        retval = kStatus_SSS_Success;
++                    }
++                    else {
++                        LOG_E("Failed to write Curve25519 public key");
++                    }
++#endif /* HAVE_CURVE25519 */
++                }
++                if (keyObject->wcPkAlgoType == WC_PK_TYPE_CURVE448) {
++#ifdef HAVE_CURVE448
++                    key448 = (curve448_key*)keyObject->contents;
++
++                    ret = wc_Curve448PublicKeyToDer(key448, data,
++                                                    (*dataLen), 1);
++                    if (ret > 0) {
++                        *dataLen = ret;
++                        *pKeyBitLen = ret * 8;
++                        retval = kStatus_SSS_Success;
++                    }
++                    else {
++                        LOG_E("Failed to write Curve448 public key");
++                    }
++#endif /* HAVE_CURVE448 */
++                }
++            }
++            else if (keyObject->cipherType == kSSS_CipherType_EC_TWISTED_ED) {
++#ifdef HAVE_ED25519
++                edKey = (ed25519_key*)keyObject->contents;
++
++                ret = wc_Ed25519PublicKeyToDer(edKey, data, (*dataLen), 1);
++                if (ret > 0) {
++                    *dataLen = ret;
++                    *pKeyBitLen = ret * 8;
++                    retval = kStatus_SSS_Success;
++                }
++                else {
++                    LOG_E("Failed to write Ed25519 public key");
++                }
++#endif /* HAVE_ED25519 */
++            }
++            else {
++                LOG_E("Unsupported cipherType");
++            }
++            break;
++        default:
++            break;
++    }
++
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_open_key(sss_wolfssl_key_store_t *keyStore,
++                                            sss_wolfssl_object_t *keyObject)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_freeze_key(sss_wolfssl_key_store_t *keyStore,
++                                              sss_wolfssl_object_t *keyObject)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++    return retval;
++}
++
++sss_status_t sss_wolfssl_key_store_erase_key(sss_wolfssl_key_store_t *keyStore,
++                                             sss_wolfssl_object_t *keyObject)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_EXIT(keyStore);
++    ENSURE_OR_GO_EXIT(keyObject);
++    ENSURE_OR_GO_EXIT(keyObject->keyStore);
++
++    if (!(keyObject->accessRights & kAccessPermission_SSS_Delete)) {
++        LOG_E("Don't have access right to delete the key");
++        return retval;
++    }
++
++    if (keyObject->keyMode == kKeyObject_Mode_Persistent) {
++#ifndef NO_FILESYSTEM
++        unsigned int i = 0;
++        /* First check if key exists delete key from shadow KS */
++        retval = ks_common_remove_fat(keyObject->keyStore->keystore_shadow,
++                                      keyObject->keyId);
++        ENSURE_OR_GO_CLEANUP(retval == kStatus_SSS_Success);
++
++        /* Update shadow keystore in file system */
++        retval = ks_wolfssl_fat_update(keyObject->keyStore);
++        ENSURE_OR_GO_CLEANUP(retval == kStatus_SSS_Success);
++
++        /* Clear key object from file */
++        retval = ks_wolfssl_remove_key(keyObject);
++        /* Check added as part of security boundary checks */
++        ENSURE_OR_GO_CLEANUP(retval == kStatus_SSS_Success);
++
++        for (i = 0; i < keyObject->keyStore->max_object_count; i++) {
++            if (keyObject->keyStore->objects[i] == keyObject) {
++                keyObject->keyStore->objects[i] = NULL;
++                break;
++            }
++        }
++#endif /* NO_FILESYSTEM */
++    }
++    else {
++        retval = kStatus_SSS_Success;
++    }
++#ifndef NO_FILESYSTEM
++cleanup:
++#endif
++exit:
++    return retval;
++}
++
++void sss_wolfssl_key_store_context_free(sss_wolfssl_key_store_t *keyStore)
++{
++#ifndef NO_FILESYSTEM
++    if (NULL != keyStore->objects) {
++        uint32_t i;
++        for (i = 0; i < keyStore->max_object_count; i++) {
++            if (keyStore->objects[i] != NULL) {
++                sss_wolfssl_key_object_free(keyStore->objects[i]);
++                keyStore->objects[i] = NULL;
++            }
++        }
++        SSS_FREE(keyStore->objects);
++        keyStore->objects = NULL;
++    }
++
++    if (NULL != keyStore->keystore_shadow) {
++        ks_sw_fat_free(keyStore->keystore_shadow);
++    }
++#endif /* NO_FILESYSTEM */
++    memset(keyStore, 0, sizeof(*keyStore));
++}
++
++int wolfssl_get_padding(sss_algorithm_t algorithm)
++{
++    int padding = 0;
++    switch (algorithm) {
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA1:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA224:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA256:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA384:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA512:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_NO_HASH:
++        case kAlgorithm_SSS_RSAES_PKCS1_V1_5:
++            padding = WC_RSA_PKCSV15_PAD;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA1:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA224:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA256:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA384:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA512:
++            padding = WC_RSA_PSS_PAD;
++            break;
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA1:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA224:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA256:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA384:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA512:
++            padding = WC_RSA_OAEP_PAD;
++            break;
++        default:
++            padding = WC_RSA_NO_PAD;
++    }
++    return padding;
++}
++
++int wolfssl_get_hash_type(sss_algorithm_t algorithm)
++{
++    enum wc_HashType type = 0;
++    switch (algorithm) {
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA1:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA1:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA1:
++        case kAlgorithm_SSS_ECDSA_SHA1:
++            type = WC_HASH_TYPE_SHA;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA224:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA224:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA224:
++        case kAlgorithm_SSS_ECDSA_SHA224:
++            type = WC_HASH_TYPE_SHA224;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA256:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA256:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA256:
++        case kAlgorithm_SSS_ECDSA_SHA256:
++            type = WC_HASH_TYPE_SHA256;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA384:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA384:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA384:
++        case kAlgorithm_SSS_ECDSA_SHA384:
++            type = WC_HASH_TYPE_SHA384;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA512:
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA512:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA512:
++        case kAlgorithm_SSS_ECDSA_SHA512:
++            type = WC_HASH_TYPE_SHA512;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_NO_HASH:
++        case kAlgorithm_SSS_RSAES_PKCS1_V1_5:
++        default:
++            type = WC_HASH_TYPE_NONE;
++            break;
++    }
++    return (int)type;
++}
++
++int wolfssl_get_mgf(sss_algorithm_t algorithm)
++{
++    int mgf = 0;
++    switch (algorithm) {
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA1:
++            mgf = WC_MGF1SHA1;
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA224:
++            mgf = WC_MGF1SHA224;
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA256:
++            mgf = WC_MGF1SHA256;
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA384:
++            mgf = WC_MGF1SHA384;
++        case kAlgorithm_SSS_RSASSA_PKCS1_PSS_MGF1_SHA512:
++            mgf = WC_MGF1SHA512;
++            break;
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA1:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA224:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA256:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA384:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_SHA512:
++        case kAlgorithm_SSS_RSASSA_PKCS1_V1_5_NO_HASH:
++        case kAlgorithm_SSS_RSAES_PKCS1_V1_5:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA1:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA224:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA256:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA384:
++        case kAlgorithm_SSS_RSAES_PKCS1_OAEP_SHA512:
++        default:
++            mgf = WC_MGF1NONE;
++            break;
++    }
++    return mgf;
++}
++
++/* End: wolfssl_keystore */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_asym                                               */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_asymmetric_context_init(
++    sss_wolfssl_asymmetric_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++
++    ENSURE_OR_GO_CLEANUP(context);
++    ENSURE_OR_GO_CLEANUP(keyObject);
++    ENSURE_OR_GO_CLEANUP(keyObject->keyStore->session->subsystem == kType_SSS_wolfSSL);
++
++    context->session   = session;
++    context->keyObject = keyObject;
++    context->algorithm = algorithm;
++    context->mode      = mode;
++    retval             = kStatus_SSS_Success;
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_asymmetric_encrypt(
++    sss_wolfssl_asymmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    sss_wolfssl_object_t *keyObj = context->keyObject;
++    int ret      = 0;
++    int padding  = 0;
++    int mgf      = 0;
++    int hashType = 0;
++    RsaKey* rsaKey = NULL;
++    WC_RNG rng;
++
++    if (!(context->keyObject->accessRights & kAccessPermission_SSS_Use)) {
++        return retval;
++    }
++
++    ret = wc_InitRng(&rng);
++    if (ret != 0) {
++        return retval;
++    }
++
++    /* Get the RSA Key, padding, mgf, hash type */
++    rsaKey   = (RsaKey*)keyObj->contents;
++    padding  = wolfssl_get_padding(context->algorithm);
++    mgf      = wolfssl_get_mgf(context->algorithm);
++    hashType = wolfssl_get_hash_type(context->algorithm);
++
++    /* Encrypt the mesasage. */
++    ret = wc_RsaPublicEncrypt_ex(srcData, srcLen, destData, (*destLen), rsaKey,
++                                 &rng, padding, hashType, mgf, NULL, 0);
++    if (ret > 0) {
++        *destLen = ret;
++        retval = kStatus_SSS_Success;
++    }
++
++    wc_FreeRng(&rng);
++
++    return retval;
++}
++
++sss_status_t sss_wolfssl_asymmetric_decrypt(
++    sss_wolfssl_asymmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    sss_wolfssl_object_t *keyObj = context->keyObject;
++    int ret     = 0;
++    int padding = 0;
++    int mgf      = 0;
++    int hashType = 0;
++    RsaKey* rsaKey = NULL;
++
++    if (!(context->keyObject->accessRights & kAccessPermission_SSS_Use)) {
++        return retval;
++    }
++
++    /* Get the RSA Key, padding, mgf, hash type */
++    rsaKey   = (RsaKey*)keyObj->contents;
++    padding  = wolfssl_get_padding(context->algorithm);
++    mgf      = wolfssl_get_mgf(context->algorithm);
++    hashType = wolfssl_get_hash_type(context->algorithm);
++
++    /* Decrypt the mesasage. */
++    ret = wc_RsaPrivateDecrypt_ex(srcData, srcLen, destData, (*destLen),
++                                  rsaKey, padding, hashType, mgf, NULL, 0);
++    if (ret > 0) {
++        *destLen = ret;
++        retval = kStatus_SSS_Success;
++    }
++
++    return retval;
++}
++
++sss_status_t sss_wolfssl_asymmetric_sign_digest(
++    sss_wolfssl_asymmetric_t *context, uint8_t *digest, size_t digestLen,
++    uint8_t *signature, size_t *signatureLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret      = 0;
++    int padding  = 0;
++    int mgf      = 0;
++    int hashType = 0;
++#ifndef NO_RSA
++    RsaKey* rsaKey = NULL;
++#endif
++#ifdef HAVE_ECC
++    ecc_key* ecKey = NULL;
++#endif
++#if defined(HAVE_ED25519) && defined(HAVE_ED25519_VERIFY)
++    ed25519_key* edKey = NULL;
++#endif
++    WC_RNG rng;
++
++    if (!(context->keyObject->accessRights & kAccessPermission_SSS_Use)) {
++        return retval;
++    }
++
++    ret = wc_InitRng(&rng);
++    if (ret != 0) {
++        return retval;
++    }
++
++    padding  = wolfssl_get_padding(context->algorithm);
++    mgf      = wolfssl_get_mgf(context->algorithm);
++    hashType = wolfssl_get_hash_type(context->algorithm);
++
++    switch (context->keyObject->cipherType) {
++        case kSSS_CipherType_RSA:
++#ifndef NO_RSA
++            rsaKey = (RsaKey*)context->keyObject->contents;
++
++            if (padding == WC_RSA_PKCSV15_PAD) {
++                ret = wc_RsaSSL_Sign(digest, digestLen, signature,
++                                     (*signatureLen), rsaKey, &rng);
++            }
++    #ifdef WC_RSA_PSS
++            else if (padding == WC_RSA_PSS_PAD) {
++                ret = wc_RsaPSS_Sign(digest, digestLen, signature,
++                                     (*signatureLen), hashType, mgf,
++                                     rsaKey, &rng);
++            }
++    #endif /* WC_RSA_PSS */
++            else {
++                LOG_E("Unsupported RSA sign padding type");
++            }
++
++            if (ret > 0) {
++                *signatureLen = ret;
++                retval = kStatus_SSS_Success;
++            }
++#endif /* NO_RSA */
++            break;
++
++        case kSSS_CipherType_EC_NIST_P:
++        case kSSS_CipherType_EC_NIST_K:
++        case kSSS_CipherType_EC_BRAINPOOL:
++#ifdef HAVE_ECC
++            ecKey = (ecc_key*)context->keyObject->contents;
++
++            ret = wc_ecc_sign_hash(digest, digestLen, signature,
++                                   signatureLen, &rng, ecKey);
++
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++#endif /* HAVE_ECC */
++            break;
++
++        case kSSS_CipherType_EC_TWISTED_ED:
++#if defined(HAVE_ED25519) && defined(HAVE_ED25519_SIGN)
++            edKey = (ed25519_key*)context->keyObject->contents;
++
++            ret = wc_ed25519_sign_msg(digest, digestLen, signature,
++                                      signatureLen, edKey);
++
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++#endif /* HAVE_ED25519 */
++            break;
++
++        default:
++            LOG_E("Unsupported cipherType for digest sign");
++            break;
++    }
++
++    wc_FreeRng(&rng);
++
++    return retval;
++}
++
++sss_status_t sss_wolfssl_asymmetric_verify_digest(
++    sss_wolfssl_asymmetric_t *context, uint8_t *digest, size_t digestLen,
++    uint8_t *signature, size_t signatureLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret      = 0;
++    int padding  = 0;
++    int mgf      = 0;
++    int hashType = 0;
++#ifndef NO_RSA
++    unsigned char* plainBuf = NULL;
++    unsigned int plainLen = 0;
++    RsaKey* rsaKey = NULL;
++#endif
++#if defined(HAVE_ECC) || (defined(HAVE_ED25519) && defined(HAVE_ED25519_VERIFY))
++    int res = 0;
++    ecc_key* ecKey = NULL;
++#endif
++#if defined(HAVE_ED25519) && defined(HAVE_ED25519_VERIFY)
++    ed25519_key* edKey = NULL;
++#endif
++
++    if (!(context->keyObject->accessRights & kAccessPermission_SSS_Use)) {
++        return retval;
++    }
++
++    padding  = wolfssl_get_padding(context->algorithm);
++    mgf      = wolfssl_get_mgf(context->algorithm);
++    hashType = wolfssl_get_hash_type(context->algorithm);
++
++    switch (context->keyObject->cipherType) {
++        case kSSS_CipherType_RSA:
++#ifndef NO_RSA
++            rsaKey = (RsaKey*)context->keyObject->contents;
++
++            plainLen = wc_RsaEncryptSize(rsaKey) * 8;
++            plainBuf = (unsigned char*)SSS_MALLOC(plainLen);
++            if (plainBuf == NULL) {
++                LOG_E("Unable to allocate memory for signature verify");
++                return retval;
++            }
++
++            if (padding == WC_RSA_PKCSV15_PAD) {
++                ret = wc_RsaSSL_Verify(signature, signatureLen,
++                                       plainBuf, plainLen, rsaKey);
++                if (ret < 0 || (ret != digestLen)) {
++                    SSS_FREE(plainBuf);
++                    return retval;
++                }
++                if (memcmp(plainBuf, digest, digestLen) == 0) {
++                    retval = kStatus_SSS_Success;
++                }
++                SSS_FREE(plainBuf);
++            }
++    #ifdef WC_RSA_PSS
++            else if (padding == WC_RSA_PSS_PAD) {
++                ret = wc_RsaPSS_Verify(signature, signatureLen, plainBuf,
++                                       plainLen, hashType, mgf, rsaKey);
++                if (ret < 0 || (ret != digestLen)) {
++                    SSS_FREE(plainBuf);
++                    return retval;
++                }
++                if (memcmp(plainBuf, digest, digestLen) == 0) {
++                    retval = kStatus_SSS_Success;
++                }
++                SSS_FREE(plainBuf);
++            }
++    #endif /* WC_RSA_PSS */
++            else {
++                LOG_E("Unsupported RSA sign padding type");
++            }
++#endif /* NO_RSA */
++            break;
++
++        case kSSS_CipherType_EC_NIST_P:
++        case kSSS_CipherType_EC_NIST_K:
++        case kSSS_CipherType_EC_BRAINPOOL:
++#ifdef HAVE_ECC
++            ecKey = (ecc_key*)context->keyObject->contents;
++
++            ret = wc_ecc_verify_hash(signature, signatureLen, digest,
++                                     digestLen, &res, ecKey);
++
++            if ((ret == 0) && (res == 1)) {
++                retval = kStatus_SSS_Success;
++            }
++#endif /* HAVE_ECC */
++            break;
++
++        case kSSS_CipherType_EC_TWISTED_ED:
++#if defined(HAVE_ED25519) && defined(HAVE_ED25519_VERIFY)
++            edKey = (ed25519_key*)context->keyObject->contents;
++
++            ret = wc_ed25519_verify_msg(signature, signatureLen, digest,
++                                        digestLen, &res, edKey);
++            if ((ret == 0) && (res == 1)) {
++                retval = kStatus_SSS_Success;
++            }
++#endif /* HAVE_ED25519 */
++            break;
++
++        default:
++            LOG_E("Unsupported cipherType for digest sign");
++            break;
++    }
++
++    return retval;
++
++}
++
++void sss_wolfssl_asymmetric_context_free(sss_wolfssl_asymmetric_t *context)
++{
++    memset(context, 0, sizeof(*context));
++}
++
++/* End: wolfssl_asym */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_symm                                               */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_symmetric_context_init(
++    sss_wolfssl_symmetric_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++
++    context->session        = session;
++    context->keyObject      = keyObject;
++    context->algorithm      = algorithm;
++    context->mode           = mode;
++    context->cache_data_len = 0;
++
++    return retval;
++}
++
++sss_status_t sss_wolfssl_cipher_one_go(sss_wolfssl_symmetric_t *context,
++    uint8_t *iv,
++    size_t ivLen,
++    const uint8_t *srcData,
++    uint8_t *destData,
++    size_t dataLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = -1;
++#ifndef NO_AES
++    Aes aes;
++#endif
++#ifndef NO_DES3
++    Des  des;
++    Des3 des3;
++#endif
++
++    /* Set encrypt/decrypt key */
++    switch (context->algorithm) {
++#ifndef NO_AES
++        case kAlgorithm_SSS_AES_ECB:
++        case kAlgorithm_SSS_AES_CBC:
++        case kAlgorithm_SSS_AES_CTR:
++            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
++        #ifdef WOLFSSL_SE050
++            if (ret == 0) {
++                /* HostCrypto should use software crypto, not SE05x */
++                aes.useSWCrypt = 1;
++            }
++        #endif
++            if (ret == 0) {
++                if (context->mode == kMode_SSS_Encrypt) {
++                    ret = wc_AesSetKey(&aes,
++                                       (uint8_t*)context->keyObject->contents,
++                                       (int)context->keyObject->contents_size,
++                                       iv, AES_ENCRYPTION);
++                }
++                else {
++                    ret = wc_AesSetKey(&aes,
++                                       (uint8_t*)context->keyObject->contents,
++                                       (int)context->keyObject->contents_size,
++                                       iv, AES_DECRYPTION);
++                }
++            }
++            break;
++#endif /* NO_AES */
++#ifndef NO_DES3
++        case kAlgorithm_SSS_DES_ECB:
++        case kAlgorithm_SSS_DES_CBC:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_Des_SetKey(&des,
++                                    (uint8_t*)context->keyObject->contents,
++                                    iv, DES_ENCRYPTION);
++            }
++            else {
++                ret = wc_Des_SetKey(&des,
++                                    (uint8_t*)context->keyObject->contents,
++                                    iv, DES_DECRYPTION);
++            }
++            break;
++        case kAlgorithm_SSS_DES3_ECB:
++        case kAlgorithm_SSS_DES3_CBC:
++            ret = wc_Des3Init(&des3, NULL, INVALID_DEVID);
++            if (ret == 0) {
++                if (context->mode == kMode_SSS_Encrypt) {
++                    ret = wc_Des3_SetKey(&des3,
++                                         (uint8_t*)context->keyObject->contents,
++                                         iv, DES_ENCRYPTION);
++                }
++                else {
++                    ret = wc_Des3_SetKey(&des3,
++                                         (uint8_t*)context->keyObject->contents,
++                                         iv, DES_DECRYPTION);
++                }
++            }
++            break;
++#endif /* NO_DES */
++        default:
++            break;
++    }
++
++    if (ret != 0) {
++#ifndef NO_AES
++        wc_AesFree(&aes);
++#endif
++#ifndef NO_DES3
++        wc_Des3Free(&des3); /* no Des free */
++#endif
++        return retval;
++    }
++
++    /* Encrypt / decrypt data */
++    switch (context->algorithm) {
++#ifndef NO_AES
++    #ifdef HAVE_AES_ECB
++        case kAlgorithm_SSS_AES_ECB:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_AesEcbEncrypt(&aes, destData, srcData, dataLen);
++            }
++            else {
++                ret = wc_AesEcbDecrypt(&aes, destData, srcData, dataLen);
++            }
++            break;
++    #endif /* HAVE_AES_ECB */
++    #ifdef HAVE_AES_CBC
++        case kAlgorithm_SSS_AES_CBC:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_AesCbcEncrypt(&aes, destData, srcData, dataLen);
++            }
++            else {
++                ret = wc_AesCbcDecrypt(&aes, destData, srcData, dataLen);
++            }
++            break;
++    #endif /* HAVE_AES_CBC */
++    #ifdef WOLFSSL_AES_COUNTER
++        case kAlgorithm_SSS_AES_CTR:
++            ret = wc_AesCtrEncrypt(&aes, destData, srcData, dataLen);
++            break;
++    #endif /* WOLFSSL_AES_COUNTER */
++#endif /* NO_AES */
++#if !defined(NO_DES3) && defined(WOLFSSL_DES_ECB)
++        case kAlgorithm_SSS_DES_ECB:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_Des_EcbEncrypt(&des, destData, srcData, dataLen);
++            }
++            else {
++                ret = wc_Des_EcbDecrypt(&des, destData, srcData, dataLen);
++            }
++            break;
++        case kAlgorithm_SSS_DES_CBC:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_Des_CbcEncrypt(&des, destData, srcData, dataLen);
++            }
++            else {
++                ret = wc_Des_CbcDecrypt(&des, destData, srcData, dataLen);
++            }
++            break;
++        case kAlgorithm_SSS_DES3_ECB:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_Des3_EcbEncrypt(&des3, destData, srcData, dataLen);
++            }
++            else {
++                ret = wc_Des3_EcbDecrypt(&des3, destData, srcData, dataLen);
++            }
++            break;
++        case kAlgorithm_SSS_DES3_CBC:
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_Des3_CbcEncrypt(&des3, destData, srcData, dataLen);
++            }
++            else {
++                ret = wc_Des3_CbcDecrypt(&des3, destData, srcData, dataLen);
++            }
++            break;
++#endif /* !NO_DES3 && WOLFSSL_DES_ECB */
++        default:
++            break;
++    }
++
++    if (ret == 0) {
++        retval = kStatus_SSS_Success;
++    }
++
++#ifndef NO_AES
++    wc_AesFree(&aes);
++#endif
++#ifndef NO_DES3
++    wc_Des3Free(&des3); /* no Des free */
++#endif
++
++    return retval;
++}
++
++sss_status_t sss_wolfssl_cipher_one_go_v2(sss_wolfssl_symmetric_t *context,
++    uint8_t *iv,
++    size_t ivLen,
++    const uint8_t *srcData,
++    const size_t srcLen,
++    uint8_t *destData,
++    size_t *pDataLen)
++{
++    if (*pDataLen < srcLen) {
++        return kStatus_SSS_Fail;
++    }
++    *pDataLen = srcLen;
++    return sss_wolfssl_cipher_one_go(context, iv, ivLen, srcData, destData,
++                                     *pDataLen);
++}
++
++sss_status_t sss_wolfssl_cipher_init(sss_wolfssl_symmetric_t *context,
++                                     uint8_t *iv, size_t ivLen)
++{
++    /* currently unsupported in wolfSSL */
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_cipher_update(
++    sss_wolfssl_symmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen)
++{
++    /* currently unsupported in wolfSSL */
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_cipher_finish(
++    sss_wolfssl_symmetric_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen)
++{
++    /* currently unsupported in wolfSSL */
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_cipher_crypt_ctr(sss_wolfssl_symmetric_t *context,
++    const uint8_t *srcData,
++    uint8_t *destData,
++    size_t size,
++    uint8_t *initialCounter,
++    uint8_t *lastEncryptedCounter,
++    size_t *szLeft)
++{
++    /* currently unsupported in wolfSSL */
++    return kStatus_SSS_Fail;
++}
++
++void sss_wolfssl_symmetric_context_free(sss_wolfssl_symmetric_t *context)
++{
++    memset(context, 0, sizeof(*context));
++}
++
++/* End: wolfssl_symm */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_aead                                               */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_aead_context_init(sss_wolfssl_aead_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    context->session    = session;
++    context->keyObject  = keyObject;
++    context->mode       = mode;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    ENSURE_OR_GO_EXIT(session != NULL);
++    ENSURE_OR_GO_EXIT(keyObject != NULL);
++
++    if (algorithm == kAlgorithm_SSS_AES_GCM ||
++        algorithm == kAlgorithm_SSS_AES_CCM) {
++        context->algorithm = algorithm;
++    }
++    else {
++        LOG_E("AEAD improper algorithm passed!!!");
++        goto exit;
++    }
++    context->pCcm_aad  = NULL;
++    context->pCcm_data = NULL;
++    context->pCcm_iv   = NULL;
++    context->pCcm_tag  = NULL;
++
++#if !defined(NO_AES) && (defined(WOLFSSL_AESGCM) || defined(WOLFSSL_CCM))
++    context->aes = NULL;
++    context->aes = (Aes*)SSS_MALLOC(sizeof(Aes));
++    if (context->aes == NULL) {
++        goto exit;
++    }
++#endif
++    retval = kStatus_SSS_Success;
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_aead_one_go(sss_wolfssl_aead_t *context,
++    const uint8_t *srcData,
++    uint8_t *destData,
++    size_t size,
++    uint8_t *nonce,
++    size_t nonceLen,
++    const uint8_t *aad,
++    size_t aadLen,
++    uint8_t *tag,
++    size_t *tagLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    if (size > 0) {
++        ENSURE_OR_GO_EXIT(srcData != NULL);
++        ENSURE_OR_GO_EXIT(destData != NULL);
++    }
++    if (nonceLen > 0) {
++        ENSURE_OR_GO_EXIT(nonce != NULL);
++    }
++    if (aadLen > 0) {
++        ENSURE_OR_GO_EXIT(aad != NULL);
++    }
++
++    if (context->algorithm == kAlgorithm_SSS_AES_GCM) {
++#if !defined(NO_AES) && defined(HAVE_AESGCM)
++        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
++    #ifdef WOLFSSL_SE050
++        if (ret == 0) {
++            /* HostCrypto should use software crypto, not SE05x */
++            context->aes->useSWCrypt = 1;
++        }
++    #endif
++        if (ret == 0) {
++            ret = wc_AesGcmSetKey(context->aes, context->keyObject->contents,
++                                  context->keyObject->contents_size);
++        }
++        if (ret == 0) {
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_AesGcmEncrypt(context->aes, destData, srcData, size,
++                                       nonce, nonceLen, tag, (*tagLen), aad,
++                                       aadLen);
++            }
++            else {
++                ret = wc_AesGcmDecrypt(context->aes, destData, srcData, size,
++                                       nonce, nonceLen, tag, (*tagLen), aad,
++                                       aadLen);
++            }
++        }
++        wc_AesFree(context->aes);
++
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#else
++        LOG_E("AES-GCM support not compiled into wolfSSL");
++#endif /* !NO_AES && HAVE_AESGCM */
++    }
++    else if (context->algorithm == kAlgorithm_SSS_AES_CCM) {
++#if !defined(NO_AES) && defined(HAVE_AESCCM)
++        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
++    #ifdef WOLFSSL_SE050
++        if (ret == 0) {
++            /* HostCrypto should use software crypto, not SE05x */
++            context->aes->useSWCrypt = 1;
++        }
++    #endif
++        if (ret == 0) {
++            ret = wc_AesCcmSetKey(context->aes, context->keyObject->contents,
++                                  context->keyObject->contents_size);
++        }
++        if (ret == 0) {
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_AesCcmEncrypt(context->aes, destData, srcData, size,
++                                       nonce, nonceLen, tag, (*tagLen), aad,
++                                       aadLen);
++            }
++            else {
++                ret = wc_AesCcmDecrypt(context->aes, destData, srcData, size,
++                                       nonce, nonceLen, tag, (*tagLen), aad,
++                                       aadLen);
++            }
++        }
++        wc_AesFree(context->aes);
++
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#else
++        LOG_E("AES-CCM support not compiled into wolfSSL");
++#endif /* !NO_AES && HAVE_AESCCM */
++    }
++    else {
++        LOG_E("Unsupported AEAD algorithm type");
++    }
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_aead_init(
++    sss_wolfssl_aead_t *context, uint8_t *nonce, size_t nonceLen,
++    size_t tagLen, size_t aadLen, size_t payloadLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
++    int ret = 0;
++#endif
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    if (nonceLen > 0) {
++        ENSURE_OR_GO_EXIT(nonce != NULL);
++    }
++
++    if (context->algorithm != kAlgorithm_SSS_AES_GCM) {
++        LOG_E("wolfSSL only supports init/update/final for AES-GCM");
++        return retval;
++    }
++
++#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
++    ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
++    #ifdef WOLFSSL_SE050
++    if (ret == 0) {
++        /* HostCrypto should use software crypto, not SE05x */
++        context->aes->useSWCrypt = 1;
++    }
++    #endif
++    if (ret == 0) {
++        if (context->mode == kMode_SSS_Encrypt) {
++            ret = wc_AesGcmEncryptInit(context->aes,
++                                       context->keyObject->contents,
++                                       context->keyObject->contents_size,
++                                       nonce, nonceLen);
++        }
++        else {
++            ret = wc_AesGcmDecryptInit(context->aes,
++                                       context->keyObject->contents,
++                                       context->keyObject->contents_size,
++                                       nonce, nonceLen);
++        }
++
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++    }
++#else
++    LOG_E("wolfSSL AES-GCM streaming not compiled in");
++#endif /* !NO_AES && HAVE_AESGCM && WOLFSSL_AESGCM_STREAM */
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_aead_update_aad(sss_wolfssl_aead_t *context,
++    const uint8_t *aadData, size_t aadDataLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
++    int ret = 0;
++#endif
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    if (aadDataLen > 0) {
++        ENSURE_OR_GO_EXIT(aadData != NULL);
++    }
++
++    if (context->algorithm != kAlgorithm_SSS_AES_GCM) {
++        LOG_E("wolfSSL only supports init/update/final for AES-GCM");
++        return retval;
++    }
++
++#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
++    /* Provide AAD data */
++    if (context->mode == kMode_SSS_Encrypt) {
++        ret = wc_AesGcmEncryptUpdate(context->aes, NULL, NULL, 0, aadData,
++                                     aadDataLen);
++    }
++    else {
++        ret = wc_AesGcmDecryptUpdate(context->aes, NULL, NULL, 0, aadData,
++                                     aadDataLen);
++    }
++
++    if (ret == 0) {
++        retval = kStatus_SSS_Success;
++    }
++#else
++    LOG_E("wolfSSL AES-GCM streaming not compiled in");
++#endif /* !NO_AES && HAVE_AESGCM && WOLFSSL_AESGCM_STREAM */
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_aead_update(
++    sss_wolfssl_aead_t *context, const uint8_t *srcData, size_t srcLen,
++    uint8_t *destData, size_t *destLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
++    uint8_t inputData[AES_BLOCK_SIZE] = {
++        0,
++    };
++    size_t inputData_len = 0;
++    size_t src_offset    = 0;
++    size_t output_offset = 0;
++    size_t outBuffSize   = *destLen;
++    size_t blockoutLen   = 0;
++    int ret              = 0;
++
++    ENSURE_OR_GO_CLEANUP(context != NULL);
++    ENSURE_OR_GO_CLEANUP(srcLen > 0);
++    ENSURE_OR_GO_CLEANUP(srcData != NULL);
++    ENSURE_OR_GO_CLEANUP(destLen != NULL);
++    if (*destLen > 0) {
++        ENSURE_OR_GO_CLEANUP(destData != NULL);
++    }
++    ENSURE_OR_GO_CLEANUP(srcLen > 0);
++
++    if (context->algorithm != kAlgorithm_SSS_AES_GCM) {
++        LOG_E("wolfSSL only supports init/update/final for AES-GCM");
++        return retval;
++    }
++
++    if ((context->cache_data_len + srcLen) < AES_BLOCK_SIZE) {
++        /* Insufficinet data to process . Cache the data */
++        memcpy((context->cache_data + context->cache_data_len),
++               srcData, srcLen);
++        context->cache_data_len = context->cache_data_len + srcLen;
++        *destLen = 0;
++        return kStatus_SSS_Success;
++    }
++    else {
++        /* Concatenate the unprocessed and current input data*/
++        memcpy(inputData, context->cache_data, context->cache_data_len);
++        inputData_len = context->cache_data_len;
++        memcpy((inputData + inputData_len), srcData,
++               (AES_BLOCK_SIZE - context->cache_data_len));
++        inputData_len += (AES_BLOCK_SIZE - context->cache_data_len);
++        src_offset += (AES_BLOCK_SIZE - context->cache_data_len);
++        blockoutLen = outBuffSize;
++
++        /* Add Source Data */
++        if (context->mode == kMode_SSS_Encrypt) {
++            ret = wc_AesGcmEncryptUpdate(context->aes,
++                    (destData + output_offset), inputData, inputData_len,
++                    NULL, 0);
++        }
++        else {
++            ret = wc_AesGcmDecryptUpdate(context->aes,
++                    (destData + output_offset), inputData, inputData_len,
++                    NULL, 0);
++        }
++        ENSURE_OR_GO_CLEANUP(ret == 0);
++        blockoutLen = inputData_len;
++        outBuffSize -= blockoutLen;
++        output_offset += blockoutLen;
++
++        while (srcLen - src_offset >= AES_BLOCK_SIZE) {
++            memcpy(inputData, (srcData + src_offset), 16);
++            src_offset += AES_BLOCK_SIZE;
++            blockoutLen = outBuffSize;
++
++            /* Add Source Data */
++            if (context->mode == kMode_SSS_Encrypt) {
++                ret = wc_AesGcmEncryptUpdate(context->aes,
++                        (destData + output_offset), inputData, inputData_len,
++                        NULL, 0);
++            }
++            else {
++                ret = wc_AesGcmDecryptUpdate(context->aes,
++                        (destData + output_offset), inputData, inputData_len,
++                        NULL, 0);
++            }
++            ENSURE_OR_GO_CLEANUP(ret == 0);
++            blockoutLen = inputData_len;
++            outBuffSize -= blockoutLen;
++            output_offset += blockoutLen;
++        }
++        *destLen = output_offset;
++        /* Copy unprocessed data to cache */
++        memcpy(context->cache_data, (srcData + src_offset), (srcLen - src_offset));
++        context->cache_data_len = (srcLen - src_offset);
++    }
++
++    retval = kStatus_SSS_Success;
++cleanup:
++    if (retval == kStatus_SSS_Fail) {
++        *destLen = 0;
++    }
++#endif /* !NO_AES && HAVE_AESGCM && WOLFSSL_AESGCM_STREAM */
++    return retval;
++}
++
++sss_status_t sss_wolfssl_aead_finish(sss_wolfssl_aead_t *context,
++    const uint8_t *srcData,
++    size_t srcLen,
++    uint8_t *destData,
++    size_t *destLen,
++    uint8_t *tag,
++    size_t *tagLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
++    uint8_t srcdata_updated[2 * AES_BLOCK_SIZE] = { 0, };
++    size_t srcdata_updated_len = 0;
++    int ret = 0;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    if (srcLen > 0) {
++        ENSURE_OR_GO_EXIT(srcData != NULL);
++    }
++
++    if (context->algorithm != kAlgorithm_SSS_AES_GCM) {
++        LOG_E("wolfSSL only supports init/update/final for AES-GCM");
++        return retval;
++    }
++
++    if (srcLen > AES_BLOCK_SIZE) {
++        LOG_E("srcLen cannot be grater than 16 bytes. Call update function ");
++        *destLen = 0;
++        goto exit;
++    }
++
++    if (context->cache_data_len != 0) {
++        memcpy(srcdata_updated, context->cache_data, context->cache_data_len);
++        srcdata_updated_len = context->cache_data_len;
++    }
++
++    if (srcLen != 0) {
++        memcpy((srcdata_updated + srcdata_updated_len), srcData, srcLen);
++        srcdata_updated_len += srcLen;
++    }
++
++    /* Add Source Data */
++    if (context->mode == kMode_SSS_Encrypt) {
++        ret = wc_AesGcmEncryptUpdate(context->aes,
++                destData, srcdata_updated, srcdata_updated_len,
++                NULL, 0);
++    }
++    else {
++        ret = wc_AesGcmDecryptUpdate(context->aes,
++                destData, srcdata_updated, srcdata_updated_len,
++                NULL, 0);
++    }
++    *destLen = srcdata_updated_len;
++    ENSURE_OR_GO_EXIT(ret == 0);
++
++    if (context->mode == kMode_SSS_Encrypt) {
++        ret = wc_AesGcmEncryptFinal(context->aes, tag, (*tagLen));
++    }
++    else if (context->mode == kMode_SSS_Decrypt) {
++        ret = wc_AesGcmDecryptFinal(context->aes, tag, (*tagLen));
++    }
++    ENSURE_OR_GO_EXIT(ret == 0);
++    retval = kStatus_SSS_Success;
++exit:
++#endif /* !NO_AES && HAVE_AESGCM && WOLFSSL_AESGCM_STREAM */
++    return retval;
++}
++
++void sss_wolfssl_aead_context_free(sss_wolfssl_aead_t *context)
++{
++#if !defined(NO_AES) && (defined(HAVE_AESGCM) || defined(HAVE_AESCCM))
++    if (context->aes != NULL) {
++        wc_AesFree(context->aes);
++        SSS_FREE(context->aes);
++    }
++#endif
++    memset(context, 0, sizeof(*context));
++}
++
++/* End: wolfssl_aead */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_mac                                                */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_mac_context_init(sss_wolfssl_mac_t *context,
++    sss_wolfssl_session_t *session,
++    sss_wolfssl_object_t *keyObject,
++    sss_algorithm_t algorithm,
++    sss_mode_t mode)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    ENSURE_OR_GO_CLEANUP(context);
++    ENSURE_OR_GO_CLEANUP(session);
++    ENSURE_OR_GO_CLEANUP(keyObject);
++
++    context->session   = session;
++    context->keyObject = keyObject;
++    context->mode      = mode;
++    context->algorithm = algorithm;
++
++#ifndef NO_HMAC
++    context->hmac = NULL;
++    context->hmac = SSS_MALLOC(sizeof(Hmac));
++    if (context->hmac == NULL) {
++        goto cleanup;
++    }
++    memset(context->hmac, 0, sizeof(Hmac));
++#endif
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++    context->cmac = NULL;
++    context->cmac = SSS_MALLOC(sizeof(Cmac));
++    if (context->cmac == NULL) {
++        goto cleanup;
++    }
++    memset(context->cmac, 0, sizeof(Cmac));
++#endif
++    retval = kStatus_SSS_Success;
++
++cleanup:
++    if (retval == kStatus_SSS_Fail) {
++#ifndef NO_HMAC
++        if (context->hmac != NULL) {
++            SSS_FREE(context->hmac);
++            context->hmac = NULL;
++        }
++#endif
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++        if (context->cmac != NULL) {
++            SSS_FREE(context->cmac);
++            context->cmac = NULL;
++        }
++#endif
++    }
++    return retval;
++}
++
++#ifndef NO_HMAC
++static int sss_wolfssl_get_hmac_type_from_algo(int algo)
++{
++    int ret = WC_HASH_TYPE_NONE;
++
++    switch (algo) {
++        case kAlgorithm_SSS_HMAC_SHA1:
++            ret = WC_SHA;
++            break;
++        case kAlgorithm_SSS_HMAC_SHA224:
++            ret = WC_SHA224;
++            break;
++        case kAlgorithm_SSS_HMAC_SHA256:
++            ret = WC_SHA256;
++            break;
++        case kAlgorithm_SSS_HMAC_SHA384:
++            ret = WC_SHA384;
++            break;
++        case kAlgorithm_SSS_HMAC_SHA512:
++            ret = WC_SHA512;
++            break;
++        default:
++            break;
++    }
++
++    return ret;
++}
++#endif /* NO_HMAC */
++
++sss_status_t sss_wolfssl_mac_one_go(
++    sss_wolfssl_mac_t *context, const uint8_t *message, size_t messageLen,
++    uint8_t *mac, size_t *macLen)
++{
++    int ret = 0;
++    int hashType;
++    unsigned int outSz;
++    sss_status_t retval = kStatus_SSS_Fail;
++
++    if ((context == NULL) || (message == NULL) ||
++        (mac == NULL) || (macLen == NULL)) {
++        goto cleanup;
++    }
++
++    outSz = (unsigned int)*macLen;
++
++    if (context->keyObject->contents == NULL) {
++        LOG_E("KeyObject key not created");
++        goto cleanup;
++    }
++
++    if (context->algorithm == kAlgorithm_SSS_CMAC_AES) {
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++    #ifdef WOLFSSL_SE050
++        /* HostCrypto should use software crypto, not SE05x */
++        context->cmac->useSWCrypt = 1;
++    #endif
++        ret = wc_InitCmac(context->cmac,
++                context->keyObject->contents,
++                context->keyObject->contents_size, WC_CMAC_AES, NULL);
++
++        if (ret == 0) {
++            ret = wc_CmacUpdate(context->cmac, message, messageLen);
++        }
++
++        if (ret == 0) {
++            if (context->mode == kMode_SSS_Mac) {
++                if (outSz > WC_CMAC_TAG_MAX_SZ) {
++                    /* wolfCrypt errors if buffer is too large */
++                    outSz = WC_CMAC_TAG_MAX_SZ;
++                }
++                ret = wc_CmacFinal(context->cmac, mac, &outSz);
++                if (ret == 0) {
++                    *macLen = (size_t)outSz;
++                    retval = kStatus_SSS_Success;
++                }
++            }
++            else if (context->mode == kMode_SSS_Mac_Validate) {
++                uint8_t macLocal[WC_CMAC_TAG_MAX_SZ] = { 0, };
++                size_t macLocalLen = sizeof(macLocal);
++                ret = wc_CmacFinal(context->cmac, macLocal, &macLocalLen);
++                if ((ret == 0) && (macLocalLen == *macLen)) {
++                    if (!memcmp(macLocal, mac, macLocalLen)) {
++                        retval = kStatus_SSS_Success;
++                    }
++                }
++            }
++            else {
++                LOG_E("Unknown CMAC mode");
++            }
++        }
++#else
++        LOG_E("wolfSSL does not have CMAC compiled in");
++#endif /* !NO_AES && WOLFSSL_CMAC */
++    }
++    else if (context->algorithm == kAlgorithm_SSS_HMAC_SHA1 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA224 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA256 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA384 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA512) {
++#ifndef NO_HMAC
++        hashType = sss_wolfssl_get_hmac_type_from_algo(context->algorithm);
++
++        ret = wc_HmacInit(context->hmac, NULL, INVALID_DEVID);
++
++        if (ret == 0) {
++            ret = wc_HmacSetKey(context->hmac, hashType,
++                    context->keyObject->contents,
++                    context->keyObject->contents_size);
++        }
++
++        if (ret == 0) {
++            ret = wc_HmacUpdate(context->hmac, message, messageLen);
++        }
++
++        if (ret == 0) {
++            if (context->mode == kMode_SSS_Mac) {
++                ret = wc_HmacFinal(context->hmac, mac);
++                if (ret == 0) {
++                    retval = kStatus_SSS_Success;
++                }
++            }
++            else if (context->mode == kMode_SSS_Mac_Validate) {
++                uint8_t macLocal[WC_HMAC_BLOCK_SIZE] = { 0, };
++                size_t macLocalLen = sizeof(macLocal);
++                ret = wc_HmacFinal(context->hmac, macLocal);
++                macLocalLen = wc_HmacSizeByType(hashType);
++                if ((ret == 0) && (macLocalLen == *macLen)) {
++                    if (!memcmp(macLocal, mac, macLocalLen)) {
++                        retval = kStatus_SSS_Success;
++                    }
++                }
++            }
++            else {
++                LOG_E("Unknown HMAC mode");
++            }
++        }
++
++        wc_HmacFree(context->hmac);
++#else
++        LOG_E("wolfSSL does not have HMAC compiled in");
++#endif /* NO_HMAC */
++    }
++
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_mac_init(sss_wolfssl_mac_t *context)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret;
++    uint8_t *key;
++    size_t keylen;
++#ifndef NO_HMAC
++    int hashType;
++#endif
++
++    ENSURE_OR_GO_CLEANUP(context != NULL)
++
++    if (context->keyObject->contents) {
++        key    = context->keyObject->contents;
++        keylen = context->keyObject->contents_size;
++    }
++    else {
++        LOG_E("KeyObject key not created");
++        goto cleanup;
++    }
++
++    if (context->algorithm == kAlgorithm_SSS_CMAC_AES) {
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++    #ifdef WOLFSSL_SE050
++        /* HostCrypto should use software crypto, not SE05x */
++        context->cmac->useSWCrypt = 1;
++    #endif
++        ret = wc_InitCmac(context->cmac, key, keylen, WC_CMAC_AES, NULL);
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#else
++        LOG_E("wolfSSL does not have CMAC compiled in");
++#endif /* !NO_AES && WOLFSSL_CMAC */
++    }
++    else if (context->algorithm == kAlgorithm_SSS_HMAC_SHA1 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA224 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA256 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA384 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA512) {
++#ifndef NO_HMAC
++        hashType = sss_wolfssl_get_hmac_type_from_algo(context->algorithm);
++
++        ret = wc_HmacInit(context->hmac, NULL, INVALID_DEVID);
++        if (ret == 0) {
++            ret = wc_HmacSetKey(context->hmac, hashType, key, keylen);
++        }
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#else
++        LOG_E("wolfSSL does not have HMAC compiled in");
++#endif /* NO_HMAC */
++    }
++
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_mac_update(sss_wolfssl_mac_t *context,
++    const uint8_t *message, size_t messageLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret;
++    if (message == NULL || context == NULL) {
++        return kStatus_SSS_InvalidArgument;
++    }
++
++    if (context->algorithm == kAlgorithm_SSS_CMAC_AES) {
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++        ret = wc_CmacUpdate(context->cmac, message, messageLen);
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#else
++        LOG_E("wolfSSL does not have CMAC compiled in");
++#endif /* !NO_AES && WOLFSSL_CMAC */
++    }
++    else if (context->algorithm == kAlgorithm_SSS_HMAC_SHA1 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA224 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA256 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA384 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA512) {
++#ifndef NO_HMAC
++        ret = wc_HmacUpdate(context->hmac, message, messageLen);
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#else
++        LOG_E("wolfSSL does not have HMAC compiled in");
++#endif /* NO_HMAC */
++    }
++
++    return retval;
++}
++
++sss_status_t sss_wolfssl_mac_finish(sss_wolfssl_mac_t *context, uint8_t *mac,
++    size_t *macLen)
++{
++    int ret;
++    sss_status_t retval = kStatus_SSS_Fail;
++#ifndef NO_HMAC
++    int hashType;
++#endif
++
++    if (mac == NULL || macLen == NULL || context == NULL) {
++        return kStatus_SSS_InvalidArgument;
++    }
++
++    if (context->algorithm == kAlgorithm_SSS_CMAC_AES) {
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++        if (context->mode == kMode_SSS_Mac) {
++            if (*macLen > WC_CMAC_TAG_MAX_SZ) {
++                /* wolfCrypt errors if buffer is too large */
++                *macLen = WC_CMAC_TAG_MAX_SZ;
++            }
++            ret = wc_CmacFinal(context->cmac, mac, macLen);
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++        }
++        else if (context->mode == kMode_SSS_Mac_Validate) {
++            uint8_t macLocal[WC_CMAC_TAG_MAX_SZ] = { 0, };
++            size_t macLocalLen = sizeof(macLocal);
++            ret = wc_CmacFinal(context->cmac, macLocal, &macLocalLen);
++            if ((ret == 0) && (macLocalLen == *macLen)) {
++                if (!memcmp(macLocal, mac, macLocalLen)) {
++                    retval = kStatus_SSS_Success;
++                }
++            }
++        }
++        else {
++            LOG_E("Unknown CMAC mode");
++        }
++#else
++        LOG_E("wolfSSL does not have CMAC compiled in");
++#endif /* !NO_AES && WOLFSSL_CMAC */
++    }
++    else if (context->algorithm == kAlgorithm_SSS_HMAC_SHA1 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA224 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA256 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA384 ||
++             context->algorithm == kAlgorithm_SSS_HMAC_SHA512) {
++#ifndef NO_HMAC
++        if (context->mode == kMode_SSS_Mac) {
++            ret = wc_HmacFinal(context->hmac, mac);
++            if (ret == 0) {
++                retval = kStatus_SSS_Success;
++            }
++        }
++        else if (context->mode == kMode_SSS_Mac_Validate) {
++            uint8_t macLocal[WC_HMAC_BLOCK_SIZE] = { 0, };
++            size_t macLocalLen = sizeof(macLocal);
++            hashType = sss_wolfssl_get_hmac_type_from_algo(context->algorithm);
++
++            ret = wc_HmacFinal(context->hmac, macLocal);
++            macLocalLen = wc_HmacSizeByType(hashType);
++            if ((ret == 0) && (macLocalLen == *macLen)) {
++                if (!memcmp(macLocal, mac, macLocalLen)) {
++                    retval = kStatus_SSS_Success;
++                }
++            }
++        }
++        else {
++            LOG_E("Unknown HMAC mode");
++        }
++#else
++        LOG_E("wolfSSL does not have HMAC compiled in");
++#endif /* NO_HMAC */
++    }
++
++    return retval;
++}
++
++void sss_wolfssl_mac_context_free(sss_wolfssl_mac_t *context)
++{
++    if (context != NULL) {
++#ifndef NO_HMAC
++        if (context->hmac != NULL) {
++            wc_HmacFree(context->hmac);
++            SSS_FREE(context->hmac);
++        }
++#endif
++#if !defined(NO_AES) && defined(WOLFSSL_CMAC)
++        if (context->cmac != NULL) {
++            SSS_FREE(context->cmac);
++        }
++#endif
++        memset(context, 0, sizeof(*context));
++    }
++}
++
++/* End: wolfssl_mac */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_md                                                 */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_digest_context_init(
++    sss_wolfssl_digest_t *context, sss_wolfssl_session_t *session,
++    sss_algorithm_t algorithm, sss_mode_t mode)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++
++    ENSURE_OR_GO_CLEANUP(context);
++    context->session   = session;
++    context->algorithm = algorithm;
++    context->mode      = mode;
++    retval             = kStatus_SSS_Success;
++cleanup:
++    return retval;
++}
++
++static enum wc_HashType sss_wolfssl_get_digest_type_from_algo(int algo)
++{
++    switch (algo) {
++        case kAlgorithm_SSS_SHA1:
++            return WC_HASH_TYPE_SHA;
++        case kAlgorithm_SSS_SHA224:
++            return WC_HASH_TYPE_SHA224;
++        case kAlgorithm_SSS_SHA256:
++            return WC_HASH_TYPE_SHA256;
++        case kAlgorithm_SSS_SHA384:
++            return WC_HASH_TYPE_SHA384;
++        case kAlgorithm_SSS_SHA512:
++            return WC_HASH_TYPE_SHA512;
++        default:
++            return WC_HASH_TYPE_NONE;
++    }
++}
++
++sss_status_t sss_wolfssl_digest_one_go(
++    sss_wolfssl_digest_t *context, const uint8_t *message, size_t messageLen,
++    uint8_t *digest, size_t *digestLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
++    int hashLen = 0;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    if (messageLen > 0) {
++        ENSURE_OR_GO_EXIT(message != NULL);
++    }
++
++    hashType = sss_wolfssl_get_digest_type_from_algo(context->algorithm);
++    hashLen = wc_HashGetDigestSize(hashType);
++
++    if (*digestLen < hashLen) {
++        LOG_E("Digest out buffer too small");
++        return retval;
++    }
++
++    if (context->hash == NULL) {
++        context->hash = (wc_HashAlg*)SSS_MALLOC(sizeof(wc_HashAlg));
++        if (context->hash == NULL) {
++            return retval;
++        }
++    }
++
++    ret = wc_HashInit(context->hash, hashType);
++    if (ret == 0) {
++        ret = wc_HashUpdate(context->hash, hashType, message, messageLen);
++    }
++    if (ret == 0) {
++        ret = wc_HashFinal(context->hash, hashType, digest);
++    }
++    if (ret == 0) {
++        *digestLen = hashLen;
++        retval = kStatus_SSS_Success;
++    }
++
++    wc_HashFree(context->hash, hashType);
++    SSS_FREE(context->hash);
++    context->hash = NULL;
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_digest_init(sss_wolfssl_digest_t *context)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++
++    if (context->hash == NULL) {
++        context->hash = (wc_HashAlg*)SSS_MALLOC(sizeof(wc_HashAlg));
++        if (context->hash == NULL) {
++            return retval;
++        }
++    }
++
++    hashType = sss_wolfssl_get_digest_type_from_algo(context->algorithm);
++
++    ret = wc_HashInit(context->hash, hashType);
++    if (ret == 0) {
++        retval = kStatus_SSS_Success;
++    }
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_digest_update(sss_wolfssl_digest_t *context,
++    const uint8_t *message, size_t messageLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    if (messageLen > 0) {
++        ENSURE_OR_GO_EXIT(message != NULL);
++    }
++
++    hashType = sss_wolfssl_get_digest_type_from_algo(context->algorithm);
++
++    ret = wc_HashUpdate(context->hash, hashType, message, messageLen);
++    if (ret == 0) {
++        retval = kStatus_SSS_Success;
++    }
++
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_digest_finish(sss_wolfssl_digest_t *context,
++    uint8_t *digest, size_t *digestLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
++    int hashLen = 0;
++
++    ENSURE_OR_GO_EXIT(context != NULL);
++    ENSURE_OR_GO_EXIT(digestLen != NULL);
++    ENSURE_OR_GO_EXIT(digest != NULL);
++
++    hashType = sss_wolfssl_get_digest_type_from_algo(context->algorithm);
++    hashLen = wc_HashGetDigestSize(hashType);
++
++    if (*digestLen < hashLen) {
++        LOG_E("Digest out buffer too small");
++        return retval;
++    }
++
++    ret = wc_HashFinal(context->hash, hashType, digest);
++    if (ret == 0) {
++        *digestLen = hashLen;
++        retval = kStatus_SSS_Success;
++    }
++
++exit:
++    return retval;
++}
++
++void sss_wolfssl_digest_context_free(sss_wolfssl_digest_t *context)
++{
++    enum wc_HashType hashType;
++
++    if (context->hash != NULL) {
++        hashType = sss_wolfssl_get_digest_type_from_algo(context->algorithm);
++        wc_HashFree(context->hash, hashType);
++        SSS_FREE(context->hash);
++    }
++    memset(context, 0, sizeof(*context));
++}
++
++/* End: wolfssl_md */
++
++/* ************************************************************************** */
++/* Functions : sss_wolfssl_rng                                                */
++/* ************************************************************************** */
++
++sss_status_t sss_wolfssl_rng_context_init(
++    sss_wolfssl_rng_context_t *context,
++    sss_wolfssl_session_t *session)
++{
++    int ret = 0;
++    sss_status_t retval = kStatus_SSS_Fail;
++
++    ENSURE_OR_GO_CLEANUP(context);
++    context->session = session;
++
++    context->rng = (WC_RNG*)SSS_MALLOC(sizeof(WC_RNG));
++    memset(context->rng, 0, sizeof(WC_RNG));
++
++    if (context->rng != NULL) {
++        ret = wc_InitRng(context->rng);
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        } else {
++            SSS_FREE(context->rng);
++            context->rng = NULL;
++        }
++    }
++
++cleanup:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_rng_get_random(sss_wolfssl_rng_context_t *context,
++    uint8_t *random_data, size_t dataLen)
++{
++    int ret = 0;
++    sss_status_t retval = kStatus_SSS_Fail;
++
++    if (random_data == NULL) {
++        goto exit;
++    }
++
++    ret = wc_RNG_GenerateBlock(context->rng, random_data, dataLen);
++    if (ret != 0) {
++        LOG_E("Error in wc_RNG_GenerateBlock");
++        goto exit;
++    }
++
++    retval = kStatus_SSS_Success;
++exit:
++    return retval;
++}
++
++sss_status_t sss_wolfssl_rng_context_free(sss_wolfssl_rng_context_t *context)
++{
++    sss_status_t retval = kStatus_SSS_Success;
++
++    if (context->rng != NULL) {
++        wc_FreeRng(context->rng);
++        SSS_FREE(context->rng);
++    }
++
++    memset(context, 0, sizeof(*context));
++    return retval;
++}
++
++/* End: wolfssl_rng */
++
++/* ************************************************************************** */
++/* Functions : Private sss wolfssl functions                                  */
++/* ************************************************************************** */
++static sss_status_t sss_wolfssl_generate_ecc_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int nid             = 0;
++    int ret             = 0;
++    ecc_key* ecKey      = NULL;
++    WC_RNG rng;
++
++    ecKey = (ecc_key*)keyObject->contents;
++
++    if (keyObject->cipherType == kSSS_CipherType_EC_NIST_P) {
++        switch (keyBitLen) {
++        case 192:
++            nid = ECC_SECP192R1;
++            break;
++        case 224:
++            nid = ECC_SECP224R1;
++            break;
++        case 256:
++            nid = ECC_SECP256R1;
++            break;
++        case 384:
++            nid = ECC_SECP384R1;
++            break;
++        case 521:
++            nid = ECC_SECP521R1;
++            break;
++        default:
++            LOG_E("Key type EC_NIST_P not supported with key length 0x%X",
++                  keyBitLen);
++            break;
++        }
++    }
++    else if (keyObject->cipherType == kSSS_CipherType_EC_BRAINPOOL) {
++        switch (keyBitLen) {
++        case 192:
++            nid = ECC_BRAINPOOLP192R1;
++            break;
++        case 224:
++            nid = ECC_BRAINPOOLP224R1;
++            break;
++        case 320:
++            nid = ECC_BRAINPOOLP320R1;
++            break;
++        case 384:
++            nid = ECC_BRAINPOOLP384R1;
++            break;
++        case 160:
++            nid = ECC_BRAINPOOLP160R1;
++            break;
++        case 256:
++            nid = ECC_BRAINPOOLP256R1;
++            break;
++        case 512:
++            nid = ECC_BRAINPOOLP512R1;
++            break;
++        default:
++            LOG_E("Key type EC_BRAINPOOL not supported with key length 0x%X",
++                  keyBitLen);
++            break;
++        }
++    }
++    else if (keyObject->cipherType == kSSS_CipherType_EC_NIST_K) {
++        switch (keyBitLen) {
++        case 160:
++            nid = ECC_SECP160K1;
++            break;
++        case 192:
++            nid = ECC_SECP192K1;
++            break;
++        case 224:
++            nid = ECC_SECP224K1;
++            break;
++        case 256:
++            nid = ECC_SECP256K1;
++            break;
++        default:
++            LOG_E("Key type EC_NIST_K not supported with key length 0x%X",
++                  keyBitLen);
++            break;
++        }
++    }
++    else {
++        LOG_E("sss_wolfssl_generate_ecc_key: Invalid key type ");
++    }
++
++    if (nid != 0) {
++        ret = wc_InitRng(&rng);
++        if (ret != 0) {
++            LOG_E("Failed to initialize RNG");
++        }
++
++        if (ret == 0) {
++            ret = wc_ecc_make_key_ex(&rng, (keyBitLen / 8), ecKey, nid);
++            if (ret != 0) {
++                LOG_E("wc_ecc_make_key_ex failed");
++            }
++        }
++
++        wc_FreeRng(&rng);
++
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++    }
++    else {
++        LOG_E("No support for keyBitLen.");
++    }
++
++    return retval;
++}
++
++static sss_status_t sss_wolfssl_generate_ec_mont_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++#ifdef HAVE_CURVE25519
++    curve25519_key* key25519 = NULL;
++#endif
++#ifdef HAVE_CURVE448
++    curve448_key*   key448   = NULL;
++#endif
++    WC_RNG rng;
++
++    ret = wc_InitRng(&rng);
++    if (ret != 0) {
++        return retval;
++    }
++
++    if (keyObject->cipherType == kSSS_CipherType_EC_MONTGOMERY) {
++
++        switch (keyBitLen) {
++#ifdef HAVE_CURVE25519
++            case 256:
++                key25519 = (curve25519_key*)keyObject->contents;
++                ret = wc_curve25519_make_key(&rng, (keyBitLen / 8), key25519);
++                if (ret == 0) {
++                    retval = kStatus_SSS_Success;
++                }
++                break;
++#endif
++#ifdef HAVE_CURVE448
++            case 448:
++                key448 = (curve448_key*)keyObject->contents;
++                ret = wc_curve448_make_key(&rng, (keyBitLen / 8), key448);
++                if (ret == 0) {
++                    retval = kStatus_SSS_Success;
++                }
++                break;
++#endif
++            default:
++                LOG_E("Key type EC_MONTGOMERY not supported with key "
++                      "length 0x%X", keyBitLen);
++                break;
++        }
++    }
++    else {
++        LOG_E("sss_wolfssl_generate_ec_mont_key: Invalid key type ");
++    }
++
++    wc_FreeRng(&rng);
++
++    return retval;
++}
++
++static sss_status_t sss_wolfssl_generate_ed_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret             = 0;
++#ifdef HAVE_ED25519
++    ed25519_key* edKey  = NULL;
++#endif
++    WC_RNG rng;
++
++    ret = wc_InitRng(&rng);
++    if (ret != 0) {
++        return retval;
++    }
++
++    if (keyObject->cipherType == kSSS_CipherType_EC_TWISTED_ED) {
++        switch (keyBitLen) {
++#ifdef HAVE_ED25519
++            case 256:
++                edKey = (ed25519_key*)keyObject->contents;
++                ret = wc_ed25519_make_key(&rng, (keyBitLen / 8), edKey);
++                if (ret == 0) {
++                    retval = kStatus_SSS_Success;
++                }
++                break;
++#endif
++            default:
++                LOG_E("Key type EC_TWISTED_ED not supported with key "
++                       "length 0x%X", keyBitLen);
++                break;
++        }
++    }
++    else {
++        LOG_E("sss_wolfssl_generate_ed_key: Invalid key type");
++    }
++
++    wc_FreeRng(&rng);
++
++    return retval;
++}
++
++#ifdef _MSC_VER
++#pragma warning(disable : 4127)
++#endif
++
++static sss_status_t sss_wolfssl_generate_rsa_key(
++    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
++{
++    sss_status_t retval = kStatus_SSS_Fail;
++    int ret = 0;
++#ifndef NO_RSA
++    RsaKey* rsaKey = NULL;
++#endif
++    WC_RNG rng;
++
++    ret = wc_InitRng(&rng);
++    if (ret != 0) {
++        return retval;
++    }
++
++    if (keyObject->cipherType == kSSS_CipherType_RSA) {
++#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
++        rsaKey = (RsaKey*)keyObject->contents;
++        ret = wc_MakeRsaKey(rsaKey, (keyBitLen / 8), WC_RSA_EXPONENT, &rng);
++        if (ret == 0) {
++            retval = kStatus_SSS_Success;
++        }
++#endif
++    }
++    else {
++        LOG_E("sss_wolfssl_generate_rsa_key: Invalid key type");
++    }
++
++    wc_FreeRng(&rng);
++
++    return retval;
++}
++
++#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
+diff -Naur simw-top/sss/sssAkmLists.mk /home/pi/se_mw/simw-top/sss/sssAkmLists.mk
+--- simw-top/sss/sssAkmLists.mk	2022-07-01 15:16:00.000000000 -0600
++++ /home/pi/se_mw/simw-top/sss/sssAkmLists.mk	2022-10-20 11:30:15.609681834 -0600
+@@ -18,6 +18,7 @@
+ 		sss/src/se05x/fsl_sss_se05x_policy.c \
+ 		sss/src/se05x/fsl_sss_se05x_mw.c \
+ 		sss/src/mbedtls/fsl_sss_mbedtls_apis.c \
++		sss/src/wolfssl/fsl_sss_wolfssl_apis.c \
+ 		sss/src/openssl/fsl_sss_openssl_apis.c \
+ 		sss/src/keystore/keystore_cmn.c \
+ 		sss/src/keystore/keystore_openssl.c \


### PR DESCRIPTION
This PR adds a patch to the NXP SE05X Middleware for wolfSSL HostCrypto support.  wolfSSL HostCrypto support can be used to enable wolfSSL to be used for host-side SCP03 authentication.

We will attempt to upstream this patch, but storing here in the meantime.