### PR TITLE
Revert "changes for py assumption 32-> 48 removed for failing pr #7771"

### DIFF
--- a/Python/wolfssl-python-3.8.14.patch
+++ b/Python/wolfssl-python-3.8.14.patch
@@ -1152,6 +1152,19 @@ index 71cfdcd..937a15a 100644
                  else:
                      self.assertEqual(len(cb_data), 12)  # True for TLSv1
  
+@@ -4017,7 +4217,11 @@ class ThreadedTests(unittest.TestCase):
+                 self.assertNotEqual(cb_data, new_cb_data)
+                 self.assertIsNotNone(cb_data)
+                 if s.version() == 'TLSv1.3':
+-                    self.assertEqual(len(cb_data), 48)
++                    if ssl.IS_WOLFSSL:
++                        # wolfSSL returns 32 length because TLS_AES_128_GCM_SHA256 is used
++                        self.assertEqual(len(cb_data), 32)
++                    else:
++                        self.assertEqual(len(cb_data), 48)
+                 else:
+                     self.assertEqual(len(cb_data), 12)  # True for TLSv1
+                 s.write(b"CB tls-unique\n")
 @@ -4051,13 +4255,20 @@ class ThreadedTests(unittest.TestCase):
          # test scenario needs TLS <= 1.2
          client_context.options |= ssl.OP_NO_TLSv1_3


### PR DESCRIPTION
Reverts wolfSSL/osp#208

This should not have been merged yet.

Let's patch python to allow 32 or 48...