### PR TITLE
add patch for xmlsec testing with wolfProvider

### DIFF
--- a/wolfProvider/xmlsec/README.md
+++ b/wolfProvider/xmlsec/README.md
@@ -1,0 +1,2 @@
+patch `xmlsec-master-wolfprov.patch` disables tests in master branch that uses RSA 512-bit key sizes which wolfProvider doesn't support.
+patch `xmlsec-xmlsec-1_2_37-wolfprov.patch` disables tests in xmlsec-1_2_37 branch that uses RSA 512-bit key sizes and RC2 algorithms which wolfProvider doesn't support.

--- a/wolfProvider/xmlsec/README.md
+++ b/wolfProvider/xmlsec/README.md
@@ -1,2 +1,3 @@
 patch `xmlsec-master-wolfprov.patch` disables tests in master branch that uses RSA 512-bit key sizes which wolfProvider doesn't support.
 patch `xmlsec-xmlsec-1_2_37-wolfprov.patch` disables tests in xmlsec-1_2_37 branch that uses RSA 512-bit key sizes and RC2 algorithms which wolfProvider doesn't support.
+The two FIPS patches disable tests that use non-FIPS algorithms

--- a/wolfProvider/xmlsec/xmlsec-FIPS-master-wolfprov.patch
+++ b/wolfProvider/xmlsec/xmlsec-FIPS-master-wolfprov.patch
@@ -1,0 +1,824 @@
+diff --git a/tests/testEnc.sh b/tests/testEnc.sh
+index 6ca08e3e..a0c44949 100755
+--- a/tests/testEnc.sh
++++ b/tests/testEnc.sh
+@@ -48,44 +48,6 @@ execEncTest $res_success \
+     "--aeskey:mykey $topfolder/xmlenc11-interop-2012/xenc11-example-AES128-GCM.key --binary-data $topfolder/xmlenc11-interop-2012/xenc11-example-AES128-GCM.data" \
+     "--aeskey:mykey $topfolder/xmlenc11-interop-2012/xenc11-example-AES128-GCM.key"
+ 
+-if [ "z$xmlsec_feature_rsa_oaep_different_digest_and_mgf1" = "zyes" ] ; then
+-    execEncTest $res_success \
+-        "" \
+-        "xmlenc11-interop-2012/cipherText__RSA-2048__aes128-gcm__rsa-oaep-mgf1p" \
+-        "aes128-gcm rsa-oaep-mgf1p sha256 sha1" \
+-        "" \
+-        "$priv_key_option:TestRsa2048Key $topfolder/xmlenc11-interop-2012/RSA-2048_SHA256WithRSA.$priv_key_format --pwd passwd" \
+-        "$priv_key_option:TestRsa2048Key $topfolder/xmlenc11-interop-2012/RSA-2048_SHA256WithRSA.$priv_key_format --pwd passwd --session-key aes-128 --xml-data $topfolder/xmlenc11-interop-2012/cipherText__RSA-2048__aes128-gcm__rsa-oaep-mgf1p.data"  \
+-        "$priv_key_option:TestRsa2048Key $topfolder/xmlenc11-interop-2012/RSA-2048_SHA256WithRSA.$priv_key_format --pwd passwd"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "xmlenc11-interop-2012/cipherText__RSA-3072__aes192-gcm__rsa-oaep-mgf1p__Sha256" \
+-        "aes192-gcm rsa-oaep-mgf1p sha256 sha1" \
+-        "" \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-3072_SHA256WithRSA.$priv_key_format --pwd passwd" \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-3072_SHA256WithRSA.$priv_key_format --pwd passwd --session-key aes-192 --xml-data $topfolder/xmlenc11-interop-2012/cipherText__RSA-3072__aes192-gcm__rsa-oaep-mgf1p__Sha256.data"  \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-3072_SHA256WithRSA.$priv_key_format --pwd passwd"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "xmlenc11-interop-2012/cipherText__RSA-3072__aes256-gcm__rsa-oaep__Sha384-MGF_Sha1" \
+-        "aes256-gcm rsa-oaep-mgf1p sha384 sha1" \
+-        "" \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-3072_SHA256WithRSA.$priv_key_format --pwd passwd" \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-3072_SHA256WithRSA.$priv_key_format --pwd passwd --session-key aes-256 --xml-data $topfolder/xmlenc11-interop-2012/cipherText__RSA-3072__aes256-gcm__rsa-oaep__Sha384-MGF_Sha1.data"  \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-3072_SHA256WithRSA.$priv_key_format --pwd passwd"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "xmlenc11-interop-2012/cipherText__RSA-4096__aes256-gcm__rsa-oaep__Sha512-MGF_Sha1_PSource" \
+-        "aes256-gcm rsa-oaep-mgf1p sha512 sha1" \
+-        "" \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-4096_SHA256WithRSA.$priv_key_format --pwd passwd" \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-4096_SHA256WithRSA.$priv_key_format --pwd passwd --session-key aes-256 --xml-data $topfolder/xmlenc11-interop-2012/cipherText__RSA-4096__aes256-gcm__rsa-oaep__Sha512-MGF_Sha1_PSource.data"  \
+-        "$priv_key_option:TestRsa3072Key $topfolder/xmlenc11-interop-2012/RSA-4096_SHA256WithRSA.$priv_key_format --pwd passwd"
+-fi
+-
+ # ConcatCDF
+ execEncTest $res_success \
+     "" \
+@@ -105,26 +67,6 @@ execEncTest $res_success \
+     "--concatkdf-key:dkey3 $topfolder/xmlenc11-interop-2012/dkey3-concatkdf.bin --binary $topfolder/xmlenc11-interop-2012/dkey3-example-ConcatKDF-crypto.data" \
+     "--concatkdf-key:dkey3 $topfolder/xmlenc11-interop-2012/dkey3-concatkdf.bin"
+ 
+-# PBKDF2
+-execEncTest $res_success \
+-    "" \
+-    "xmlenc11-interop-2012/dkey-example-PBKDF2-crypto" \
+-    "aes256-cbc pbkdf2 sha256" \
+-    "derived-key" \
+-    "--pbkdf2-key:dkey-pbkdf2 $topfolder/xmlenc11-interop-2012/dkey-pbkdf2.bin" \
+-    "--pbkdf2-key:dkey-pbkdf2 $topfolder/xmlenc11-interop-2012/dkey-pbkdf2.bin --binary $topfolder/xmlenc11-interop-2012/dkey-example-PBKDF2-crypto.data" \
+-    "--pbkdf2-key:dkey-pbkdf2 $topfolder/xmlenc11-interop-2012/dkey-pbkdf2.bin"
+-
+-execEncTest $res_success \
+-    "" \
+-    "xmlenc11-interop-2012/dkey3-example-PBKDF2-crypto" \
+-    "aes256-cbc pbkdf2 sha256" \
+-    "derived-key" \
+-    "--pbkdf2-key:dkey3-pbkdf2 $topfolder/xmlenc11-interop-2012/dkey3-pbkdf2.bin" \
+-    "--pbkdf2-key:dkey3-pbkdf2 $topfolder/xmlenc11-interop-2012/dkey3-pbkdf2.bin --binary $topfolder/xmlenc11-interop-2012/dkey3-example-PBKDF2-crypto.data" \
+-    "--pbkdf2-key:dkey3-pbkdf2 $topfolder/xmlenc11-interop-2012/dkey3-pbkdf2.bin"
+-
+-
+ # ECDH-ES
+ execEncTest $res_success \
+     "" \
+@@ -255,228 +197,6 @@ execEncTest $res_success \
+     "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec --session-key aes-256 $priv_key_option:originator-key-name $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123 $pub_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$pub_key_format --xml-data $topfolder/aleksey-xmlenc-01/enc_ecdh_p256_concatkdf_sha3_512_kw_aes256_aes128gcm.data" \
+     "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123"
+ 
+-# ECDH + PBKDF2+SHA1
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha1_kw_aes256_aes128gcm" \
+-    "aes256-gcm kw-aes256 ecdh-es pbkdf2 hmac-sha1" \
+-    "agreement-method enc-key ec" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec --session-key aes-256 $priv_key_option:originator-key-name $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123 $pub_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$pub_key_format --xml-data $topfolder/aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha1_kw_aes256_aes128gcm.data" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123"
+-
+-# ECDH + PBKDF2+SHA2
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha224_kw_aes256_aes128gcm" \
+-    "aes256-gcm kw-aes256 ecdh-es pbkdf2 hmac-sha224" \
+-    "agreement-method enc-key ec" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec --session-key aes-256 $priv_key_option:originator-key-name $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123 $pub_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$pub_key_format --xml-data $topfolder/aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha224_kw_aes256_aes128gcm.data" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha256_kw_aes256_aes128gcm" \
+-    "aes256-gcm kw-aes256 ecdh-es pbkdf2 hmac-sha256" \
+-    "agreement-method enc-key ec" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec --session-key aes-256 $priv_key_option:originator-key-name $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123 $pub_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$pub_key_format --xml-data $topfolder/aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha256_kw_aes256_aes128gcm.data" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha384_kw_aes256_aes128gcm" \
+-    "aes256-gcm kw-aes256 ecdh-es pbkdf2 hmac-sha384" \
+-    "agreement-method enc-key ec" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec --session-key aes-256 $priv_key_option:originator-key-name $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123 $pub_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$pub_key_format --xml-data $topfolder/aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha384_kw_aes256_aes128gcm.data" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha512_kw_aes256_aes128gcm" \
+-    "aes256-gcm kw-aes256 ecdh-es pbkdf2 hmac-sha512" \
+-    "agreement-method enc-key ec" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec --session-key aes-256 $priv_key_option:originator-key-name $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123 $pub_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$pub_key_format --xml-data $topfolder/aleksey-xmlenc-01/enc_ecdh_p256_pbkdf2_1000_hmac_sha512_kw_aes256_aes128gcm.data" \
+-    "--enabled-key-data agreement-method,enc-key,key-name,key-value,ec $priv_key_option:recipient-key-name $topfolder/keys/ecdsa-secp256r1-second-key.$priv_key_format --pwd secret123"
+-
+-if [ "z$xmlsec_feature_x509_data_lookup" = "zyes" ] ; then
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_subject_name" \
+-        "aes256-cbc rsa-1_5" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_subject_name.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_issuer_name_serial" \
+-        "aes256-cbc rsa-1_5" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_issuer_name_serial.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_ski" \
+-        "aes256-cbc rsa-1_5" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_ski.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha1" \
+-        "aes256-cbc rsa-1_5 sha1" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha1.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha224" \
+-        "aes256-cbc rsa-1_5 sha224" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha224.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha256" \
+-        "aes256-cbc rsa-1_5 sha256" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha256.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha384" \
+-        "aes256-cbc rsa-1_5 sha384" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha384.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha512" \
+-        "aes256-cbc rsa-1_5 sha512" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha512.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_224" \
+-        "aes256-cbc rsa-1_5 sha3-224" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_224.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_256" \
+-        "aes256-cbc rsa-1_5 sha3-256" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_256.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_384" \
+-        "aes256-cbc rsa-1_5 sha3-384" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_384.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_512" \
+-        "aes256-cbc rsa-1_5 sha3-512" \
+-        "x509" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "--session-key aes-256 --pubkey-cert-$cert_format $topfolder/keys/largersacert.$cert_format --xml-data $topfolder/aleksey-xmlenc-01/enc_rsa_1_5_x509_digest_sha3_512.data --node-name http://example.org/paymentv2:CreditCard" \
+-        "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-fi
+-
+-# same file is encrypted with two keys, test both
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123"
+-
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/large_input" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:my-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/large_input.data --pubkey-cert-$cert_format:my-key $topfolder/keys/largersacert.$cert_format" \
+-    "$priv_key_option:my-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-element-isolatin1" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:my-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-element-isolatin1.data --pubkey-cert-$cert_format:my-key $topfolder/keys/largersacert.$cert_format" \
+-    "$priv_key_option:my-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-content-isolatin1" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:my-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-content-isolatin1.data --node-name http://example.org/paymentv2:CreditCard --pubkey-cert-$cert_format:my-key $topfolder/keys/largersacert.$cert_format" \
+-    "$priv_key_option:my-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname" \
+-    "tripledes-cbc" \
+-    "" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $topfolder/keys/keys.xml --binary-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname.data" \
+-    "--keys-file $topfolder/keys/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname2" \
+-    "tripledes-cbc" \
+-    "" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $topfolder/keys/keys.xml --binary-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname2.data" \
+-    "--keys-file $topfolder/keys/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "aleksey-xmlenc-01/enc-aes128cbc-keyname" \
+@@ -520,60 +240,6 @@ execEncTest $res_success \
+     "--keys-file $topfolder/keys/keys.xml --binary-data $topfolder/aleksey-xmlenc-01/enc-aes256cbc-keyname.data" \
+     "--keys-file $topfolder/keys/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname-content" \
+-    "tripledes-cbc" \
+-    " " \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $topfolder/keys/keys.xml --xml-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname-content.data --node-id Test" \
+-    "--keys-file $topfolder/keys/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname-element" \
+-    "tripledes-cbc" \
+-    " " \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $topfolder/keys/keys.xml --xml-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname-element.data --node-id Test" \
+-    "--keys-file $topfolder/keys/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname-element-root" \
+-    "tripledes-cbc" \
+-    " " \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $topfolder/keys/keys.xml --xml-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname-element-root.data --node-id Test" \
+-    "--keys-file $topfolder/keys/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-aes192-keyname" \
+-    "tripledes-cbc kw-aes192" \
+-    "enc-key aes des" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $topfolder/keys/keys.xml  --session-key des-192  --binary-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-aes192-keyname.data" \
+-    "--keys-file $topfolder/keys/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params" \
+-    "aes256-cbc rsa-oaep-mgf1p sha1" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1" \
+-    "aes256-cbc rsa-oaep-mgf1p sha1 sha1" \
+-    " " \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+ if [ "z$xmlsec_feature_rsa_oaep_different_digest_and_mgf1" = "zyes" ] ; then
+     # various digest and default mgf1 (sha1)
+     execEncTest $res_success \
+@@ -594,42 +260,6 @@ if [ "z$xmlsec_feature_rsa_oaep_different_digest_and_mgf1" = "zyes" ] ; then
+         "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_ripemd160.data --node-name http://example.org/paymentv2:CreditCard"  \
+         "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+ 
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha224" \
+-        "aes256-cbc rsa-oaep-mgf1p sha224 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha224.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha256" \
+-        "aes256-cbc rsa-oaep-mgf1p sha256 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha256.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha384" \
+-        "aes256-cbc rsa-oaep-mgf1p sha384 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha384.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512" \
+-        "aes256-cbc rsa-oaep-mgf1p sha512 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+     # various digest and mgf1=sha512
+     execEncTest $res_success \
+         "" \
+@@ -648,159 +278,8 @@ if [ "z$xmlsec_feature_rsa_oaep_different_digest_and_mgf1" = "zyes" ] ; then
+         "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+         "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_ripemd160_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+         "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1_mgf1_sha512" \
+-        "aes256-cbc rsa-oaep-mgf1p sha1 sha512" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha224_mgf1_sha512" \
+-        "aes256-cbc rsa-oaep-mgf1p sha224 sha512" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha224_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha256_mgf1_sha512" \
+-        "aes256-cbc rsa-oaep-mgf1p sha256 sha512" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha256_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha384_mgf1_sha512" \
+-        "aes256-cbc rsa-oaep-mgf1p sha384 sha512" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha384_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    # digest=sha512 and various mgf1
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha1" \
+-        "aes256-cbc rsa-oaep-mgf1p sha512 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha224" \
+-        "aes256-cbc rsa-oaep-mgf1p sha512 sha224" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha224.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha256" \
+-        "aes256-cbc rsa-oaep-mgf1p sha512 sha256" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha256.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha384" \
+-        "aes256-cbc rsa-oaep-mgf1p sha512 sha384" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha384.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+ fi
+ 
+-# same diges for both digest and MGF1
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1_mgf1_sha1" \
+-    "aes256-cbc rsa-oaep-mgf1p sha1 sha1" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1_mgf1_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-if [ "z$xmlsec_feature_rsa_oaep_non_sha1" = "zyes" ] ; then
+-    # same diges for both digest and MGF1
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha224_mgf1_sha224" \
+-        "aes256-cbc rsa-oaep-mgf1p sha224 sha224" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha224_mgf1_sha224.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha256_mgf1_sha256" \
+-        "aes256-cbc rsa-oaep-mgf1p sha256 sha256" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha256_mgf1_sha256.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha384_mgf1_sha384" \
+-        "aes256-cbc rsa-oaep-mgf1p sha384 sha384" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha384_mgf1_sha384.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha512" \
+-        "aes256-cbc rsa-oaep-mgf1p sha512 sha512" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha512_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-    # RSA OAEP XMLEnc 1.1 transform (exactly same as 1.0 but different URL)
+-    execEncTest $res_success \
+-        "" \
+-        "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_enc11_sha512_mgf1_sha512" \
+-        "aes256-cbc rsa-oaep-enc11 sha512 sha512" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name,enc-key --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_enc11_sha512_mgf1_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-fi
+-
+-# same test but decrypt using two different keys
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-recipients" \
+-    "tripledes-cbc rsa-1_5" \
+-    "x509" \
+-    "--lax-key-search $priv_key_option:pub1 $topfolder/keys/rsakey.$priv_key_format --pwd secret123" \
+-    "--pubkey-cert-$cert_format:pub1 $topfolder/keys/rsacert.$cert_format --pubkey-cert-$cert_format:pub2 $topfolder/keys/largersacert.$cert_format --session-key des-192 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-recipients.data" \
+-    "--lax-key-search $priv_key_option:pub1 $topfolder/keys/rsakey.$priv_key_format --pwd secret123"
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-recipients" \
+-    "tripledes-cbc rsa-1_5" \
+-    "x509" \
+-    "--lax-key-search $priv_key_option:pub1 $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "--pubkey-cert-$cert_format:pub1 $topfolder/keys/rsacert.$cert_format --pubkey-cert-$cert_format:pub2 $topfolder/keys/largersacert.$cert_format --session-key des-192 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-recipients.data" \
+-    "--lax-key-search $priv_key_option:pub1 $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-
+ ##########################################################################
+ #
+ # merlin-xmlenc-five
+@@ -816,15 +295,6 @@ execEncTest $res_success \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-aes128-cbc.data" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-content-tripledes-cbc" \
+-    "tripledes-cbc" \
+-    "" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/merlin-xmlenc-five/encrypt-content-tripledes-cbc.data --node-id Payment" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-content-aes256-cbc-prop" \
+@@ -841,44 +311,6 @@ execEncTest $res_success \
+     "" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-element-aes128-cbc-rsa-1_5" \
+-    "aes128-cbc rsa-1_5" \
+-    "" \
+-    "--lax-key-search $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret --verification-gmt-time 2003-01-01+10:00:00" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-128 $priv_key_option:mykey $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --xml-data $topfolder/merlin-xmlenc-five/encrypt-element-aes128-cbc-rsa-1_5.data --node-id Purchase --pwd secret"  \
+-    "$priv_key_option:mykey $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p" \
+-    "tripledes-cbc rsa-oaep-mgf1p sha1" \
+-    "" \
+-    "--lax-key-search $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key des-192 $priv_key_option:mykey $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p.data --pwd secret"  \
+-    "$priv_key_option:mykey $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-
+-if [ "z$xmlsec_feature_rsa_oaep_different_digest_and_mgf1" = "zyes" ] ; then
+-    execEncTest $res_success \
+-        "" \
+-        "merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p-sha256" \
+-        "tripledes-cbc rsa-oaep-mgf1p sha256 sha1" \
+-        "" \
+-        "--lax-key-search $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret" \
+-        "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key des-192 $priv_key_option:mykey $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p-sha256.data --pwd secret"  \
+-        "$priv_key_option:mykey $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-fi
+-
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-data-aes256-cbc-kw-tripledes" \
+-    "aes256-cbc kw-tripledes" \
+-    "" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-256 --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-aes256-cbc-kw-tripledes.data" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-content-aes128-cbc-kw-aes192" \
+@@ -897,15 +329,6 @@ execEncTest $res_success \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-192 --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-aes192-cbc-kw-aes256.data" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-element-tripledes-cbc-kw-aes128" \
+-    "tripledes-cbc kw-aes128" \
+-    "" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml  --session-key des-192 --node-name urn:example:po:PaymentInfo --xml-data $topfolder/merlin-xmlenc-five/encrypt-element-tripledes-cbc-kw-aes128.data" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-element-aes256-cbc-retrieved-kw-aes256" \
+@@ -929,90 +352,6 @@ execEncTest $res_success \
+ #
+ ##########################################################################
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kt-rsa1_5" \
+-    "tripledes-cbc rsa-1_5" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha1" \
+-    "tripledes-cbc rsa-oaep-mgf1p sha1 sha1" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-if [ "z$xmlsec_feature_rsa_oaep_different_digest_and_mgf1" = "zyes" ] ; then
+-    execEncTest $res_success \
+-        "" \
+-        "01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha256" \
+-        "tripledes-cbc rsa-oaep-mgf1p sha256 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-        "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha256.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-    execEncTest $res_success \
+-        "" \
+-        "01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha512" \
+-        "tripledes-cbc rsa-oaep-mgf1p sha512 sha1" \
+-        "" \
+-        "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-        "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha512.data --node-name http://example.org/paymentv2:CreditCard"  \
+-        "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-fi
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes128-kt-rsa1_5" \
+-    "aes128-cbc rsa-1_5" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes128-kt-rsa_oaep_sha1" \
+-    "aes128-cbc rsa-oaep-mgf1p sha1 sha1" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes192-kt-rsa_oaep_sha1" \
+-    "aes192-cbc rsa-oaep-mgf1p sha1 sha1" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes192-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-aes192-kt-rsa1_5" \
+-    "aes192-cbc rsa-1_5" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-aes192-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-aes256-kt-rsa1_5" \
+-    "aes256-cbc rsa-1_5" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-aes256-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-
+ extra_message="Negative test: missing key"
+ execEncTest $res_fail \
+     "" \
+@@ -1021,33 +360,6 @@ execEncTest $res_fail \
+     "" \
+     "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-retrieval-method-uris empty"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-aes256-kt-rsa_oaep_sha1" \
+-    "aes256-cbc rsa-oaep-mgf1p sha1  sha1" \
+-    "" \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-aes256-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kw-3des" \
+-    "tripledes-cbc kw-tripledes" \
+-    "" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kw-3des.data --node-name http://example.org/paymentv2:CreditCard" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-aes128-kw-3des" \
+-    "aes128-cbc kw-tripledes" \
+-    "" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-aes128-kw-3des.data --node-name http://example.org/paymentv2:CreditCard" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-element-aes128-kw-aes128" \
+@@ -1066,15 +378,6 @@ execEncTest $res_success \
+     "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kw-aes256.data --node-name http://example.org/paymentv2:CreditCard" \
+     "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-3des-kw-aes192" \
+-    "tripledes-cbc kw-aes192" \
+-    "" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-3des-kw-aes192.data --node-name http://example.org/paymentv2:CreditCard" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-content-aes192-kw-aes256" \
+@@ -1102,15 +405,6 @@ execEncTest $res_success \
+     "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes256-kw-aes256.data --node-name http://example.org/paymentv2:CreditCard" \
+     "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-3des-kw-aes256" \
+-    "tripledes-cbc kw-aes256" \
+-    "" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name,enc-key --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-3des-kw-aes256.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-text-aes128-kw-aes192" \
+diff --git a/tests/testKeys.sh b/tests/testKeys.sh
+index 980c2b38..b351c1ce 100755
+--- a/tests/testKeys.sh
++++ b/tests/testKeys.sh
+@@ -34,16 +34,6 @@ execKeysTest $res_success   \
+     "test-hmac-sha1"        \
+     "hmac-192"
+ 
+-execKeysTest $res_success       \
+-    "rsa"                       \
+-    "test-rsa"                  \
+-    "rsa-1024"                  \
+-    "$topfolder/keys/largersakey$priv_key_suffix"    \
+-    "$topfolder/keys/largersapubkey" \
+-    "$topfolder/keys/largersacert"   \
+-    "$topfolder/aleksey-xmldsig-01/enveloped-sha1-rsa-sha1" \
+-    "--pwd secret123 --enabled-key-data key-name"
+-
+ execKeysTest $res_success       \
+     "dsa"                       \
+     "test-dsa"                  \

