### PR TITLE
Qt unit test update

### DIFF
--- a/qt/qssl_wolf/qt_website_chain.sh
+++ b/qt/qssl_wolf/qt_website_chain.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CHAIN_INFO=www_qt_io_chain.info
+
+if [ -e $CHAIN_INFO ]; then
+    rm -f $CHAIN_INFO
+fi
+# 
+CHAIN=`echo -n|openssl s_client -connect www.qt.io:443 -nameopt lname < /dev/null 2> /dev/null|grep -i commonName=|grep -i s:|awk -v FS=[,:] '{print $(NF)}'|awk -v FS=[=] '{print $2}' >> $CHAIN_INFO`
+
+#for CN in $CHAIN ; do
+#    echo $CN >> $CHAIN_INFO
+#done
+
+

--- a/qt/qssl_wolf/www_qt_io_chain.info
+++ b/qt/qssl_wolf/www_qt_io_chain.info
@@ -1,0 +1,3 @@
+www.qt.io
+E5
+ISRG Root X1


### PR DESCRIPTION
Testing for accessing www.qt.io returns different cert-chain from being expectation now. Therefore, it needs to disable a part of the testing.