### PR TITLE
SQLCipher support

### DIFF
--- a/sqlcipher/README.md
+++ b/sqlcipher/README.md
@@ -1,0 +1,85 @@
+# SQLCipher + wolfSSL
+
+This port contains patches that introduce wolfCrypt as a cryptographic provider for [SQLCipher](https://github.com/sqlcipher/sqlcipher). These patches were generated and tested against SQLCipher `v4.6.1` using wolfSSL `v5.7.4-stable`.
+
+SQLCipher is a standalone fork of the [SQLite](https://www.sqlite.org/) database library that adds 256 bit AES encryption of database files, along with a host of other security features.
+
+SQLCipher is maintained by Zetetic, LLC, and additional information and documentation is available on the official [SQLCipher site](https://www.zetetic.net/sqlcipher/).
+
+
+## Patch Files
+
+There are two patch files included in this port:
+
+- `sqlcipher_wolfssl_${sqlcipher_version}_raw.patch`
+- `sqlcipher_wolfssl_${sqlcipher_version}_gitinfo.patch`
+
+The raw patch file only contains the raw code changes, suitable if you are not applying the patch to a git repository. The git info patch includes the changes as a git commit, suitable if you wish to apply the changes as a commit to your fork of SQLCipher. Note that applying the raw patch to a git repo will also work, resulting in the patch being applied as unstaged changes, which you can then commit.
+
+To apply the raw patch, navigate to SQLCipher and run:
+
+```sh
+git apply /path/to/sqlcipher_wolfssl_v4.6.1_raw.patch
+```
+
+To apply the git info patch, navigate to SQLCipher and run:
+```
+git am < /path/to/sqlcipher_wolfssl_v4.6.1_gitinfo.patch
+```
+
+## Prerequisites
+
+1. A working `git` and `autotools` installation on a UNIX-like system
+2. SQLite (and SQLCipher) requires the `tcl` development headers installed. On Ubuntu, you can obtain these headers by installing the `tcl-dev` package (`apt install tcl-dev`)
+
+## Build Instructions
+
+1. Clone or download the official SQLCipher release
+2. Clone or download wolfSSL
+3. Configure, build, and install wolfSSL
+
+```sh
+cd /path/to/wolfSSL
+./configure --enable-all    # or provide your custom configure options here
+make install
+
+# Note: This installs wolfSSL as a shared library on the host system. You can also
+# install wolfSSL to a specific directory, or build wolfSSL as a static library
+# if desired. Consult the wolfSSL docs for more information.
+```
+
+2. Apply the patches to SQLCipher using one of the two methods above
+3. Regenerate the SQLCipher `configure` script to include the new wolfSSL option
+
+```sh
+autoreconf --install --force
+```
+
+4. Configure SQLCipher to use wolfSSL as a cryptographic provider. You should also add any other SQLCipher configuration flags you need at this point. See the SQLCipher documentation for information
+
+```sh
+./configure --enable-tempstore=yes --with-crypto-lib=wolfssl --enable-fts5 CFLAGS="-DSQLITE_HAS_CODEC -DSQLCIPHER_TEST" LDFLAGS="-lwolfssl"
+```
+
+5. Build SQLCipher and the test fixture
+
+```sh
+make
+make testfixture
+```
+
+6. Run the SQLCipher tests
+
+```sh
+./testfixture test/sqlcipher.test
+```
+
+Note that SQLCipher also supports linking against static libraries for its crypto implementations. See the SQLCipher documentation for more details.
+
+## Troubleshooting
+
+1. Compiler errors like `fatal error: tcl.h: No such file or directory` indicate that SQLite cannot find the `tcl` development headers on your system. You can install the development headers using the steps in the [Prerequisites](##prerequisites) section. Please refer to the SQLite and SQLCipher documentation for more info.
+
+
+2. If using a FIPS build of wolfSSL, the sqlcipher tests will all fail as they use a password/key shorter than the minimum FIPS mandated length (14 bytes). There are some tests that are easy to change to accomodate that (`sqlcipher-backup.test`, for example). For these you can run `sed -i 's/testkey/testkey012345678/g'`. Other tests will take too long to fix as they use random keys ("foo", "0123", etc) and others like `sqlcipher-compatibility.test` operate on databases already encrypted with short keys, and so should be skipped.
+

--- a/sqlcipher/sqlcipher_wolfssl_v4.6.1_gitinfo.patch
+++ b/sqlcipher/sqlcipher_wolfssl_v4.6.1_gitinfo.patch
@@ -1,0 +1,437 @@
+From fb103ae04134dbc31c5617d076118a0dfe7c7a2b Mon Sep 17 00:00:00 2001
+From: Brett Nicholas <7547222+bigbrett@users.noreply.github.com>
+Date: Tue, 5 Nov 2024 15:58:33 -0700
+Subject: [PATCH] - add wolfSSL support to refactored sqlcipher - add patch
+ generation script
+
+---
+ Makefile.in            |   4 +
+ Makefile.msc           |   1 +
+ README.md              |  30 +++++
+ SQLCipher.podspec.json |   4 +-
+ configure.ac           |  18 ++-
+ src/crypto_wolfssl.c   | 246 +++++++++++++++++++++++++++++++++++++++++
+ src/sqlcipher.c        |   4 +
+ tool/mksqlite3c.tcl    |   1 +
+ 8 files changed, 301 insertions(+), 7 deletions(-)
+ create mode 100644 src/crypto_wolfssl.c
+
+diff --git a/Makefile.in b/Makefile.in
+index 8431c25a..54d438cf 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -149,6 +149,7 @@ CRYPTOLIBOBJ = \
+   crypto_openssl.lo \
+   crypto_libtomcrypt.lo \
+   crypto_nss.lo \
++  crypto_wolfssl.lo \
+   crypto_cc.lo
+ 
+ CRYPTOSRC = \
+@@ -157,6 +158,7 @@ CRYPTOSRC = \
+ 	$(TOP)/src/crypto_libtomcrypt.c \
+ 	$(TOP)/src/crypto_nss.c \
+ 	$(TOP)/src/crypto_openssl.c \
++	$(TOP)/src/crypto_wolfssl.c \
+ 	$(TOP)/src/crypto_cc.c
+ 
+ # END CRYPTO
+@@ -900,6 +902,8 @@ crypto_libtomcrypt.lo:	$(TOP)/src/crypto_libtomcrypt.c $(HDR)
+ 	$(LTCOMPILE) -c $(TOP)/src/crypto_libtomcrypt.c
+ crypto_cc.lo:	$(TOP)/src/crypto_cc.c $(HDR)
+ 	$(LTCOMPILE) -c $(TOP)/src/crypto_cc.c
++crypto_wolfssl.lo:  $(TOP)/src/crypto_wolfssl.c $(HDR)
++	$(LTCOMPILE) -c $(TOP)/src/crypto_wolfssl.c
+ # END CRYPTO
+ 
+ # Rules to build individual *.o files from files in the src directory.
+diff --git a/Makefile.msc b/Makefile.msc
+index d46cee15..bc77cfe4 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -1332,6 +1332,7 @@ SRC00 = \
+ 	$(TOP)\src\crypto_libtomcrypt.c \
+ 	$(TOP)\src\crypto_nss.c \
+ 	$(TOP)\src\crypto_openssl.c \
++	$(TOP)\src\crypto_wolfssl.c \
+ 	$(TOP)\src\sqlcipher.h \
+   $(TOP)\src\alter.c \
+   $(TOP)\src\analyze.c \
+diff --git a/README.md b/README.md
+index 83cb3825..4d0282d7 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,33 @@
++## WolfSSL Instructions
++
++To build with wolfSSL, clone this repo and build as usual, but regenerate the configure file and then add the `-with-crypto-lib=wolfssl` option to `configure`. For example, to build and run the tests after cloning (following the instructions in the original README below), you should run the following commands:
++
++```sh
++$ autoreconf --install --force # Necessary only the first time, since we modify configure.ac to add an option for wolfSSL
++$ ./configure --enable-tempstore=yes --with-crypto-lib=wolfssl --enable-fts5 CFLAGS="-DSQLITE_HAS_CODEC -DSQLCIPHER_TEST" LDFLAGS="-lwolfssl"
++$ make
++$ make testfixture
++$ ./testfixture test/sqlcipher.test
++```
++
++Note that if using a FIPS build, the sqlcipher tests will all fail as they use a password/key shorter than the minimum FIPS mandated length (14 bytes). There are some tests that are easy to change to accomodate that (`sqlcipher-backup.test`, for example). For these you can run `sed -i 's/testkey/testkey012345678/g'`. Other tests will take too long to fix as they use random keys ("foo", "0123", etc) and others like `sqlcipher-compatibility.test` operate on databases already encrypted with short keys.
++
++### Troubleshooting
++
++Note that the SQLite test suite requires the tcl development headers to be installed on the system. If they are not installed, `make testfixture` will fail with errors like:
++
++``
++sqlcipher/src/test1.c:32:12: fatal error: tcl.h: No such file or directory
++   32 | #  include "tcl.h"
++      |            ^~~~~~~
++compilation terminated.
++``
++
++To fix this on Ubuntu, [install the tcl-dev package](https://askubuntu.com/a/568760) (`apt install tcl-dev`)
++
++
++# Original Readme:
++
+ ## SQLCipher
+ 
+ SQLCipher is a standalone fork of the [SQLite](https://www.sqlite.org/) database library that adds 256 bit AES encryption of database files and other security features like:
+diff --git a/SQLCipher.podspec.json b/SQLCipher.podspec.json
+index 90c5eb3a..e564baa3 100644
+--- a/SQLCipher.podspec.json
++++ b/SQLCipher.podspec.json
+@@ -14,7 +14,7 @@
+     "tvos": "12.0",
+     "watchos": "7.0"
+   },
+-  "prepare_command": "./configure --enable-tempstore=yes --with-crypto-lib=commoncrypto CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_SOUNDEX -DSQLITE_THREADSAFE -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_STAT3 -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_LOAD_EXTENSION -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS4_UNICODE61 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DHAVE_USLEEP=1 -DSQLITE_MAX_VARIABLE_NUMBER=99999\"; make sqlite3.c",
++  "prepare_command": "./configure --enable-tempstore=yes --with-crypto-lib=wolfssl CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_SOUNDEX -DSQLITE_THREADSAFE -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_STAT3 -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_LOAD_EXTENSION -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS4_UNICODE61 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DHAVE_USLEEP=1 -DSQLITE_MAX_VARIABLE_NUMBER=99999\"; make sqlite3.c",
+   "requires_arc": false,
+   "source": {
+     "git": "https://github.com/sqlcipher/sqlcipher.git",
+@@ -42,7 +42,7 @@
+         "-DSQLITE_ENABLE_UNLOCK_NOTIFY",
+         "-DSQLITE_ENABLE_JSON1",
+         "-DSQLITE_ENABLE_FTS5",
+-        "-DSQLCIPHER_CRYPTO_CC",
++        "-DSQLCIPHER_CRYPTO_WOLFSSL",
+         "-DHAVE_USLEEP=1",
+         "-DSQLITE_MAX_VARIABLE_NUMBER=99999"
+       ],
+diff --git a/configure.ac b/configure.ac
+index 50273b49..684dd011 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -273,11 +273,19 @@ else
+         AC_CHECK_LIB([nss3], [PK11_Decrypt], ,
+                      AC_MSG_ERROR([Library crypto not found. Install nss!"]))
+       else
+-        CFLAGS="$CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
+-        BUILD_CFLAGS="$BUILD_CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
+-	      AC_MSG_RESULT([openssl])
+-        AC_CHECK_LIB([crypto], [HMAC_Init_ex], ,
+-                     AC_MSG_ERROR([Library crypto not found. Install openssl!"]))
++        if test "$crypto_lib" = "wolfssl"; then
++          CFLAGS="$CFLAGS -DSQLCIPHER_CRYPTO_WOLFSSL"
++          BUILD_CFLAGS="$BUILD_CFLAGS -DSQLCIPHER_CRYPTO_WOLFSSL"
++          AC_MSG_RESULT([wolfssl])
++          AC_CHECK_LIB([wolfssl], [wolfCrypt_Init], ,
++                      AC_MSG_ERROR([Library crypto not found. Install wolfSSL!"]))
++        else
++          CFLAGS="$CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
++          BUILD_CFLAGS="$BUILD_CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
++          AC_MSG_RESULT([openssl])
++          AC_CHECK_LIB([crypto], [HMAC_Init_ex], ,
++                      AC_MSG_ERROR([Library crypto not found. Install openssl!"]))
++        fi
+       fi
+     fi
+   fi
+diff --git a/src/crypto_wolfssl.c b/src/crypto_wolfssl.c
+new file mode 100644
+index 00000000..40c3ffca
+--- /dev/null
++++ b/src/crypto_wolfssl.c
+@@ -0,0 +1,246 @@
++/*
++** SQLCipher
++** http://sqlcipher.net
++**
++** Copyright (c) 2008 - 2013, ZETETIC LLC
++** All rights reserved.
++**
++** Redistribution and use in source and binary forms, with or without
++** modification, are permitted provided that the following conditions are met:
++**     * Redistributions of source code must retain the above copyright
++**       notice, this list of conditions and the following disclaimer.
++**     * Redistributions in binary form must reproduce the above copyright
++**       notice, this list of conditions and the following disclaimer in the
++**       documentation and/or other materials provided with the distribution.
++**     * Neither the name of the ZETETIC LLC nor the
++**       names of its contributors may be used to endorse or promote products
++**       derived from this software without specific prior written permission.
++**
++** THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
++** EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++** WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++** DISCLAIMED. IN NO EVENT SHALL ZETETIC LLC BE LIABLE FOR ANY
++** DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++** (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++** LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++** ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++**
++*/
++/* BEGIN SQLCIPHER */
++#ifdef SQLITE_HAS_CODEC
++#ifdef SQLCIPHER_CRYPTO_WOLFSSL
++#include "sqliteInt.h"
++#include "sqlcipher.h"
++
++#include <wolfssl/options.h>
++#include <wolfssl/wolfcrypt/settings.h>
++#include <wolfssl/wolfcrypt/aes.h>
++#include <wolfssl/wolfcrypt/sha.h>
++#include <wolfssl/wolfcrypt/sha256.h>
++#include <wolfssl/wolfcrypt/sha512.h>
++#include <wolfssl/wolfcrypt/hmac.h>
++#include <wolfssl/wolfcrypt/random.h>
++#include <wolfssl/wolfcrypt/pwdbased.h>
++#include <wolfssl/wolfcrypt/error-crypt.h>
++#include <wolfssl/version.h>
++
++int sqlcipher_wolf_setup(sqlcipher_provider *p);
++
++#ifdef HAVE_FIPS
++#include <wolfssl/wolfcrypt/fips_test.h>
++static void wcFipsCb(int ok, int err, const char* hash)
++{
++    sqlcipher_log(SQLCIPHER_LOG_ERROR, "wolfCrypt Fips error callback, ok = %d, err = %d\n", ok, err);
++    sqlcipher_log(SQLCIPHER_LOG_ERROR, "message = %s\n", wc_GetErrorString(err));
++    sqlcipher_log(SQLCIPHER_LOG_ERROR, "hash = %s\n", hash);
++    if (err == IN_CORE_FIPS_E) {
++        sqlcipher_log(SQLCIPHER_LOG_ERROR, "In core integrity hash check failure, copy above hash\n");
++        sqlcipher_log(SQLCIPHER_LOG_ERROR, "into verifyCore[] in fips_test.c and rebuild\n");
++    }
++}
++#endif
++
++static int sqlcipher_wolf_add_random(void *ctx, void *buffer, int length) {
++  (void)ctx;
++  (void)buffer;
++  (void)length;
++  /* not used */
++  return SQLITE_OK;
++}
++
++/* generate a defined number of random bytes */
++static WC_RNG gRng;
++static int    gRngInit = 0;
++static int sqlcipher_wolf_random(void *ctx, void *buffer, int length) {
++  int ret = -1;
++  if (!gRngInit) {
++    ret = wc_InitRng(&gRng);
++    if (ret == 0) {
++      gRngInit = 1;
++    }
++  }
++  if (gRngInit) {
++      ret = wc_RNG_GenerateBlock(&gRng, buffer, length);
++  }
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static const char* sqlcipher_wolf_get_provider_name(void *ctx) {
++  return "wolfssl";
++}
++
++static const char* sqlcipher_wolf_get_provider_version(void *ctx) {
++    return LIBWOLFSSL_VERSION_STRING;
++}
++
++static int sqlcipher_wolf_hmac(void *ctx, int algorithm, unsigned char *hmac_key,
++    int key_sz, unsigned char *in, int in_sz, unsigned char *in2, int in2_sz, unsigned char *out) {
++  int ret;
++  Hmac hmac_context;
++  if(in == NULL) return SQLITE_ERROR;
++  if (wc_HmacInit(&hmac_context, NULL, INVALID_DEVID) != 0) return SQLITE_ERROR;
++  switch(algorithm) {
++    case SQLCIPHER_HMAC_SHA1:
++      ret = wc_HmacSetKey(&hmac_context, WC_SHA, hmac_key, key_sz);
++      break;
++    case SQLCIPHER_HMAC_SHA256:
++      ret = wc_HmacSetKey(&hmac_context, WC_SHA256, hmac_key, key_sz);
++      break;
++    case SQLCIPHER_HMAC_SHA512:
++      ret = wc_HmacSetKey(&hmac_context, WC_SHA512, hmac_key, key_sz);
++      break;
++    default:
++      ret = SQLITE_ERROR;
++  }
++  if (ret == 0)
++    ret = wc_HmacUpdate(&hmac_context, in, in_sz);
++  if (ret == 0 && in2 != NULL)
++    ret = wc_HmacUpdate(&hmac_context, in2, in2_sz);
++  if (ret == 0)
++    ret = wc_HmacFinal(&hmac_context, out);
++  wc_HmacFree(&hmac_context);
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static int sqlcipher_wolf_kdf(void *ctx, int algorithm, const unsigned char *pass,
++    int pass_sz, unsigned char* salt, int salt_sz, int workfactor, int key_sz, unsigned char *key) {
++  int ret;
++  switch(algorithm) {
++    case SQLCIPHER_HMAC_SHA1:
++      ret = wc_PBKDF2(key, pass, pass_sz, salt, salt_sz, workfactor, key_sz, WC_SHA);
++      break;
++    case SQLCIPHER_HMAC_SHA256:
++      ret = wc_PBKDF2(key, pass, pass_sz, salt, salt_sz, workfactor, key_sz, WC_SHA256);
++      break;
++    case SQLCIPHER_HMAC_SHA512:
++      ret = wc_PBKDF2(key, pass, pass_sz, salt, salt_sz, workfactor, key_sz, WC_SHA512);
++      break;
++    default:
++      ret = SQLITE_ERROR;
++  }
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static int sqlcipher_wolf_cipher(void *ctx, int mode, unsigned char *key,
++    int key_sz, unsigned char *iv, unsigned char *in, int in_sz, unsigned char *out) {
++  int ret;
++  Aes aes;
++  if (wc_AesInit(&aes, NULL, INVALID_DEVID) != 0) return SQLITE_ERROR;
++  ret = wc_AesSetKey(&aes, key, key_sz, iv,
++    mode == CIPHER_ENCRYPT ? AES_ENCRYPTION : AES_DECRYPTION);
++  if (ret == 0) {
++      if (mode == CIPHER_ENCRYPT)
++        ret = wc_AesCbcEncrypt(&aes, out, in, in_sz);
++      else
++        ret = wc_AesCbcDecrypt(&aes, out, in, in_sz);
++  }
++  wc_AesFree(&aes);
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static const char* sqlcipher_wolf_get_cipher(void *ctx) {
++  return "aes-256-cbc";
++}
++
++static int sqlcipher_wolf_get_key_sz(void *ctx) {
++  return AES_256_KEY_SIZE;
++}
++
++static int sqlcipher_wolf_get_iv_sz(void *ctx) {
++  return AES_BLOCK_SIZE;
++}
++
++static int sqlcipher_wolf_get_block_sz(void *ctx) {
++  return AES_BLOCK_SIZE;
++}
++
++static int sqlcipher_wolf_get_hmac_sz(void *ctx, int algorithm) {
++  switch(algorithm) {
++    case SQLCIPHER_HMAC_SHA1:
++      return WC_SHA_DIGEST_SIZE;
++    case SQLCIPHER_HMAC_SHA256:
++      return WC_SHA256_DIGEST_SIZE;
++    case SQLCIPHER_HMAC_SHA512:
++      return WC_SHA512_DIGEST_SIZE;
++    default:
++      return 0;
++  }
++}
++
++static int sqlcipher_wolf_ctx_init(void **ctx) {
++
++  if (wolfCrypt_Init() != 0) {
++      return SQLITE_ERROR;
++  }
++#ifdef HAVE_FIPS
++  wolfCrypt_SetCb_fips(wcFipsCb);
++#if (FIPS_VERSION_GE(5,3))
++  wc_SetSeed_Cb(wc_GenerateSeed);
++#endif
++#endif
++  return SQLITE_OK;
++}
++
++static int sqlcipher_wolf_ctx_free(void **ctx) {
++  if (gRngInit) {
++      wc_FreeRng(&gRng);
++      gRngInit = 0;
++  }
++
++  wolfCrypt_Cleanup();
++  return SQLITE_OK;
++}
++
++static int sqlcipher_wolf_fips_status(void *ctx) {
++#ifdef HAVE_FIPS
++    if (wolfCrypt_GetStatus_fips() == 0) {
++        return 1; /* FIPS available and valid */
++    }
++#endif
++  return 0;
++}
++
++int sqlcipher_wolf_setup(sqlcipher_provider *p) {
++  p->random = sqlcipher_wolf_random;
++  p->get_provider_name = sqlcipher_wolf_get_provider_name;
++  p->hmac = sqlcipher_wolf_hmac;
++  p->kdf = sqlcipher_wolf_kdf;
++  p->cipher = sqlcipher_wolf_cipher;
++  p->get_cipher = sqlcipher_wolf_get_cipher;
++  p->get_key_sz = sqlcipher_wolf_get_key_sz;
++  p->get_iv_sz = sqlcipher_wolf_get_iv_sz;
++  p->get_block_sz = sqlcipher_wolf_get_block_sz;
++  p->get_hmac_sz = sqlcipher_wolf_get_hmac_sz;
++  p->ctx_init = sqlcipher_wolf_ctx_init;
++  p->ctx_free = sqlcipher_wolf_ctx_free;
++  p->add_random = sqlcipher_wolf_add_random;
++  p->fips_status = sqlcipher_wolf_fips_status;
++  p->get_provider_version = sqlcipher_wolf_get_provider_version;
++  return SQLITE_OK;
++}
++
++#endif /* SQLCIPHER_CRYPTO_WOLFSSL */
++#endif
++/* END SQLCIPHER */
+diff --git a/src/sqlcipher.c b/src/sqlcipher.c
+index 8be4bc92..aeee88d5 100644
+--- a/src/sqlcipher.c
++++ b/src/sqlcipher.c
+@@ -76,6 +76,7 @@ void sqlite3pager_reset(Pager *pPager);
+ #if !defined (SQLCIPHER_CRYPTO_CC) \
+    && !defined (SQLCIPHER_CRYPTO_LIBTOMCRYPT) \
+    && !defined (SQLCIPHER_CRYPTO_NSS) \
++   && !defined (SQLCIPHER_CRYPTO_WOLFSSL) \
+    && !defined (SQLCIPHER_CRYPTO_OPENSSL)
+ #define SQLCIPHER_CRYPTO_OPENSSL
+ #endif
+@@ -534,6 +535,9 @@ static void sqlcipher_activate() {
+ #elif defined (SQLCIPHER_CRYPTO_NSS)
+     extern int sqlcipher_nss_setup(sqlcipher_provider *p);
+     sqlcipher_nss_setup(p);
++#elif defined (SQLCIPHER_CRYPTO_WOLFSSL)
++    extern int sqlcipher_wolf_setup(sqlcipher_provider *p);
++    sqlcipher_wolf_setup(p);
+ #elif defined (SQLCIPHER_CRYPTO_OPENSSL)
+     extern int sqlcipher_openssl_setup(sqlcipher_provider *p);
+     sqlcipher_openssl_setup(p);
+diff --git a/tool/mksqlite3c.tcl b/tool/mksqlite3c.tcl
+index 5cfcd6f0..4542a58d 100644
+--- a/tool/mksqlite3c.tcl
++++ b/tool/mksqlite3c.tcl
+@@ -434,6 +434,7 @@ set flist {
+    crypto_nss.c
+    crypto_openssl.c
+    crypto_cc.c
++   crypto_wolfssl.c
+ 
+    walker.c
+    resolve.c
+-- 
+2.34.1
+

--- a/sqlcipher/sqlcipher_wolfssl_v4.6.1_raw.patch
+++ b/sqlcipher/sqlcipher_wolfssl_v4.6.1_raw.patch
@@ -1,0 +1,416 @@
+diff --git a/Makefile.in b/Makefile.in
+index 8431c25a..54d438cf 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -149,6 +149,7 @@ CRYPTOLIBOBJ = \
+   crypto_openssl.lo \
+   crypto_libtomcrypt.lo \
+   crypto_nss.lo \
++  crypto_wolfssl.lo \
+   crypto_cc.lo
+ 
+ CRYPTOSRC = \
+@@ -157,6 +158,7 @@ CRYPTOSRC = \
+ 	$(TOP)/src/crypto_libtomcrypt.c \
+ 	$(TOP)/src/crypto_nss.c \
+ 	$(TOP)/src/crypto_openssl.c \
++	$(TOP)/src/crypto_wolfssl.c \
+ 	$(TOP)/src/crypto_cc.c
+ 
+ # END CRYPTO
+@@ -900,6 +902,8 @@ crypto_libtomcrypt.lo:	$(TOP)/src/crypto_libtomcrypt.c $(HDR)
+ 	$(LTCOMPILE) -c $(TOP)/src/crypto_libtomcrypt.c
+ crypto_cc.lo:	$(TOP)/src/crypto_cc.c $(HDR)
+ 	$(LTCOMPILE) -c $(TOP)/src/crypto_cc.c
++crypto_wolfssl.lo:  $(TOP)/src/crypto_wolfssl.c $(HDR)
++	$(LTCOMPILE) -c $(TOP)/src/crypto_wolfssl.c
+ # END CRYPTO
+ 
+ # Rules to build individual *.o files from files in the src directory.
+diff --git a/Makefile.msc b/Makefile.msc
+index d46cee15..bc77cfe4 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -1332,6 +1332,7 @@ SRC00 = \
+ 	$(TOP)\src\crypto_libtomcrypt.c \
+ 	$(TOP)\src\crypto_nss.c \
+ 	$(TOP)\src\crypto_openssl.c \
++	$(TOP)\src\crypto_wolfssl.c \
+ 	$(TOP)\src\sqlcipher.h \
+   $(TOP)\src\alter.c \
+   $(TOP)\src\analyze.c \
+diff --git a/README.md b/README.md
+index 83cb3825..4d0282d7 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,33 @@
++## WolfSSL Instructions
++
++To build with wolfSSL, clone this repo and build as usual, but regenerate the configure file and then add the `-with-crypto-lib=wolfssl` option to `configure`. For example, to build and run the tests after cloning (following the instructions in the original README below), you should run the following commands:
++
++```sh
++$ autoreconf --install --force # Necessary only the first time, since we modify configure.ac to add an option for wolfSSL
++$ ./configure --enable-tempstore=yes --with-crypto-lib=wolfssl --enable-fts5 CFLAGS="-DSQLITE_HAS_CODEC -DSQLCIPHER_TEST" LDFLAGS="-lwolfssl"
++$ make
++$ make testfixture
++$ ./testfixture test/sqlcipher.test
++```
++
++Note that if using a FIPS build, the sqlcipher tests will all fail as they use a password/key shorter than the minimum FIPS mandated length (14 bytes). There are some tests that are easy to change to accomodate that (`sqlcipher-backup.test`, for example). For these you can run `sed -i 's/testkey/testkey012345678/g'`. Other tests will take too long to fix as they use random keys ("foo", "0123", etc) and others like `sqlcipher-compatibility.test` operate on databases already encrypted with short keys.
++
++### Troubleshooting
++
++Note that the SQLite test suite requires the tcl development headers to be installed on the system. If they are not installed, `make testfixture` will fail with errors like:
++
++``
++sqlcipher/src/test1.c:32:12: fatal error: tcl.h: No such file or directory
++   32 | #  include "tcl.h"
++      |            ^~~~~~~
++compilation terminated.
++``
++
++To fix this on Ubuntu, [install the tcl-dev package](https://askubuntu.com/a/568760) (`apt install tcl-dev`)
++
++
++# Original Readme:
++
+ ## SQLCipher
+ 
+ SQLCipher is a standalone fork of the [SQLite](https://www.sqlite.org/) database library that adds 256 bit AES encryption of database files and other security features like:
+diff --git a/SQLCipher.podspec.json b/SQLCipher.podspec.json
+index 90c5eb3a..e564baa3 100644
+--- a/SQLCipher.podspec.json
++++ b/SQLCipher.podspec.json
+@@ -14,7 +14,7 @@
+     "tvos": "12.0",
+     "watchos": "7.0"
+   },
+-  "prepare_command": "./configure --enable-tempstore=yes --with-crypto-lib=commoncrypto CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_SOUNDEX -DSQLITE_THREADSAFE -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_STAT3 -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_LOAD_EXTENSION -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS4_UNICODE61 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DHAVE_USLEEP=1 -DSQLITE_MAX_VARIABLE_NUMBER=99999\"; make sqlite3.c",
++  "prepare_command": "./configure --enable-tempstore=yes --with-crypto-lib=wolfssl CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_SOUNDEX -DSQLITE_THREADSAFE -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_STAT3 -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_LOAD_EXTENSION -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS4_UNICODE61 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DHAVE_USLEEP=1 -DSQLITE_MAX_VARIABLE_NUMBER=99999\"; make sqlite3.c",
+   "requires_arc": false,
+   "source": {
+     "git": "https://github.com/sqlcipher/sqlcipher.git",
+@@ -42,7 +42,7 @@
+         "-DSQLITE_ENABLE_UNLOCK_NOTIFY",
+         "-DSQLITE_ENABLE_JSON1",
+         "-DSQLITE_ENABLE_FTS5",
+-        "-DSQLCIPHER_CRYPTO_CC",
++        "-DSQLCIPHER_CRYPTO_WOLFSSL",
+         "-DHAVE_USLEEP=1",
+         "-DSQLITE_MAX_VARIABLE_NUMBER=99999"
+       ],
+diff --git a/configure.ac b/configure.ac
+index 50273b49..684dd011 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -273,11 +273,19 @@ else
+         AC_CHECK_LIB([nss3], [PK11_Decrypt], ,
+                      AC_MSG_ERROR([Library crypto not found. Install nss!"]))
+       else
+-        CFLAGS="$CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
+-        BUILD_CFLAGS="$BUILD_CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
+-	      AC_MSG_RESULT([openssl])
+-        AC_CHECK_LIB([crypto], [HMAC_Init_ex], ,
+-                     AC_MSG_ERROR([Library crypto not found. Install openssl!"]))
++        if test "$crypto_lib" = "wolfssl"; then
++          CFLAGS="$CFLAGS -DSQLCIPHER_CRYPTO_WOLFSSL"
++          BUILD_CFLAGS="$BUILD_CFLAGS -DSQLCIPHER_CRYPTO_WOLFSSL"
++          AC_MSG_RESULT([wolfssl])
++          AC_CHECK_LIB([wolfssl], [wolfCrypt_Init], ,
++                      AC_MSG_ERROR([Library crypto not found. Install wolfSSL!"]))
++        else
++          CFLAGS="$CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
++          BUILD_CFLAGS="$BUILD_CFLAGS -DSQLCIPHER_CRYPTO_OPENSSL"
++          AC_MSG_RESULT([openssl])
++          AC_CHECK_LIB([crypto], [HMAC_Init_ex], ,
++                      AC_MSG_ERROR([Library crypto not found. Install openssl!"]))
++        fi
+       fi
+     fi
+   fi
+diff --git a/src/crypto_wolfssl.c b/src/crypto_wolfssl.c
+new file mode 100644
+index 00000000..40c3ffca
+--- /dev/null
++++ b/src/crypto_wolfssl.c
+@@ -0,0 +1,246 @@
++/*
++** SQLCipher
++** http://sqlcipher.net
++**
++** Copyright (c) 2008 - 2013, ZETETIC LLC
++** All rights reserved.
++**
++** Redistribution and use in source and binary forms, with or without
++** modification, are permitted provided that the following conditions are met:
++**     * Redistributions of source code must retain the above copyright
++**       notice, this list of conditions and the following disclaimer.
++**     * Redistributions in binary form must reproduce the above copyright
++**       notice, this list of conditions and the following disclaimer in the
++**       documentation and/or other materials provided with the distribution.
++**     * Neither the name of the ZETETIC LLC nor the
++**       names of its contributors may be used to endorse or promote products
++**       derived from this software without specific prior written permission.
++**
++** THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
++** EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++** WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++** DISCLAIMED. IN NO EVENT SHALL ZETETIC LLC BE LIABLE FOR ANY
++** DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++** (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++** LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++** ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++**
++*/
++/* BEGIN SQLCIPHER */
++#ifdef SQLITE_HAS_CODEC
++#ifdef SQLCIPHER_CRYPTO_WOLFSSL
++#include "sqliteInt.h"
++#include "sqlcipher.h"
++
++#include <wolfssl/options.h>
++#include <wolfssl/wolfcrypt/settings.h>
++#include <wolfssl/wolfcrypt/aes.h>
++#include <wolfssl/wolfcrypt/sha.h>
++#include <wolfssl/wolfcrypt/sha256.h>
++#include <wolfssl/wolfcrypt/sha512.h>
++#include <wolfssl/wolfcrypt/hmac.h>
++#include <wolfssl/wolfcrypt/random.h>
++#include <wolfssl/wolfcrypt/pwdbased.h>
++#include <wolfssl/wolfcrypt/error-crypt.h>
++#include <wolfssl/version.h>
++
++int sqlcipher_wolf_setup(sqlcipher_provider *p);
++
++#ifdef HAVE_FIPS
++#include <wolfssl/wolfcrypt/fips_test.h>
++static void wcFipsCb(int ok, int err, const char* hash)
++{
++    sqlcipher_log(SQLCIPHER_LOG_ERROR, "wolfCrypt Fips error callback, ok = %d, err = %d\n", ok, err);
++    sqlcipher_log(SQLCIPHER_LOG_ERROR, "message = %s\n", wc_GetErrorString(err));
++    sqlcipher_log(SQLCIPHER_LOG_ERROR, "hash = %s\n", hash);
++    if (err == IN_CORE_FIPS_E) {
++        sqlcipher_log(SQLCIPHER_LOG_ERROR, "In core integrity hash check failure, copy above hash\n");
++        sqlcipher_log(SQLCIPHER_LOG_ERROR, "into verifyCore[] in fips_test.c and rebuild\n");
++    }
++}
++#endif
++
++static int sqlcipher_wolf_add_random(void *ctx, void *buffer, int length) {
++  (void)ctx;
++  (void)buffer;
++  (void)length;
++  /* not used */
++  return SQLITE_OK;
++}
++
++/* generate a defined number of random bytes */
++static WC_RNG gRng;
++static int    gRngInit = 0;
++static int sqlcipher_wolf_random(void *ctx, void *buffer, int length) {
++  int ret = -1;
++  if (!gRngInit) {
++    ret = wc_InitRng(&gRng);
++    if (ret == 0) {
++      gRngInit = 1;
++    }
++  }
++  if (gRngInit) {
++      ret = wc_RNG_GenerateBlock(&gRng, buffer, length);
++  }
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static const char* sqlcipher_wolf_get_provider_name(void *ctx) {
++  return "wolfssl";
++}
++
++static const char* sqlcipher_wolf_get_provider_version(void *ctx) {
++    return LIBWOLFSSL_VERSION_STRING;
++}
++
++static int sqlcipher_wolf_hmac(void *ctx, int algorithm, unsigned char *hmac_key,
++    int key_sz, unsigned char *in, int in_sz, unsigned char *in2, int in2_sz, unsigned char *out) {
++  int ret;
++  Hmac hmac_context;
++  if(in == NULL) return SQLITE_ERROR;
++  if (wc_HmacInit(&hmac_context, NULL, INVALID_DEVID) != 0) return SQLITE_ERROR;
++  switch(algorithm) {
++    case SQLCIPHER_HMAC_SHA1:
++      ret = wc_HmacSetKey(&hmac_context, WC_SHA, hmac_key, key_sz);
++      break;
++    case SQLCIPHER_HMAC_SHA256:
++      ret = wc_HmacSetKey(&hmac_context, WC_SHA256, hmac_key, key_sz);
++      break;
++    case SQLCIPHER_HMAC_SHA512:
++      ret = wc_HmacSetKey(&hmac_context, WC_SHA512, hmac_key, key_sz);
++      break;
++    default:
++      ret = SQLITE_ERROR;
++  }
++  if (ret == 0)
++    ret = wc_HmacUpdate(&hmac_context, in, in_sz);
++  if (ret == 0 && in2 != NULL)
++    ret = wc_HmacUpdate(&hmac_context, in2, in2_sz);
++  if (ret == 0)
++    ret = wc_HmacFinal(&hmac_context, out);
++  wc_HmacFree(&hmac_context);
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static int sqlcipher_wolf_kdf(void *ctx, int algorithm, const unsigned char *pass,
++    int pass_sz, unsigned char* salt, int salt_sz, int workfactor, int key_sz, unsigned char *key) {
++  int ret;
++  switch(algorithm) {
++    case SQLCIPHER_HMAC_SHA1:
++      ret = wc_PBKDF2(key, pass, pass_sz, salt, salt_sz, workfactor, key_sz, WC_SHA);
++      break;
++    case SQLCIPHER_HMAC_SHA256:
++      ret = wc_PBKDF2(key, pass, pass_sz, salt, salt_sz, workfactor, key_sz, WC_SHA256);
++      break;
++    case SQLCIPHER_HMAC_SHA512:
++      ret = wc_PBKDF2(key, pass, pass_sz, salt, salt_sz, workfactor, key_sz, WC_SHA512);
++      break;
++    default:
++      ret = SQLITE_ERROR;
++  }
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static int sqlcipher_wolf_cipher(void *ctx, int mode, unsigned char *key,
++    int key_sz, unsigned char *iv, unsigned char *in, int in_sz, unsigned char *out) {
++  int ret;
++  Aes aes;
++  if (wc_AesInit(&aes, NULL, INVALID_DEVID) != 0) return SQLITE_ERROR;
++  ret = wc_AesSetKey(&aes, key, key_sz, iv,
++    mode == CIPHER_ENCRYPT ? AES_ENCRYPTION : AES_DECRYPTION);
++  if (ret == 0) {
++      if (mode == CIPHER_ENCRYPT)
++        ret = wc_AesCbcEncrypt(&aes, out, in, in_sz);
++      else
++        ret = wc_AesCbcDecrypt(&aes, out, in, in_sz);
++  }
++  wc_AesFree(&aes);
++  return (ret == 0) ? SQLITE_OK : SQLITE_ERROR;
++}
++
++static const char* sqlcipher_wolf_get_cipher(void *ctx) {
++  return "aes-256-cbc";
++}
++
++static int sqlcipher_wolf_get_key_sz(void *ctx) {
++  return AES_256_KEY_SIZE;
++}
++
++static int sqlcipher_wolf_get_iv_sz(void *ctx) {
++  return AES_BLOCK_SIZE;
++}
++
++static int sqlcipher_wolf_get_block_sz(void *ctx) {
++  return AES_BLOCK_SIZE;
++}
++
++static int sqlcipher_wolf_get_hmac_sz(void *ctx, int algorithm) {
++  switch(algorithm) {
++    case SQLCIPHER_HMAC_SHA1:
++      return WC_SHA_DIGEST_SIZE;
++    case SQLCIPHER_HMAC_SHA256:
++      return WC_SHA256_DIGEST_SIZE;
++    case SQLCIPHER_HMAC_SHA512:
++      return WC_SHA512_DIGEST_SIZE;
++    default:
++      return 0;
++  }
++}
++
++static int sqlcipher_wolf_ctx_init(void **ctx) {
++
++  if (wolfCrypt_Init() != 0) {
++      return SQLITE_ERROR;
++  }
++#ifdef HAVE_FIPS
++  wolfCrypt_SetCb_fips(wcFipsCb);
++#if (FIPS_VERSION_GE(5,3))
++  wc_SetSeed_Cb(wc_GenerateSeed);
++#endif
++#endif
++  return SQLITE_OK;
++}
++
++static int sqlcipher_wolf_ctx_free(void **ctx) {
++  if (gRngInit) {
++      wc_FreeRng(&gRng);
++      gRngInit = 0;
++  }
++
++  wolfCrypt_Cleanup();
++  return SQLITE_OK;
++}
++
++static int sqlcipher_wolf_fips_status(void *ctx) {
++#ifdef HAVE_FIPS
++    if (wolfCrypt_GetStatus_fips() == 0) {
++        return 1; /* FIPS available and valid */
++    }
++#endif
++  return 0;
++}
++
++int sqlcipher_wolf_setup(sqlcipher_provider *p) {
++  p->random = sqlcipher_wolf_random;
++  p->get_provider_name = sqlcipher_wolf_get_provider_name;
++  p->hmac = sqlcipher_wolf_hmac;
++  p->kdf = sqlcipher_wolf_kdf;
++  p->cipher = sqlcipher_wolf_cipher;
++  p->get_cipher = sqlcipher_wolf_get_cipher;
++  p->get_key_sz = sqlcipher_wolf_get_key_sz;
++  p->get_iv_sz = sqlcipher_wolf_get_iv_sz;
++  p->get_block_sz = sqlcipher_wolf_get_block_sz;
++  p->get_hmac_sz = sqlcipher_wolf_get_hmac_sz;
++  p->ctx_init = sqlcipher_wolf_ctx_init;
++  p->ctx_free = sqlcipher_wolf_ctx_free;
++  p->add_random = sqlcipher_wolf_add_random;
++  p->fips_status = sqlcipher_wolf_fips_status;
++  p->get_provider_version = sqlcipher_wolf_get_provider_version;
++  return SQLITE_OK;
++}
++
++#endif /* SQLCIPHER_CRYPTO_WOLFSSL */
++#endif
++/* END SQLCIPHER */
+diff --git a/src/sqlcipher.c b/src/sqlcipher.c
+index 8be4bc92..aeee88d5 100644
+--- a/src/sqlcipher.c
++++ b/src/sqlcipher.c
+@@ -76,6 +76,7 @@ void sqlite3pager_reset(Pager *pPager);
+ #if !defined (SQLCIPHER_CRYPTO_CC) \
+    && !defined (SQLCIPHER_CRYPTO_LIBTOMCRYPT) \
+    && !defined (SQLCIPHER_CRYPTO_NSS) \
++   && !defined (SQLCIPHER_CRYPTO_WOLFSSL) \
+    && !defined (SQLCIPHER_CRYPTO_OPENSSL)
+ #define SQLCIPHER_CRYPTO_OPENSSL
+ #endif
+@@ -534,6 +535,9 @@ static void sqlcipher_activate() {
+ #elif defined (SQLCIPHER_CRYPTO_NSS)
+     extern int sqlcipher_nss_setup(sqlcipher_provider *p);
+     sqlcipher_nss_setup(p);
++#elif defined (SQLCIPHER_CRYPTO_WOLFSSL)
++    extern int sqlcipher_wolf_setup(sqlcipher_provider *p);
++    sqlcipher_wolf_setup(p);
+ #elif defined (SQLCIPHER_CRYPTO_OPENSSL)
+     extern int sqlcipher_openssl_setup(sqlcipher_provider *p);
+     sqlcipher_openssl_setup(p);
+diff --git a/tool/mksqlite3c.tcl b/tool/mksqlite3c.tcl
+index 5cfcd6f0..4542a58d 100644
+--- a/tool/mksqlite3c.tcl
++++ b/tool/mksqlite3c.tcl
+@@ -434,6 +434,7 @@ set flist {
+    crypto_nss.c
+    crypto_openssl.c
+    crypto_cc.c
++   crypto_wolfssl.c
+ 
+    walker.c
+    resolve.c


### PR DESCRIPTION
Adds patch set for adding wolfSSL as a cryptographic provider for SQLCipher. 

Based on the original work done by @dgarske in https://github.com/sqlcipher/sqlcipher/pull/411, which I then updated and maintained for a customer in a private fork for a while. Now that there is more interest, I think we should add to OSP.