--- a/wolfProvider/xmlsec/xmlsec-FIPS-xmlsec-1_2_37-wolfprov.patch
+++ b/wolfProvider/xmlsec/xmlsec-FIPS-xmlsec-1_2_37-wolfprov.patch
@@ -1,0 +1,308 @@
+diff --git a/tests/testEnc.sh b/tests/testEnc.sh
+index e715a6ff..61870565 100755
+--- a/tests/testEnc.sh
++++ b/tests/testEnc.sh
+@@ -30,38 +30,6 @@ echo "--------- Positive Testing ----------"
+ ##########################################################################
+ 
+ # same file is encrypted with two keys, test both
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname" \
+-    "tripledes-cbc" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $keysfile --binary-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname.data" \
+-    "--keys-file $keysfile"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname2" \
+-    "tripledes-cbc" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $keysfile --binary-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname2.data" \
+-    "--keys-file $keysfile"
+-
+ execEncTest $res_success \
+     "" \
+     "aleksey-xmlenc-01/enc-aes128cbc-keyname" \
+@@ -92,62 +60,6 @@ execEncTest $res_success \
+     "--keys-file $keysfile --binary-data $topfolder/aleksey-xmlenc-01/enc-aes256cbc-keyname.data" \
+     "--keys-file $keysfile"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname-content" \
+-    "tripledes-cbc" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $keysfile --xml-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname-content.data --node-id Test" \
+-    "--keys-file $keysfile"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname-element" \
+-    "tripledes-cbc" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $keysfile --xml-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname-element.data --node-id Test" \
+-    "--keys-file $keysfile"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-keyname-element-root" \
+-    "tripledes-cbc" \
+-    "--keys-file $topfolder/keys/keys.xml" \
+-    "--keys-file $keysfile --xml-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-keyname-element-root.data --node-id Test" \
+-    "--keys-file $keysfile"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-des3cbc-aes192-keyname" \
+-    "tripledes-cbc kw-aes192" \
+-    "--keys-file $topfolder/keys/keys.xml --enabled-key-data key-name,enc-key" \
+-    "--keys-file $keysfile  --session-key des-192  --binary-data $topfolder/aleksey-xmlenc-01/enc-des3cbc-aes192-keyname.data" \
+-    "--keys-file $keysfile"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params" \
+-    "aes256-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+-# same test but decrypt using two different keys
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-recipients" \
+-    "tripledes-cbc rsa-1_5" \
+-    "$priv_key_option:pub1 $topfolder/keys/rsakey.$priv_key_format --pwd secret123" \
+-    "--pubkey-cert-$cert_format:pub1 $topfolder/keys/rsacert.$cert_format --pubkey-cert-$cert_format:pub2 $topfolder/keys/largersacert.$cert_format --session-key des-192 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-recipients.data" \
+-    "$priv_key_option:pub1 $topfolder/keys/rsakey.$priv_key_format --pwd secret123"
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-recipients" \
+-    "tripledes-cbc rsa-1_5" \
+-    "$priv_key_option:pub1 $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "--pubkey-cert-$cert_format:pub1 $topfolder/keys/rsacert.$cert_format --pubkey-cert-$cert_format:pub2 $topfolder/keys/largersacert.$cert_format --session-key des-192 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-recipients.data" \
+-    "$priv_key_option:pub1 $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+ ##########################################################################
+ #
+ # merlin-xmlenc-five
+@@ -162,14 +74,6 @@ execEncTest $res_success \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-aes128-cbc.data" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-content-tripledes-cbc" \
+-    "tripledes-cbc" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --enabled-key-data key-name --xml-data $topfolder/merlin-xmlenc-five/encrypt-content-tripledes-cbc.data --node-id Payment" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-content-aes256-cbc-prop" \
+@@ -184,30 +88,6 @@ execEncTest $res_success \
+     "aes192-cbc" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-element-aes128-cbc-rsa-1_5" \
+-    "aes128-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-128 $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --xml-data $topfolder/merlin-xmlenc-five/encrypt-element-aes128-cbc-rsa-1_5.data --node-id Purchase --pwd secret"  \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p" \
+-    "tripledes-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key des-192 $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p.data --pwd secret"  \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-data-aes256-cbc-kw-tripledes" \
+-    "aes256-cbc kw-tripledes" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-256 --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-aes256-cbc-kw-tripledes.data" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-content-aes128-cbc-kw-aes192" \
+@@ -216,22 +96,6 @@ execEncTest $res_success \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-128 --node-name urn:example:po:PaymentInfo --xml-data $topfolder/merlin-xmlenc-five/encrypt-content-aes128-cbc-kw-aes192.data" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-data-aes192-cbc-kw-aes256" \
+-    "aes192-cbc kw-aes256" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-192 --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-aes192-cbc-kw-aes256.data" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-element-tripledes-cbc-kw-aes128" \
+-    "tripledes-cbc kw-aes128" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml  --session-key des-192 --node-name urn:example:po:PaymentInfo --xml-data $topfolder/merlin-xmlenc-five/encrypt-element-tripledes-cbc-kw-aes128.data" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-element-aes256-cbc-retrieved-kw-aes256" \
+@@ -256,86 +120,6 @@ execEncTest $res_success \
+ #
+ ##########################################################################
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kt-rsa1_5" \
+-    "tripledes-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha1" \
+-    "tripledes-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes128-kt-rsa1_5" \
+-    "aes128-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes128-kt-rsa_oaep_sha1" \
+-    "aes128-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes192-kt-rsa_oaep_sha1" \
+-    "aes192-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes192-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-aes192-kt-rsa1_5" \
+-    "aes192-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-aes192-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-aes256-kt-rsa1_5" \
+-    "aes256-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-aes256-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-aes256-kt-rsa_oaep_sha1" \
+-    "aes256-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-aes256-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kw-3des" \
+-    "tripledes-cbc kw-tripledes" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kw-3des.data --node-name http://example.org/paymentv2:CreditCard" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-aes128-kw-3des" \
+-    "aes128-cbc kw-tripledes" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-aes128-kw-3des.data --node-name http://example.org/paymentv2:CreditCard" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-element-aes128-kw-aes128" \
+@@ -352,14 +136,6 @@ execEncTest $res_success \
+     "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kw-aes256.data --node-name http://example.org/paymentv2:CreditCard" \
+     "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-3des-kw-aes192" \
+-    "tripledes-cbc kw-aes192" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-3des-kw-aes192.data --node-name http://example.org/paymentv2:CreditCard" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-content-aes192-kw-aes256" \
+@@ -384,14 +160,6 @@ execEncTest $res_success \
+     "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes256-kw-aes256.data --node-name http://example.org/paymentv2:CreditCard" \
+     "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-3des-kw-aes256" \
+-    "tripledes-cbc kw-aes256" \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-3des-kw-aes256.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "--keys-file $topfolder/01-phaos-xmlenc-3/keys.xml"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-text-aes128-kw-aes192" \
+diff --git a/tests/testKeys.sh b/tests/testKeys.sh
+index af3ee8a0..873beb78 100755
+--- a/tests/testKeys.sh
++++ b/tests/testKeys.sh
+@@ -34,11 +34,6 @@ execKeysTest $res_success \
+     "test-hmac-sha1" \
+     "hmac-192"
+ 
+-execKeysTest $res_success \
+-    "rsa " \
+-    "test-rsa      " \
+-    "rsa-1024"
+-
+ execKeysTest $res_success \
+     "dsa " \
+     "test-dsa      " \

