### PR TITLE
urllib3: add support for 1.26.18

### DIFF
--- a/urllib3-patches/1.26.18/0001-urllib3-1.26.18-add-wolfSSL-support.patch
+++ b/urllib3-patches/1.26.18/0001-urllib3-1.26.18-add-wolfSSL-support.patch
@@ -1,0 +1,562 @@
+From 815a6b12bf830160cdfd8588a6128880ebb29840 Mon Sep 17 00:00:00 2001
+From: Marco Oliverio <marco@wolfssl.com>
+Date: Thu, 18 Jul 2024 20:40:55 +0000
+Subject: [PATCH] urllib3 1.26.18: add wolfSSL support
+
+Co-authored-by: Chris Conlon <chris@wolfssl.com>
+Co-authored-by: Tesfa Mael <tesfa@wolfssl.com>
+---
+ src/urllib3/connection.py                 |   2 +-
+ src/urllib3/contrib/wolfssl.py            | 307 ++++++++++++++++++++++
+ src/urllib3/util/__init__.py              |   2 +
+ src/urllib3/util/ssl_.py                  |   7 +-
+ test/__init__.py                          |   4 +-
+ test/conftest.py                          |  10 +
+ test/contrib/test_wolfssl.py              |  29 ++
+ test/with_dummyserver/test_https.py       |  10 +-
+ test/with_dummyserver/test_no_ssl.py      |   3 +-
+ test/with_dummyserver/test_socketlevel.py |  14 +
+ 10 files changed, 379 insertions(+), 9 deletions(-)
+ create mode 100644 src/urllib3/contrib/wolfssl.py
+ create mode 100644 test/contrib/test_wolfssl.py
+
+diff --git a/src/urllib3/connection.py b/src/urllib3/connection.py
+index 54b96b19..1273eefe 100644
+--- a/src/urllib3/connection.py
++++ b/src/urllib3/connection.py
+@@ -68,7 +68,7 @@ port_by_scheme = {"http": 80, "https": 443}
+ 
+ # When it comes time to update this value as a part of regular maintenance
+ # (ie test_recent_date is failing) update it to ~6 months before the current date.
+-RECENT_DATE = datetime.date(2022, 1, 1)
++RECENT_DATE = datetime.date(2024, 6, 1)
+ 
+ _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+ 
+diff --git a/src/urllib3/contrib/wolfssl.py b/src/urllib3/contrib/wolfssl.py
+new file mode 100644
+index 00000000..b469a0f0
+--- /dev/null
++++ b/src/urllib3/contrib/wolfssl.py
+@@ -0,0 +1,307 @@
++"""
++SSL/TLS support via the wolfSSL embedded SSL/TLS library.
++
++You can install the wolfSSL python wrapper using the following command:
++
++    pip install wolfssl
++
++To activate wolfSSL support, call
++:func:`~urllib3.contrib.wolfssl.inject_into_urllib3` from your Python code
++before you begin making HTTP requests. This can be done in a ``sitecustomize``
++module, or at any other time before your application begins using ``urllib3``,
++like this::
++
++    try:
++        import urllib3.contrib.wolfssl
++        urllib3.contrib.wolfssl.inject_into_urllib3()
++    except ImportError:
++        pass
++
++If you want to configure the default list of supported cipher suites, you can
++set the ``urllib3.contrib.wolfssl.DEFAULT_SSL_CIPHER_LIST`` variable.
++"""
++from __future__ import absolute_import
++
++import wolfssl
++
++from socket import timeout, error as SocketError
++from io import BytesIO
++
++try:  # Platform-specific: Python 2
++    from socket import _fileobject
++except ImportError:  # Platform-specific: Python 3
++    _fileobject = None
++    from ..packages.backports.makefile import backport_makefile
++
++import logging
++import ssl
++from ..packages import six
++import sys
++
++from .. import util
++
++__all__ = ['inject_into_urllib3', 'extract_from_urllib3']
++
++# wolfssl-py is configured to have SNI always compiled in
++HAS_SNI = True
++
++try:
++    from ssl import PROTOCOL_TLS_CLIENT
++except ImportError:
++    PROTOCOL_TLS_CLIENT = ssl.PROTOCOL_SSLv23
++# Map from urllib3 to wolfSSL compatible parameter-values.
++_wolfssl_versions = {
++    ssl.PROTOCOL_SSLv23: wolfssl.PROTOCOL_SSLv23,
++    ssl.PROTOCOL_TLSv1: wolfssl.PROTOCOL_TLSv1,
++}
++
++# PROTOCOL_TLS (alias for PROTOCOL_SSLv23) was deprecated in favor of the side specific PROTOCOL_TLS_CLIENT
++# This layer cares about the side later, so map PROTOCOL_TLS_CLIENT to PROTCOL_SSLv23
++if hasattr(ssl, 'PROTOCOL_TLS_CLIENT'):
++    _wolfssl_versions[ssl.PROTOCOL_TLS_CLIENT] = wolfssl.PROTOCOL_SSLv23
++
++# add SSL 3.0, TLS 1.1 and TLS 1.2 support, if available
++if hasattr(ssl, 'PROTOCOL_TLSv1_1') and hasattr(wolfssl, 'PROTOCOL_TLSv1_1'):
++    _wolfssl_versions[ssl.PROTOCOL_TLSv1_1] = wolfssl.PROTOCOL_TLSv1_1
++
++if hasattr(ssl, 'PROTOCOL_TLSv1_2') and hasattr(wolfssl, 'PROTOCOL_TLSv1_2'):
++    _wolfssl_versions[ssl.PROTOCOL_TLSv1_2] = wolfssl.PROTOCOL_TLSv1_2
++
++try:
++    _wolfssl_versions.update({ssl.PROTOCOL_SSLv3: wolfssl.PROTOCOL_SSLv3})
++except AttributeError:
++    pass
++
++# wolfssl-py doesn't support CERT_OPTIONAL yet, map to CERT_REQUIRED
++_stdlib_to_wolfssl_verify = {
++    ssl.CERT_NONE: wolfssl.CERT_NONE,
++    ssl.CERT_OPTIONAL: wolfssl.CERT_REQUIRED,
++    ssl.CERT_REQUIRED: wolfssl.CERT_REQUIRED,
++}
++_wolfssl_to_stdlib_verify = dict(
++    (v, k) for k, v in _stdlib_to_wolfssl_verify.items()
++)
++
++# store original util ssl settings, in case user wants to extract wolfssl-py
++orig_util_HAS_SNI = util.HAS_SNI
++orig_util_ssl_SSLContext = util.ssl_.SSLContext
++orig_util_SSLContext = util.SSLContext
++
++
++log = logging.getLogger(__name__)
++
++# 2^14, TLS max size by standard
++TLS_MAX_RECORD_SIZE = 16384
++
++def inject_into_urllib3():
++    'Monkey-patch urllib3 with wolfssl-backed SSL-support.'
++
++    util.ssl_.SSLContext = wolfSSLContext
++    util.SSLContext = wolfSSLContext
++    util.HAS_SNI = HAS_SNI
++    util.ssl_.HAS_SNI = HAS_SNI
++    util.IS_WOLFSSL = True
++    util.ssl_.IS_WOLFSSL = True
++
++
++def extract_from_urllib3():
++    'Undo monkey-patching by :func:`inject_into_urllib3`.'
++
++    util.ssl_.SSLContext = orig_util_ssl_SSLContext
++    util.SSLContext = orig_util_SSLContext
++    util.HAS_SNI = orig_util_HAS_SNI
++    util.ssl_.HAS_SNI = orig_util_HAS_SNI
++    util.IS_WOLFSSL = False
++    util.ssl_.IS_WOLFSSL = False
++
++
++class WrappedSocket(object):
++    '''API-compatibility wrapper for wolfSSL's SSLSocket class.
++
++    Note: _makefile_refs, _drop() and _reuse() are needed for the garbage
++    collector of pypy.
++    '''
++
++    def __init__(self, connection, socket, suppress_ragged_eofs=True):
++        self.connection = connection
++        self.socket = socket
++        self.suppress_ragged_eofs = suppress_ragged_eofs
++        self._makefile_refs = 0
++        self._closed = False
++
++    def fileno(self):
++        return self.socket.fileno()
++
++    # Copy-pasted from Python 3.5 source code
++    def _decref_socketios(self):
++        if self._makefile_refs > 0:
++            self._makefile_refs -= 1
++        if self._closed:
++            self.close()
++
++    def recv(self, *args, **kwargs):
++        try:
++            data = self.connection.recv(*args, **kwargs)
++        except wolfssl.SSLWantReadError:
++            if not util.wait_for_read(self.socket, self.connection.gettimeout()):
++                raise timeout('The read operation timed out')
++            else:
++                return self.recv(*args, **kwargs)
++        else:
++            return data
++
++    def recv_into(self, *args, **kwargs):
++        try:
++            data = self.connection.recv_into(*args, **kwargs)
++        except wolfssl.SSLWantReadError:
++            if not util.wait_for_read(self.socket, self.connection.gettimeout()):
++                raise timeout('The read operation timed out')
++            else:
++                return self.recv_into(*args, **kwargs)
++        else:
++            return data
++
++    def settimeout(self, timeout):
++        return self.connection.settimeout(timeout)
++
++    def _send_until_done(self, data):
++        while True:
++            try:
++                self.connection.sendall(data)
++                return len(data)
++            except wolfssl.SSLWantWriteError:
++                if not util.wait_for_write(self.socket, self.connection.gettimeout()):
++                    raise timeout('The write operation timed out')
++                continue
++
++
++
++    def sendall(self, data):
++        total_sent = 0
++        while total_sent < len(data):
++            if (len(data[total_sent: ]) > total_sent + TLS_MAX_RECORD_SIZE):
++                sent = self._send_until_done(data[total_sent: total_sent + TLS_MAX_RECORD_SIZE])
++            else:
++                sent = self._send_until_done(data[total_sent: ])
++            total_sent += sent
++
++    def shutdown(self):
++        self.connection.shutdown()
++
++    def close(self):
++        if self._makefile_refs < 1:
++            self._closed = True
++            return self.connection.close()
++        else:
++            self._makefile_refs -= 1
++
++    def getpeercert(self, binary_form=False):
++        return self.connection.getpeercert(binary_form=binary_form)
++
++    def version(self):
++        return self.connection.version()
++
++    def _reuse(self):
++        self._makefile_refs += 1
++
++    def _drop(self):
++        if self._makefile_refs < 1:
++            self.close()
++        else:
++            self._makefile_refs -= 1
++
++
++if _fileobject:  # Platform-specific: Python 2
++    def makefile(self, mode, bufsize=-1):
++        self._makefile_refs += 1
++        return _fileobject(self, mode, bufsize, close=True)
++else:  # Platform-specific: Python 3
++    makefile = backport_makefile
++
++WrappedSocket.makefile = makefile
++
++
++class wolfSSLContext(object):
++    """
++    Wrapper class for wolfssl-py ``Context`` object. Responsible for translating
++    the interface of the standard library ``SSLContext`` object
++    to calls into wolfSSL
++    """
++    def __init__(self, protocol):
++        self.protocol = _wolfssl_versions[protocol]
++        self._ctx = wolfssl.SSLContext(self.protocol)
++        self._options = 0
++        self.check_hostname = False
++
++    @property
++    def options(self):
++        return self._options
++
++    @options.setter
++    def options(self, value):
++        self._options = value
++        self._ctx.set_options(value)
++
++    @property
++    def verify_mode(self):
++        return _wolfssl_to_stdlib_verify[self._ctx.verify_mode]
++
++    @verify_mode.setter
++    def verify_mode(self, value):
++        self._ctx.verify_mode = _stdlib_to_wolfssl_verify[value]
++
++    def set_default_verify_paths(self):
++        return
++
++    def set_ciphers(self, ciphers):
++        if isinstance(ciphers, six.text_type):
++            ciphers = ciphers.encode('utf-8')
++        self._ctx.set_ciphers(ciphers)
++
++    def load_verify_locations(self, cafile=None, capath=None, cadata=None):
++        if cafile is not None:
++            cafile = cafile.encode('utf-8')
++        if capath is not None:
++            capath = capath.encode('utf-8')
++        self._ctx.load_verify_locations(cafile, capath=capath)
++        if cadata is not None:
++            self._ctx.load_verify_locations(BytesIO(cadata=cadata))
++
++    def load_cert_chain(self, certfile, keyfile=None, password=None):
++        if password is not None:
++            if not isinstance(password, six.binary_type):
++                password = password.encode("utf-8")
++            self._ctx.set_passwd_cb(lambda *_: password)
++        self._ctx.load_cert_chain(certfile, keyfile=keyfile, password=password)
++
++    def wrap_socket(self, sock, server_side=False,
++                    do_handshake_on_connect=True, suppress_ragged_eofs=True,
++                    server_hostname=None):
++
++        # turn off do_handshake_on_connect, so we can set SNI.
++        # Manually do handshake below instead.
++        cnx = self._ctx.wrap_socket(sock, server_side=server_side,
++                                do_handshake_on_connect=False,
++                                suppress_ragged_eofs=suppress_ragged_eofs)
++
++        if isinstance(server_hostname, six.text_type):  # Platform-specific: Python 3
++            server_hostname = server_hostname.encode('utf-8')
++
++        # set SNI hostname
++        if server_hostname is not None:
++            cnx.use_sni(server_hostname)
++
++        # do handshake
++        while True:
++            try:
++                cnx.do_handshake()
++            except wolfssl.SSLWantReadError:
++                if not util.wait_for_read(sock, sock.gettimeout()):
++                    raise timeout('select timed out')
++                continue
++            except wolfssl.SSLError as e:
++                raise ssl.SSLError('bad handshake: %r' % e)
++            break
++
++        return WrappedSocket(cnx, sock)
++
+diff --git a/src/urllib3/util/__init__.py b/src/urllib3/util/__init__.py
+index 4547fc52..0e08468b 100644
+--- a/src/urllib3/util/__init__.py
++++ b/src/urllib3/util/__init__.py
+@@ -8,6 +8,7 @@ from .retry import Retry
+ from .ssl_ import (
+     ALPN_PROTOCOLS,
+     HAS_SNI,
++    IS_WOLFSSL,
+     IS_PYOPENSSL,
+     IS_SECURETRANSPORT,
+     PROTOCOL_TLS,
+@@ -25,6 +26,7 @@ __all__ = (
+     "HAS_SNI",
+     "IS_PYOPENSSL",
+     "IS_SECURETRANSPORT",
++    "IS_WOLFSSL",
+     "SSLContext",
+     "PROTOCOL_TLS",
+     "ALPN_PROTOCOLS",
+diff --git a/src/urllib3/util/ssl_.py b/src/urllib3/util/ssl_.py
+index 8f867812..cb2709fb 100644
+--- a/src/urllib3/util/ssl_.py
++++ b/src/urllib3/util/ssl_.py
+@@ -20,6 +20,7 @@ SSLContext = None
+ SSLTransport = None
+ HAS_SNI = False
+ IS_PYOPENSSL = False
++IS_WOLFSSL = False
+ IS_SECURETRANSPORT = False
+ ALPN_PROTOCOLS = ["http/1.1"]
+ 
+@@ -289,7 +290,11 @@ def create_urllib3_context(
+ 
+     context = SSLContext(ssl_version)
+ 
+-    context.set_ciphers(ciphers or DEFAULT_CIPHERS)
++    if IS_WOLFSSL:
++        # Use wolfSSL internal default cipher list
++        context.set_ciphers(ciphers or 'DEFAULT')
++    else:
++        context.set_ciphers(ciphers or DEFAULT_CIPHERS)
+ 
+     # Setting the default here, as we may have no ssl module on import
+     cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs
+diff --git a/test/__init__.py b/test/__init__.py
+index 2307b2db..bad7767b 100644
+--- a/test/__init__.py
++++ b/test/__init__.py
+@@ -50,9 +50,7 @@ INVALID_SOURCE_ADDRESSES = [("192.0.2.255", 0), ("2001:db8::1", 0)]
+ # 3. To test our timeout logic by using two different values, eg. by using different
+ #    values at the pool level and at the request level.
+ SHORT_TIMEOUT = 0.001
+-LONG_TIMEOUT = 0.01
+-if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS") == "true":
+-    LONG_TIMEOUT = 0.5
++LONG_TIMEOUT = 0.5
+ 
+ 
+ def _can_resolve(host):
+diff --git a/test/conftest.py b/test/conftest.py
+index 656493a7..d3e9bcf2 100644
+--- a/test/conftest.py
++++ b/test/conftest.py
+@@ -14,6 +14,7 @@ from dummyserver.handlers import TestingApp
+ from dummyserver.proxy import ProxyHandler
+ from dummyserver.server import HAS_IPV6, run_tornado_app
+ from dummyserver.testcase import HTTPSDummyServerTestCase
++from urllib3 import util
+ from urllib3.util import ssl_
+ 
+ from .tz_stub import stub_timezone_ctx
+@@ -235,6 +236,9 @@ def supported_tls_versions():
+         _ssl_version = getattr(ssl, _ssl_version_name, 0)
+         if _ssl_version == 0:
+             continue
++        # wolfSSL doesn't support TLSv1
++        if _ssl_version_name == "PROTOCOL_TLSv1" and util.IS_WOLFSSL:
++            continue
+         _sock = socket.create_connection((_server.host, _server.port))
+         try:
+             _sock = ssl_.ssl_wrap_socket(
+@@ -242,6 +246,12 @@ def supported_tls_versions():
+             )
+         except ssl.SSLError:
+             pass
++        except ValueError as e:
++            if util.IS_WOLFSSL:
++                if ("this protocol is not supported" in str(e)
++                    or "wolfSSL not built with old TLS support" in str(e)):
++                    continue
++            raise(e)
+         else:
+             tls_versions.add(_sock.version())
+         _sock.close()
+diff --git a/test/contrib/test_wolfssl.py b/test/contrib/test_wolfssl.py
+new file mode 100644
+index 00000000..9b1c83cb
+--- /dev/null
++++ b/test/contrib/test_wolfssl.py
+@@ -0,0 +1,29 @@
++# -*- coding: utf-8 -*-
++import os
++import sys
++import unittest
++
++import mock
++import pytest
++
++def setup_module():
++    try:
++        from urllib3.contrib.wolfssl import inject_into_urllib3
++        inject_into_urllib3()
++    except ImportError as e:
++        pytest.skip('Could not import wolfssl: %r' % e)
++
++
++def teardown_module():
++    try:
++        from urllib3.contrib.wolfssl import extract_from_urllib3
++        extract_from_urllib3()
++    except ImportError:
++        pass
++
++
++from ..with_dummyserver.test_https import TestHTTPS, TestHTTPS_TLSv1  # noqa: F401
++from ..with_dummyserver.test_socketlevel import (  # noqa: F401
++    TestSNI, TestSocketClosing, TestClientCerts
++)
++
+diff --git a/test/with_dummyserver/test_https.py b/test/with_dummyserver/test_https.py
+index f37f8e6e..28b192ea 100644
+--- a/test/with_dummyserver/test_https.py
++++ b/test/with_dummyserver/test_https.py
+@@ -705,9 +705,13 @@ class TestHTTPS(HTTPSDummyServerTestCase):
+             self.host, self.port, ca_certs=DEFAULT_CA
+         ) as https_pool:
+             https_pool.ssl_version = self.certs["ssl_version"]
+-            r = https_pool.request("GET", "/")
+-            assert r.status == 200, r.data
+-
++            try:
++                r = https_pool.request("GET", "/")
++                assert r.status == 200, r.data
++            except ValueError as e:
++                # wolfSSL has TLS 1.0 disabled by default
++                if not ('this protocol is not supported') in str(e):
++                    raise
+     def test_set_cert_default_cert_required(self):
+         conn = VerifiedHTTPSConnection(self.host, self.port)
+         conn.set_cert()
+diff --git a/test/with_dummyserver/test_no_ssl.py b/test/with_dummyserver/test_no_ssl.py
+index 43e79b70..026e8437 100644
+--- a/test/with_dummyserver/test_no_ssl.py
++++ b/test/with_dummyserver/test_no_ssl.py
+@@ -7,6 +7,7 @@ import pytest
+ 
+ import urllib3
+ from dummyserver.testcase import HTTPDummyServerTestCase, HTTPSDummyServerTestCase
++from dummyserver.server import (DEFAULT_CA)
+ 
+ from ..test_no_ssl import TestWithoutSSL
+ 
+@@ -24,7 +25,7 @@ class TestHTTPWithoutSSL(HTTPDummyServerTestCase, TestWithoutSSL):
+ class TestHTTPSWithoutSSL(HTTPSDummyServerTestCase, TestWithoutSSL):
+     def test_simple(self):
+         with urllib3.HTTPSConnectionPool(
+-            self.host, self.port, cert_reqs="NONE"
++            self.host, self.port, ca_certs=DEFAULT_CA, cert_reqs="NONE"
+         ) as pool:
+             try:
+                 pool.request("GET", "/")
+diff --git a/test/with_dummyserver/test_socketlevel.py b/test/with_dummyserver/test_socketlevel.py
+index 9ee3dff6..00728542 100644
+--- a/test/with_dummyserver/test_socketlevel.py
++++ b/test/with_dummyserver/test_socketlevel.py
+@@ -191,6 +191,12 @@ class TestClientCerts(SocketDummyServerTestCase):
+         done_receiving = Event()
+         client_certs = []
+ 
++        # wolfSSL does not support loading a certificate file that contains
++        # both the certificate and private key together. For this case,
++        # users need to use individual files for each. Skipping this test,
++        # since dummyserver/certs/server.combined.pem contains both.
++        if ssl_.IS_WOLFSSL:
++            pytest.skip('wolfSSL does not support cert and key in same file')
+         def socket_handler(listener):
+             sock = listener.accept()[0]
+             sock = self._wrap_in_ssl(sock)
+@@ -232,6 +238,11 @@ class TestClientCerts(SocketDummyServerTestCase):
+         Having a client cert and its associated private key in just one file
+         works properly.
+         """
++        # wolfSSL does not support loading a certificate file that contains
++        # both the certificate and private key together. For this case,
++        # users need to use individual files for each.
++        if ssl_.IS_WOLFSSL:
++            pytest.skip('wolfSSL does not support cert and key in same file')
+         done_receiving = Event()
+         client_certs = []
+ 
+@@ -360,6 +371,9 @@ class TestClientCerts(SocketDummyServerTestCase):
+             from OpenSSL.SSL import Error
+ 
+             expected_error = Error
++        elif ssl_.IS_WOLFSSL:
++            from wolfssl import SSLError as wSSLError
++            expected_error = wSSLError
+         else:
+             expected_error = ssl.SSLError
+ 
+-- 
+2.45.2
+

--- a/urllib3-patches/README.md
+++ b/urllib3-patches/README.md
@@ -1,0 +1,32 @@
+# urllib3 wolfSSL port
+
+This folder contains patches to add support for wolfSSL to urllib3 project.
+Subfolder x.yy.zz contains patches for urllib3 version x.yy.zz.
+
+## Installation instructions
+
+1. clone urllib3 repository and checkout to the right verion (eg. 1.26.18)
+```bash
+git clone https://github.com/urllib3/urllib3.git
+git checkout 1.26.18
+```
+2. apply patches from this repository
+```bash
+git am path/to/osp/urllib3-patches/1.26.18/*.patch
+```
+3. Install wolfssl-py
+
+Follow instructions in [wolfssl-py](https://github.com/wolfssl/wolfssl-py) repository.
+
+4. (Optional) if you want to run the test suite install urllib3 dev requirements
+```bash
+python -m pip install -r urllib3/dev-requirements.txt
+```
+5. Install urllib3 from the folder where you applied patches
+```bash
+python -m pip install -e .
+```
+6. (Optional) run the test suite
+```bash
+python -m pytest
+```


### PR DESCRIPTION
This patch is based on wolfSSL port for version 1.25.8. It uses patches instead of a forked repo to provide the support.

Specific to 1.26.18:

- added support for SSLSocket.version() method
- inject util.SSLContext and not only util.ssl_.SSLContext
- map PROTCOL_TLS_CLIENTee1666a
- tests fixes

Note: wolfSSL v5.7.0 minimum version required to pass test suite