### PR TITLE
Add FIPS openssh testing support

### DIFF
--- a/wolfProvider/openssh/README.md
+++ b/wolfProvider/openssh/README.md
@@ -1,3 +1,5 @@
-This patch is only needed for the full openssh test suite to run with wolfProvider.
+These patches are needed to run a full openssh test suite with wolfProvider.
 For V_9_9_P1 testing use the patch `openssh-V_9_9_P1-wolfprov.patch`
 For V_10_0_P2 testing use the patch `openssh-V_10_0_P2-wolfprov.patch`
+For V_10_0_P2 FIPS testing support use the patch `openssh-FIPS-V_10_0_P2-wolfprov.patch`
+Note: use either the V_10_0_P2 FIPS patch or the normal ones not both.

--- a/wolfProvider/openssh/openssh-FIPS-V_10_0_P2-wolfprov.patch
+++ b/wolfProvider/openssh/openssh-FIPS-V_10_0_P2-wolfprov.patch
@@ -1,0 +1,250 @@
+diff --git a/myproposal.h b/myproposal.h
+index 8fe9276..f9a1b5f 100644
+--- a/myproposal.h
++++ b/myproposal.h
+@@ -59,7 +59,6 @@
+ 	"rsa-sha2-256"
+
+ #define	KEX_SERVER_ENCRYPT \
+-	"chacha20-poly1305@openssh.com," \
+ 	"aes128-gcm@openssh.com,aes256-gcm@openssh.com," \
+ 	"aes128-ctr,aes192-ctr,aes256-ctr"
+
+diff --git a/regress/Makefile b/regress/Makefile
+index 7e7f95b..6aef711 100644
+--- a/regress/Makefile
++++ b/regress/Makefile
+@@ -2,7 +2,13 @@
+
+ tests:		prep file-tests t-exec unit
+
+-REGRESS_TARGETS=	t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 t11 t12
++# Define default REGRESS_TARGETS
++REGRESS_TARGETS := t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 t11 t12
++
++# Override REGRESS_TARGETS in FIPS mode
++ifeq ($(FIPS_MODE),1)
++REGRESS_TARGETS := t2 t3 t4 t5 t6 t7 t8 t9 t10 t11 t12
++endif
+
+ # File based tests
+ file-tests: $(REGRESS_TARGETS)
+diff --git a/regress/unittests/kex/test_kex.c b/regress/unittests/kex/test_kex.c
+index caf8f57..ab95c4f 100644
+--- a/regress/unittests/kex/test_kex.c
++++ b/regress/unittests/kex/test_kex.c
+@@ -111,6 +111,7 @@ do_kex_with_key(char *kex, int keytype, int bits)
+ 	ASSERT_INT_EQ(ssh_add_hostkey(client, public), 0);
+ 	TEST_DONE();
+
++#ifndef FIPS_MODE
+ 	TEST_START("kex");
+ 	run_kex(client, server);
+ 	TEST_DONE();
+@@ -174,6 +175,7 @@ do_kex_with_key(char *kex, int keytype, int bits)
+ 	ssh_free(server2);
+ 	free(keyname);
+ 	TEST_DONE();
++#endif /* FIPS_MODE */
+ }
+
+ static void
+diff --git a/regress/unittests/sshkey/test_file.c b/regress/unittests/sshkey/test_file.c
+index 3babe60..e345004 100644
+--- a/regress/unittests/sshkey/test_file.c
++++ b/regress/unittests/sshkey/test_file.c
+@@ -23,6 +23,7 @@
+ #include <openssl/rsa.h>
+ #include <openssl/dsa.h>
+ #include <openssl/objects.h>
++#include <openssl/evp.h>
+ #ifdef OPENSSL_HAS_NISTP256
+ # include <openssl/ec.h>
+ #endif /* OPENSSL_HAS_NISTP256 */
+@@ -38,6 +39,13 @@
+
+ #include "common.h"
+
++/* Check if we're in FIPS mode */
++#ifdef WITH_OPENSSL
++#define FIPS_MODE (EVP_default_properties_is_fips_enabled(NULL))
++#else
++#define FIPS_MODE 0
++#endif
++
+ void sshkey_file_tests(void);
+
+ void
+@@ -72,6 +80,7 @@ sshkey_file_tests(void)
+ 	BN_free(c);
+ 	TEST_DONE();
+
++#ifndef FIPS_MODE
+ 	TEST_START("parse RSA from private w/ passphrase");
+ 	buf = load_file("rsa_1_pw");
+ 	ASSERT_INT_EQ(sshkey_parse_private_fileblob(buf,
+@@ -164,6 +173,7 @@ sshkey_file_tests(void)
+ 	TEST_DONE();
+
+ 	sshkey_free(k1);
++#endif /* FIPS_MODE */
+
+ #ifdef WITH_DSA
+ 	TEST_START("parse DSA from private");
+diff --git a/regress/unittests/sshkey/test_fuzz.c b/regress/unittests/sshkey/test_fuzz.c
+index 0aff7c9..84cbf44 100644
+--- a/regress/unittests/sshkey/test_fuzz.c
++++ b/regress/unittests/sshkey/test_fuzz.c
+@@ -338,6 +338,7 @@ sshkey_fuzz_tests(void)
+ 	TEST_DONE();
+
+ #ifdef WITH_OPENSSL
++#ifndef FIPS_MODE
+ 	TEST_START("fuzz RSA sig");
+ 	buf = load_file("rsa_1");
+ 	ASSERT_INT_EQ(sshkey_parse_private_fileblob(buf, "", &k1, NULL), 0);
+@@ -361,6 +362,7 @@ sshkey_fuzz_tests(void)
+ 	sig_fuzz(k1, "rsa-sha2-512");
+ 	sshkey_free(k1);
+ 	TEST_DONE();
++#endif /* FIPS_MODE */
+
+ #ifdef WITH_DSA
+ 	TEST_START("fuzz DSA sig");
+diff --git a/regress/unittests/sshkey/test_sshkey.c b/regress/unittests/sshkey/test_sshkey.c
+index 5bf4b65..bcd2bd9 100644
+--- a/regress/unittests/sshkey/test_sshkey.c
++++ b/regress/unittests/sshkey/test_sshkey.c
+@@ -268,13 +268,13 @@ sshkey_tests(void)
+ 	TEST_START("generate KEY_RSA");
+ 	ASSERT_INT_EQ(sshkey_generate(KEY_RSA, 767, &kr),
+ 	    SSH_ERR_KEY_LENGTH);
+-	ASSERT_INT_EQ(sshkey_generate(KEY_RSA, 1024, &kr), 0);
++	ASSERT_INT_EQ(sshkey_generate(KEY_RSA, 2048, &kr), 0);
+ 	ASSERT_PTR_NE(kr, NULL);
+ 	ASSERT_PTR_NE(EVP_PKEY_get0_RSA(kr->pkey), NULL);
+ 	ASSERT_PTR_NE(rsa_n(kr), NULL);
+ 	ASSERT_PTR_NE(rsa_e(kr), NULL);
+ 	ASSERT_PTR_NE(rsa_p(kr), NULL);
+-	ASSERT_INT_EQ(BN_num_bits(rsa_n(kr)), 1024);
++	ASSERT_INT_EQ(BN_num_bits(rsa_n(kr)), 2048);
+ 	TEST_DONE();
+
+ #ifdef WITH_DSA
+@@ -391,7 +391,7 @@ sshkey_tests(void)
+
+ 	TEST_START("equal different keys");
+ #ifdef WITH_OPENSSL
+-	ASSERT_INT_EQ(sshkey_generate(KEY_RSA, 1024, &k1), 0);
++	ASSERT_INT_EQ(sshkey_generate(KEY_RSA, 2048, &k1), 0);
+ 	ASSERT_INT_EQ(sshkey_equal(kr, k1), 0);
+ 	sshkey_free(k1);
+ #ifdef OPENSSL_HAS_ECC
+@@ -461,6 +461,7 @@ sshkey_tests(void)
+ 	TEST_DONE();
+
+ #ifdef WITH_OPENSSL
++#ifndef FIPS_MODE
+ 	TEST_START("sign and verify RSA");
+ 	k1 = get_private("rsa_1");
+ 	ASSERT_INT_EQ(sshkey_load_public(test_data_file("rsa_2.pub"), &k2,
+@@ -487,6 +488,7 @@ sshkey_tests(void)
+ 	sshkey_free(k1);
+ 	sshkey_free(k2);
+ 	TEST_DONE();
++#endif /* FIPS_MODE */
+
+ #ifdef WITH_DSA
+ 	TEST_START("sign and verify DSA");
+@@ -521,6 +523,7 @@ sshkey_tests(void)
+ 	TEST_DONE();
+
+ #ifdef WITH_OPENSSL
++#ifndef FIPS_MODE
+ 	TEST_START("nested certificate");
+ 	ASSERT_INT_EQ(sshkey_load_cert(test_data_file("rsa_1"), &k1), 0);
+ 	ASSERT_INT_EQ(sshkey_load_public(test_data_file("rsa_1.pub"), &k2,
+@@ -535,5 +538,6 @@ sshkey_tests(void)
+ 	sshkey_free(k3);
+ 	sshbuf_free(b);
+ 	TEST_DONE();
++#endif /* FIPS_MODE */
+ #endif /* WITH_OPENSSL */
+ }
+diff --git a/regress/unittests/sshkey/testdata/rsa_1 b/regress/unittests/sshkey/testdata/rsa_1
+index 5de3f84..e27402e 100644
+--- a/regress/unittests/sshkey/testdata/rsa_1
++++ b/regress/unittests/sshkey/testdata/rsa_1
+@@ -1,15 +1,28 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIICXAIBAAKBgQDLV5lUTt7FrADseB/CGhEZzpoojjEW5y8+ePvLppmK3MmMI18u
+-d6vxzpK3bwZLYkVSyfJYI0HmIuGhdu7yMrW6wb84gbq8C31Xoe9EORcIUuGSvDKd
+-NSM1SjlhDquRblDFB8kToqXyx1lqrXecXylxIUOL0jE+u0rU1967pDJx+wIDAQAB
+-AoGAXyj5mpjmbD+YlxGIWz/zrM4hGsWgd4VteKEJxT6MMI4uzCRpkMd0ck8oHiwZ
+-GAI/SwUzIsgtONQuH3AXVsUgghW4Ynn+8ksEv0IZ918WDMDwqvqkyrVzsOsZzqYj
+-Pf8DUDKCpwFjnlknJ04yvWBZvVhWtY4OiZ8GV0Ttsu3k+GECQQD1YHfvBb5FdJBv
+-Uhde2Il+jaFia8mwVVNNaiD2ECxXx6CzGz54ZLEB9NPVfDUZK8lJ4UJDqelWNh3i
+-PF3RefWDAkEA1CVBzAFL4mNwpleVPzrfy69xP3gWOa26MxM/GE6zx9jC7HgQ3KPa
+-WKdG/FuHs085aTRDaDLmGcZ8IvMuu7NgKQJAcIOKmxR0Gd8IN7NZugjqixggb0Pj
+-mLKXXwESGiJyYtHL0zTj4Uqyi6Ya2GJ66o7UXscmnmYz828fJtTtZBdbRwJBALfi
+-C2QvA32Zv/0PEXibKXy996WSC4G3ShwXZKtHHKHvCxY5BDSbehk59VesZrVPyG2e
+-NYdOBxD0cIlCzJE56/ECQAndVkxvO8hwyEFGGwF3faHIAe/OxVb+MjaU25//Pe1/
+-h/e6tlCk4w9CODpyV685gV394eYwMcGDcIkipTNUDZs=
+------END RSA PRIVATE KEY-----
++-----BEGIN PRIVATE KEY-----
++MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDSPKJ5kN0YbOI2
++K3LZjpckfoi/TvGpDxhM3n07Kt8hjVc/Qp82D3mM0u36AapPvijLe7TYgJCQ/Ak+
++5e9dCpmt8Tg3UNu5IEpQil7wl23lW1d8aa38NYdP3CWpmxhGfuCRzAHO2kjkp5Fx
++PrwogCtoa5Y3L8Q7WBNjhLU3W+S2xlTRlH3en8tRx9jX32rv0BkqlZXieBOOQ+fD
++6xPfBG3jKyBPTEYeUsFoVPubI0e/WFC0tScIVrCXZv0tmLgQQBfge3H6IO/VYSaP
++fxYuis1iJwAbn0awFcSpL28xJ8tD/cN6RQNo37jUlZn9sMWrK9zVeFAzruEjYkHT
++OH5nPahXAgMBAAECggEAD9hcEoRIwnK3Ne5eY84SAo3uECUkcS54qv2vbv2TMm8s
++3tEbOMxy+wDAYn7GCRtdVCcvTfLN2O+PlTsCDswh7j2alA8ddr11STUa/lBOpK7j
++g0/5U5a60dnXLz17CrOJvDm/ZSMhXU831tL4nkDSt+lr7LestyBM2pi08JNiqiSN
++I3Hp4jcxNtFsKgvQ9kqvh+E+ZexseOJJfRQu4EmRRBbR2g2TR33H3easkuI8bv0i
++EmK/JnAbsH1q4ICgC8zizfEMoSPJEdMB8tfkh/5402Y8f+ldA6n9NlVFzE59kAYJ
++OcTqwFDzRRXO7zLSyzpSTypunuX1vZtuefvopToSAQKBgQD1y/FQ1e6BPAWJqHn0
++Od+XwS6JL5JpHy6B6NOLFsEIM2+dzQw2hX1myaeLaQBGTeck6xW4bNvwqWdvAJd1
++/iJdE69FGgZmoovSeuIzpvRfJ3tX/6a+k6mCn2sVS0BgURDXi6eYtORxlxjkgtUr
++6rVIIpWth1Au6Tx8RjZjWNd/VwKBgQDa9s0uX/JNFINkDtbCd65XLG7nGBCHIiRA
++1OETW1QekJ7qAX9QxcvhyI7F2WgLhxEG0/TT1BqaFblkYr7T0hIG0fJNNNTg3t4h
++WTXfX73xfu90AQGtki0gl6Bqxj4kt0LPBaZ7AagFsksbvIwIzni4LQF+oBEgzzTu
++qPxfOVZ/AQKBgQDTCILr8IGSG8J1al0qvvWmCYq25k1CTC9WAlx+Ms8RB3hxd7dg
++qEP+mGxtWX2O3xvxqpU/ftdnTUstFsjz2XoPh/MX1TxhqnV6BV9pEZMGj5Nq/mhf
++f9AuAkmiQrXG/FMFfTYr+kOY8y3AJER6LE3w3SC9mEvTuxTfbjkMGx8KiQKBgHd7
++yYcO0DeDhBcricFgcYAcPQBZv1seJE5EW/WmFob/P9hNrN20sYapXE9WTVJNB9uD
+++ctFqKaASEQhJiSMM04JboD23VtAAlKMTbtwkUOgkqXojrPaWkm4s87QEsUSQ6CY
++Yrooszk4i4e9IWUE1hcaaABi9DXFHAtHpz+HGE4BAoGAMLkRuIF1O0cc5iPTwzfQ
++R+jL1l6EP84A50KYTxoyDPqUfxmhJCWd23LfaT4o4+2dHKEVBDpTGSQjrRq/4dPU
++/+/du6Wkfmm7LqzeZCKgkZ0ukO+flbgQByyiT0PitEFvjZzeujrMrLrw3dbnFTS4
++WDeEfwZc0pXMNAGPzvnOlHY=
++-----END PRIVATE KEY-----
+\ No newline at end of file
+diff --git a/regress/unittests/sshkey/testdata/rsa_1.param.n b/regress/unittests/sshkey/testdata/rsa_1.param.n
+index 4933712..4263b83 100644
+--- a/regress/unittests/sshkey/testdata/rsa_1.param.n
++++ b/regress/unittests/sshkey/testdata/rsa_1.param.n
+@@ -1 +1 @@
+-00cb5799544edec5ac00ec781fc21a1119ce9a288e3116e72f3e78fbcba6998adcc98c235f2e77abf1ce92b76f064b624552c9f2582341e622e1a176eef232b5bac1bf3881babc0b7d57a1ef4439170852e192bc329d3523354a39610eab916e50c507c913a2a5f2c7596aad779c5f297121438bd2313ebb4ad4d7debba43271fb
++00d23ca27990dd186ce2362b72d98e97247e88bf4ef1a90f184cde7d3b2adf218d573f429f360f798cd2edfa01aa4fbe28cb7bb4d8809090fc093ee5ef5d0a99adf1383750dbb9204a508a5ef0976de55b577c69adfc35874fdc25a99b18467ee091cc01ceda48e4a791713ebc28802b686b96372fc43b58136384b5375be4b6c654d1947dde9fcb51c7d8d7df6aefd0192a9595e278138e43e7c3eb13df046de32b204f4c461e52c16854fb9b2347bf5850b4b5270856b09766fd2d98b8104017e07b71fa20efd561268f7f162e8acd6227001b9f46b015c4a92f6f3127cb43fdc37a450368dfb8d49599fdb0c5ab2bdcd5785033aee1236241d3387e673da857
+diff --git a/regress/unittests/sshkey/testdata/rsa_1.param.p b/regress/unittests/sshkey/testdata/rsa_1.param.p
+index 4783d21..41396d5 100644
+--- a/regress/unittests/sshkey/testdata/rsa_1.param.p
++++ b/regress/unittests/sshkey/testdata/rsa_1.param.p
+@@ -1 +1 @@
+-00f56077ef05be4574906f52175ed8897e8da1626bc9b055534d6a20f6102c57c7a0b31b3e7864b101f4d3d57c35192bc949e14243a9e956361de23c5dd179f583
++00f5cbf150d5ee813c0589a879f439df97c12e892f92691f2e81e8d38b16c108336f9dcd0c36857d66c9a78b6900464de724eb15b86cdbf0a9676f009775fe225d13af451a0666a28bd27ae233a6f45f277b57ffa6be93a9829f6b154b40605110d78ba798b4e4719718e482d52beab5482295ad87502ee93c7c46366358d77f57
+diff --git a/regress/unittests/sshkey/testdata/rsa_1.param.q b/regress/unittests/sshkey/testdata/rsa_1.param.q
+index 00fc8a2..86a2a34 100644
+--- a/regress/unittests/sshkey/testdata/rsa_1.param.q
++++ b/regress/unittests/sshkey/testdata/rsa_1.param.q
+@@ -1 +1 @@
+-00d42541cc014be26370a657953f3adfcbaf713f781639adba33133f184eb3c7d8c2ec7810dca3da58a746fc5b87b34f396934436832e619c67c22f32ebbb36029
++00daf6cd2e5ff24d1483640ed6c277ae572c6ee7181087222440d4e1135b541e909eea017f50c5cbe1c88ec5d9680b871106d3f4d3d41a9a15b96462bed3d21206d1f24d34d4e0dede215935df5fbdf17eef740101ad922d2097a06ac63e24b742cf05a67b01a805b24b1bbc8c08ce78b82d017ea01120cf34eea8fc5f39567f01
+diff --git a/regress/unittests/sshkey/testdata/rsa_2.pub b/regress/unittests/sshkey/testdata/rsa_2.pub
+index 3322fbc..98e6840 100644
+--- a/regress/unittests/sshkey/testdata/rsa_2.pub
++++ b/regress/unittests/sshkey/testdata/rsa_2.pub
+@@ -1 +1 @@
+-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD00RRenvxICSYvj54CPiYHM86OT5xwI9XORNH6Zkl3JPCQkAEdQ3hyfhraROaHsSv43wJcKyKrEg5XUZ8fZ/BoKIGU4Rd5AmL9wyPGv2RVY7gWELqXVSpu89R2tQJRmMVMD38CH0wqCTuoZirlKMTen6yfgYuFEpuqar0uOIeAyaQG6/9rVKWK36tcfM7YXx8fmGSN4eK/JhWDDjlo28YJ7ZFF9umh5baZG2Ai/vL3BJ7C3pqaEQNdKj8XqaSoDvFWKfOujk1620Rcuj3W0D0dvp/rH8xz8YkM1dMqGlYIZ4nrF5acB58Nk5FYBjtj1hu4DGEQlWL1Avk1agU4DQLr RSA test key #2
++ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPKJ5kN0YbOI2K3LZjpckfoi/TvGpDxhM3n07Kt8hjVc/Qp82D3mM0u36AapPvijLe7TYgJCQ/Ak+5e9dCpmt8Tg3UNu5IEpQil7wl23lW1d8aa38NYdP3CWpmxhGfuCRzAHO2kjkp5FxPrwogCtoa5Y3L8Q7WBNjhLU3W+S2xlTRlH3en8tRx9jX32rv0BkqlZXieBOOQ+fD6xPfBG3jKyBPTEYeUsFoVPubI0e/WFC0tScIVrCXZv0tmLgQQBfge3H6IO/VYSaPfxYuis1iJwAbn0awFcSpL28xJ8tD/cN6RQNo37jUlZn9sMWrK9zVeFAzruEjYkHTOH5nPahX RSA test key #2


### PR DESCRIPTION
This patch adds FIPS testing support for openssh `V_10_0_P2`. It disables rsa tests with keys 1024 and also changes the default key to a 2048 fips compliant key. For now I have disabled most of the rsa operations that need certain keys other than the `rsa_1` and `rsa_2.pub` in the tests. You can enable `FIPS_MODE=1` and this will disable the out of boundary tests.