--- a/wolfProvider/xmlsec/xmlsec-master-wolfprov.patch
+++ b/wolfProvider/xmlsec/xmlsec-master-wolfprov.patch
@@ -1,0 +1,30 @@
+diff --git a/tests/testEnc.sh b/tests/testEnc.sh
+index 6ca08e3e..78ef44eb 100755
+--- a/tests/testEnc.sh
++++ b/tests/testEnc.sh
+@@ -412,25 +412,6 @@ if [ "z$xmlsec_feature_x509_data_lookup" = "zyes" ] ; then
+         "$priv_key_option $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+ fi
+ 
+-# same file is encrypted with two keys, test both
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "x509" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123"
+-
+ 
+ execEncTest $res_success \
+     "" \

--- a/wolfProvider/xmlsec/xmlsec-xmlsec-1_2_37-wolfprov.patch
+++ b/wolfProvider/xmlsec/xmlsec-xmlsec-1_2_37-wolfprov.patch
@@ -1,0 +1,144 @@
+diff --git a/tests/testEnc.sh b/tests/testEnc.sh
+index e715a6ff..f4a58e3b 100755
+--- a/tests/testEnc.sh
++++ b/tests/testEnc.sh
+@@ -30,22 +30,6 @@ echo "--------- Positive Testing ----------"
+ ##########################################################################
+ 
+ # same file is encrypted with two keys, test both
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key1 $topfolder/keys/cakey.$priv_key_format --pwd secret123"
+-
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-enc-keys" \
+-    "aes256-cbc rsa-1_5" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123" \
+-    "--session-key aes-256 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-enc-keys.data --pubkey-cert-$cert_format:key1 $topfolder/keys/cacert.$cert_format --pubkey-cert-$cert_format:key2 $topfolder/keys/ca2cert.$cert_format" \
+-    "$priv_key_option:key2 $topfolder/keys/ca2key.$priv_key_format --pwd secret123"
+-
+ execEncTest $res_success \
+     "" \
+     "aleksey-xmlenc-01/enc-des3cbc-keyname" \
+@@ -132,22 +116,6 @@ execEncTest $res_success \
+     "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123 --session-key aes-256 --enabled-key-data key-name --xml-data $topfolder/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params.data --node-name http://example.org/paymentv2:CreditCard"  \
+     "$priv_key_option:my-rsa-key $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+ 
+-# same test but decrypt using two different keys
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-recipients" \
+-    "tripledes-cbc rsa-1_5" \
+-    "$priv_key_option:pub1 $topfolder/keys/rsakey.$priv_key_format --pwd secret123" \
+-    "--pubkey-cert-$cert_format:pub1 $topfolder/keys/rsacert.$cert_format --pubkey-cert-$cert_format:pub2 $topfolder/keys/largersacert.$cert_format --session-key des-192 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-recipients.data" \
+-    "$priv_key_option:pub1 $topfolder/keys/rsakey.$priv_key_format --pwd secret123"
+-execEncTest $res_success \
+-    "" \
+-    "aleksey-xmlenc-01/enc-two-recipients" \
+-    "tripledes-cbc rsa-1_5" \
+-    "$priv_key_option:pub1 $topfolder/keys/largersakey.$priv_key_format --pwd secret123" \
+-    "--pubkey-cert-$cert_format:pub1 $topfolder/keys/rsacert.$cert_format --pubkey-cert-$cert_format:pub2 $topfolder/keys/largersacert.$cert_format --session-key des-192 --xml-data $topfolder/aleksey-xmlenc-01/enc-two-recipients.data" \
+-    "$priv_key_option:pub1 $topfolder/keys/largersakey.$priv_key_format --pwd secret123"
+-
+ ##########################################################################
+ #
+ # merlin-xmlenc-five
+@@ -184,22 +152,6 @@ execEncTest $res_success \
+     "aes192-cbc" \
+     "--keys-file $topfolder/merlin-xmlenc-five/keys.xml"
+ 
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-element-aes128-cbc-rsa-1_5" \
+-    "aes128-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key aes-128 $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --xml-data $topfolder/merlin-xmlenc-five/encrypt-element-aes128-cbc-rsa-1_5.data --node-id Purchase --pwd secret"  \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p" \
+-    "tripledes-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret" \
+-    "--keys-file $topfolder/merlin-xmlenc-five/keys.xml --session-key des-192 $priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --binary-data $topfolder/merlin-xmlenc-five/encrypt-data-tripledes-cbc-rsa-oaep-mgf1p.data --pwd secret"  \
+-    "$priv_key_option $topfolder/merlin-xmlenc-five/rsapriv.$priv_key_format --pwd secret"
+-
+ execEncTest $res_success \
+     "" \
+     "merlin-xmlenc-five/encrypt-data-aes256-cbc-kw-tripledes" \
+@@ -256,70 +208,6 @@ execEncTest $res_success \
+ #
+ ##########################################################################
+ 
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kt-rsa1_5" \
+-    "tripledes-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha1" \
+-    "tripledes-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key des-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-3des-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes128-kt-rsa1_5" \
+-    "aes128-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes128-kt-rsa_oaep_sha1" \
+-    "aes128-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-128 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes128-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-element-aes192-kt-rsa_oaep_sha1" \
+-    "aes192-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-element-aes192-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-aes192-kt-rsa1_5" \
+-    "aes192-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-192 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-aes192-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-content-aes256-kt-rsa1_5" \
+-    "aes256-cbc rsa-1_5" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-content-aes256-kt-rsa1_5.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+-execEncTest $res_success \
+-    "" \
+-    "01-phaos-xmlenc-3/enc-text-aes256-kt-rsa_oaep_sha1" \
+-    "aes256-cbc rsa-oaep-mgf1p" \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret" \
+-    "--session-key aes-256 --keys-file $topfolder/01-phaos-xmlenc-3/keys.xml --enabled-key-data key-name --xml-data $topfolder/01-phaos-xmlenc-3/enc-text-aes256-kt-rsa_oaep_sha1.data --node-name http://example.org/paymentv2:CreditCard"  \
+-    "$priv_key_option $topfolder/01-phaos-xmlenc-3/rsa-priv-key.$priv_key_format --pwd secret"
+-
+ execEncTest $res_success \
+     "" \
+     "01-phaos-xmlenc-3/enc-element-3des-kw-3des" \


### PR DESCRIPTION
Disables RSA-512 bit key sizes and RC2 algorithms that wolfProvider doesn't support.
Disables non-FIPS algorithms for FIPS testing.