### PR TITLE
Fix python cipher suite check

### DIFF
--- a/Python/wolfssl-python-3.8.14.patch
+++ b/Python/wolfssl-python-3.8.14.patch
@@ -385,7 +385,7 @@ index 7b1d854..e8ba7c8 100644
          resp = self.client.stls(context=ctx)
          self.assertEqual(resp, expected)
 diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
-index 71cfdcd..a9b8c9f 100644
+index 71cfdcd..c4a931a 100644
 --- a/Lib/test/test_ssl.py
 +++ b/Lib/test/test_ssl.py
 @@ -67,9 +67,17 @@ BYTES_ONLYKEY = os.fsencode(ONLYKEY)
@@ -1146,7 +1146,7 @@ index 71cfdcd..a9b8c9f 100644
                  if s.version() == 'TLSv1.3':
 -                    self.assertEqual(len(cb_data), 48)
 +                    cipher_suite = s.cipher()
-+                    if cipher_suite == 'TLS_AES_128_GCM_SHA256':
++                    if cipher_suite.__eq__("TLS_AES_128_GCM_SHA256"):
 +                        self.assertEqual(len(cb_data), 32)
 +                    else:
 +                        self.assertEqual(len(cb_data), 48)
@@ -1159,7 +1159,7 @@ index 71cfdcd..a9b8c9f 100644
                  if s.version() == 'TLSv1.3':
 -                    self.assertEqual(len(cb_data), 48)
 +                    cipher_suite = s.cipher()
-+                    if cipher_suite == 'TLS_AES_128_GCM_SHA256':
++                    if cipher_suite.__eq__("TLS_AES_128_GCM_SHA256"):
 +                        self.assertEqual(len(cb_data), 32)
 +                    else:
 +                        self.assertEqual(len(cb_data), 48)


### PR DESCRIPTION
Before:

```
FAIL: test_tls_unique_channel_binding (test.test_ssl.ThreadedTests)
Test tls-unique channel binding.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/davidgarske/GitHub/python-3.8.14/Lib/test/test_ssl.py", line 4206, in test_tls_unique_channel_binding
    self.assertEqual(len(cb_data), 48)
AssertionError: 32 != 48

----------------------------------------------------------------------

Ran 163 tests in 36.776s

FAILED (failures=1, skipped=17)
test test_ssl failed
1 test failed again:
    test_ssl

== Tests result: FAILURE then FAILURE ==

1 test failed:
    test_ssl

1 re-run test:
    test_ssl

Total duration: 1 min 13 sec
Tests result: FAILURE then FAILURE
```


After:

```
test_tls_unique_channel_binding (test.test_ssl.ThreadedTests)
Test tls-unique channel binding. ... 
 server:  new connection from ('127.0.0.1', 51813)
 got channel binding data: b'\x7f\xb1\xdcf\xf0\x0f\xc5\x82\n\x02\x8a\\L]\xf2\x87\x17[\xc6\x9d\xc5Q|\xc2TY\xd9\x13\xaf\xe7\xe1\xea'
 server: connection cipher is now ('TLS_AES_128_GCM_SHA256', 'TLSv1.3', 128)
 server: selected protocol is now None
 server:  new connection from ('127.0.0.1', 51814)
got another channel binding data: b'\\UY\xa7|1\x13:\x14\x9c\xbf\x9a\x98W\xaf\xa6\x01W\x07\x0bb\x88n4[x7\x06^3)\xd3'
 server: connection cipher is now ('TLS_AES_128_GCM_SHA256', 'TLSv1.3', 128)
 server: selected protocol is now None
ok
...

Ran 163 tests in 35.947s

OK (skipped=17)

== Tests result: SUCCESS ==

1 test OK.

Total duration: 36.2 sec
Tests result: SUCCESS
```