### PR TITLE
openssh: add compile time message about necessary config

### DIFF
--- a/openssh-patches/openssh-10.0p2.patch
+++ b/openssh-patches/openssh-10.0p2.patch
@@ -1,4 +1,4 @@
-From 1bc48b0bd5ec1fe5d9aee7b761c736c10d26989c Mon Sep 17 00:00:00 2001
+From 3cef05d622d63b642fd7a3abd5728893240b9b6b Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Mon, 26 May 2025 13:26:59 +0200
 Subject: [PATCH] 10.0p2 patch for wolfSSL
@@ -32,10 +32,10 @@ make tests
  config.h.in                                 |  41 +++-
  configure.ac                                | 211 +++++++++++++++++++-
  includes.h                                  |   6 +
- log.c                                       |  45 +++++
+ log.c                                       |  46 +++++
  openbsd-compat/openssl-compat.c             |   3 +
  regress/unittests/test_helper/test_helper.c |   5 +
- 9 files changed, 310 insertions(+), 7 deletions(-)
+ 9 files changed, 311 insertions(+), 7 deletions(-)
 
 diff --git a/Makefile.in b/Makefile.in
 index 4617cebcd..03fba6469 100644
@@ -504,7 +504,7 @@ index 8f933568d..ad612446f 100644
  #include <openssl/opensslv.h> /* For OPENSSL_VERSION_NUMBER */
  #endif
 diff --git a/log.c b/log.c
-index 6617f2672..891af621d 100644
+index 6617f2672..0f0436f0d 100644
 --- a/log.c
 +++ b/log.c
 @@ -188,6 +188,40 @@ log_verbose_reset(void)
@@ -548,7 +548,7 @@ index 6617f2672..891af621d 100644
  /*
   * Initialize the log.
   */
-@@ -202,6 +236,17 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
+@@ -202,6 +236,18 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
  
  	argv0 = av0;
  
@@ -558,8 +558,9 @@ index 6617f2672..891af621d 100644
 +    wolfSSL_Debugging_ON();
 +    wolfSSL_SetLoggingCb(Logging_cb);
 +    wolfSSL_Init();
++#ifndef WC_RNG_SEED_CB
++#error wolfSSL needs to be built with WC_RNG_SEED_CB
 +#endif
-+#ifdef WC_RNG_SEED_CB
 +    wc_SetSeed_Cb(wolf_seed);
 +#endif
 +

--- a/openssh-patches/openssh-9.6.patch
+++ b/openssh-patches/openssh-9.6.patch
@@ -1,4 +1,4 @@
-From b0a960e857e710e1bdc296025a7a54e6eb427113 Mon Sep 17 00:00:00 2001
+From 38f8965cd5333795a13dca1e5361ffb3dda76d02 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Thu, 18 Jan 2024 13:58:48 +0100
 Subject: [PATCH] Patch for wolfSSL
@@ -34,12 +34,11 @@ Signed-off-by: Juliusz Sosinowicz <juliusz@wolfssl.com>
  Makefile.in                                 |   1 +
  cipher.c                                    |   3 +-
  configure.ac                                | 211 +++++++++++++++++++-
- entropy.c                                   |   4 +
  includes.h                                  |   6 +
- log.c                                       |  43 ++++
+ log.c                                       |  44 ++++
  regress/unittests/test_helper/test_helper.c |   5 +
  ssh-rsa.c                                   |  11 +
- 8 files changed, 280 insertions(+), 4 deletions(-)
+ 7 files changed, 277 insertions(+), 4 deletions(-)
 
 diff --git a/Makefile.in b/Makefile.in
 index 1efe11f6f..3bb8b989e 100644
@@ -367,21 +366,6 @@ index 379cd746b..5def42d73 100644
 +    echo "---"
 +    echo ""
 +fi
