### PR TITLE
Stop checking for OpenSSL's error logging.

### DIFF
--- a/rsyslog/8.2106.0/rsyslog-8.2106.0.patch
+++ b/rsyslog/8.2106.0/rsyslog-8.2106.0.patch
@@ -452,3 +452,13 @@ index 4ad2a5c58..b02572a6f 100644
  
  	/* Blocking socket */
  	BIO_set_nbio( client, 0 );
+diff --git a/tests/imtcp-tls-ossl-error-key2.sh b/tests/imtcp-tls-ossl-error-key2.sh
+index 4ad2a5c58..b02572a6f 100644
+--- a/tests/imtcp-tls-ossl-error-key2.sh
++++ b/tests/imtcp-tls-ossl-error-key2.sh
+@@ -19,5 +19,4 @@
+ shutdown_when_empty
+ wait_shutdown
+ content_check "Error: Key could not be accessed"
+-content_check "OpenSSL Error Stack:"
+ exit_test


### PR DESCRIPTION
Fixes ZD17579

In one of the tests an OpenSSL error is expected.  Then error log output is expected: 

```
rsyslogd: nsd_ossl:OpenSSL Error Stack: error:1E08010C:DECODER routines::unsupported [v8.2106.0]
rsyslogd: nsd_ossl:OpenSSL Error Stack: error:068000A8:asn1 encoding routines::wrong tag [v8.2106.0]
rsyslogd: nsd_ossl:OpenSSL Error Stack: error:0688010A:asn1 encoding routines::nested asn1 error [v8.2106.0]
rsyslogd: nsd_ossl:OpenSSL Error Stack: error:068000A8:asn1 encoding routines::wrong tag [v8.2106.0]
rsyslogd: nsd_ossl:OpenSSL Error Stack: error:0688010A:asn1 encoding routines::nested asn1 error [v8.2106.0]
rsyslogd: nsd_ossl:OpenSSL Error Stack: error:0A080009:SSL routines::PEM lib [v8.2106.0]
```

This change removes that expectation. 