-diff --git a/entropy.c b/entropy.c
-index 842c66fd6..80622fdd8 100644
---- a/entropy.c
-+++ b/entropy.c
-@@ -66,6 +66,10 @@ seed_rng(void)
- 	/* Initialise libcrypto */
- 	ssh_libcrypto_init();
- 
-+#ifdef WC_RNG_SEED_CB
-+    wc_SetSeed_Cb(wc_GenerateSeed);
-+#endif
-+
- 	if (!ssh_compatible_openssl(OPENSSL_VERSION_NUMBER,
- 	    OpenSSL_version_num()))
- 		fatal("OpenSSL version mismatch. Built against %lx, you "
 diff --git a/includes.h b/includes.h
 index 6d17ef6da..97197532c 100644
 --- a/includes.h
@@ -400,7 +384,7 @@ index 6d17ef6da..97197532c 100644
  #include <openssl/opensslv.h> /* For OPENSSL_VERSION_NUMBER */
  #endif
 diff --git a/log.c b/log.c
-index 9fc1a2e2e..4e7c63734 100644
+index 9fc1a2e2e..0baf0f9c5 100644
 --- a/log.c
 +++ b/log.c
 @@ -186,6 +186,40 @@ log_verbose_reset(void)
@@ -444,7 +428,7 @@ index 9fc1a2e2e..4e7c63734 100644
  /*
   * Initialize the log.
   */
-@@ -200,6 +234,15 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
+@@ -200,6 +234,16 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
  
  	argv0 = av0;
  
@@ -452,8 +436,9 @@ index 9fc1a2e2e..4e7c63734 100644
 +    wolfSSL_Debugging_ON();
 +    wolfSSL_SetLoggingCb(Logging_cb);
 +    wolfSSL_Init();
++#ifndef WC_RNG_SEED_CB
++#error wolfSSL needs to be built with WC_RNG_SEED_CB
 +#endif
-+#ifdef WC_RNG_SEED_CB
 +    wc_SetSeed_Cb(wolf_seed);
 +#endif
 +

--- a/openssh-patches/openssh-9.9p2.patch
+++ b/openssh-patches/openssh-9.9p2.patch
@@ -1,4 +1,4 @@
-From be5ce50735ccf895a3c0dbcd7fcdd5aca91fffcc Mon Sep 17 00:00:00 2001
+From 01a673d8b3f0fc3f1eed817b6982c8e8b5d80b53 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Tue, 11 Mar 2025 14:17:17 +0100
 Subject: [PATCH] 9.9p2 patch for wolfSSL
@@ -32,10 +32,10 @@ make tests
  config.h.in                                 |  41 +++-
  configure.ac                                | 211 +++++++++++++++++++-
  includes.h                                  |   6 +
- log.c                                       |  45 +++++
+ log.c                                       |  46 +++++
  openbsd-compat/openssl-compat.c             |   3 +
  regress/unittests/test_helper/test_helper.c |   5 +
- 9 files changed, 310 insertions(+), 7 deletions(-)
+ 9 files changed, 311 insertions(+), 7 deletions(-)
 
 diff --git a/Makefile.in b/Makefile.in
 index 4243006b0..709f29793 100644
@@ -501,7 +501,7 @@ index 6d17ef6da..97197532c 100644
  #include <openssl/opensslv.h> /* For OPENSSL_VERSION_NUMBER */
  #endif
 diff --git a/log.c b/log.c
-index 23ad10c02..4df34a901 100644
+index 23ad10c02..42c592f82 100644
 --- a/log.c
 +++ b/log.c
 @@ -186,6 +186,40 @@ log_verbose_reset(void)
@@ -545,7 +545,7 @@ index 23ad10c02..4df34a901 100644
  /*
   * Initialize the log.
   */
-@@ -200,6 +234,17 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
+@@ -200,6 +234,18 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
  
  	argv0 = av0;
  
@@ -555,8 +555,9 @@ index 23ad10c02..4df34a901 100644
 +    wolfSSL_Debugging_ON();
 +    wolfSSL_SetLoggingCb(Logging_cb);
 +    wolfSSL_Init();
++#ifndef WC_RNG_SEED_CB
++#error wolfSSL needs to be built with WC_RNG_SEED_CB
 +#endif
-+#ifdef WC_RNG_SEED_CB
 +    wc_SetSeed_Cb(wolf_seed);
 +#endif
 +


### PR DESCRIPTION
Removes entropy.c patch in 9.6.patch as this is no longer required.
