### PR TITLE
add patch for python3-ntp testing in wolfProvider

### DIFF
--- a/wolfProvider/python3-ntp/README.md
+++ b/wolfProvider/python3-ntp/README.md
@@ -1,0 +1,6 @@
+All patches disable tests that call openssl low level CMAC API that is not
+supported with the openssl provider model.
+`python3-ntp-FIPS-NTPsec_1_2_2-wolfprov.patch` also disables a test that uses
+non FIPS algorithms. Conicidentally `python3-ntp-master-wolfprov.patch` already
+disables this test for FIPS testing on master because it also contains the CMAC
+issue in that test.

--- a/wolfProvider/python3-ntp/python3-ntp-FIPS-NTPsec_1_2_2-wolfprov.patch
+++ b/wolfProvider/python3-ntp/python3-ntp-FIPS-NTPsec_1_2_2-wolfprov.patch
@@ -1,0 +1,39 @@
+diff --git a/tests/wscript b/tests/wscript
+index 685038a7a..7302a13dd 100644
+--- a/tests/wscript
++++ b/tests/wscript
+@@ -55,16 +55,6 @@ def build(ctx):
+         "libntp/ymd2yd.c"
+     ] + common_source
+ 
+-    ctx.ntp_test(
+-        features="c cprogram test",
+-        target="test_libntp",
+-        install_path=None,
+-        defines=unity_config + ["TEST_LIBNTP=1"],
+-        includes=[ctx.bldnode.parent.abspath(), "../include", "unity", "common"],
+-        use="unity ntp parse M PTHREAD CRYPTO RT SOCKET NSL",
+-        source=libntp_source,
+-    )
+-
+     if ctx.env.REFCLOCK_GENERIC or ctx.env.REFCLOCK_TRIMBLE:
+         # libparse available/required with generic and Trimble refclocks
+ 
+@@ -103,17 +93,6 @@ def build(ctx):
+         "ntpd/nts_extens.c",
+     ]
+ 
+-    ctx.ntp_test(
+-        defines=unity_config + ["TEST_NTPD=1"],
+-        features="c cprogram test",
+-        includes=[ctx.bldnode.parent.abspath(), "../include", "unity", "../ntpd", "common", "../libaes_siv"],
+-        install_path=None,
+-        source=ntpd_source,
+-        target="test_ntpd",
+-        use="ntpd_lib libntpd_obj unity ntp aes_siv "
+-            "M PTHREAD CRYPTO RT SOCKET NSL",
+-    )
+-
+     testpylib.get_bld().mkdir()
+ 
+     pypath = pylib.get_bld()

--- a/wolfProvider/python3-ntp/python3-ntp-NTPsec_1_2_2-wolfprov.patch
+++ b/wolfProvider/python3-ntp/python3-ntp-NTPsec_1_2_2-wolfprov.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/wscript b/tests/wscript
+index 685038a7a..978c821f7 100644
+--- a/tests/wscript
++++ b/tests/wscript
+@@ -103,17 +103,6 @@ def build(ctx):
+         "ntpd/nts_extens.c",
+     ]
+ 
+-    ctx.ntp_test(
+-        defines=unity_config + ["TEST_NTPD=1"],
+-        features="c cprogram test",
+-        includes=[ctx.bldnode.parent.abspath(), "../include", "unity", "../ntpd", "common", "../libaes_siv"],
+-        install_path=None,
+-        source=ntpd_source,
+-        target="test_ntpd",
+-        use="ntpd_lib libntpd_obj unity ntp aes_siv "
+-            "M PTHREAD CRYPTO RT SOCKET NSL",
+-    )
+-
+     testpylib.get_bld().mkdir()
+ 
+     pypath = pylib.get_bld()

--- a/wolfProvider/python3-ntp/python3-ntp-master-wolfprov.patch
+++ b/wolfProvider/python3-ntp/python3-ntp-master-wolfprov.patch
@@ -1,0 +1,39 @@
+diff --git a/tests/wscript b/tests/wscript
+index 15dabbc09..8fff80b04 100644
+--- a/tests/wscript
++++ b/tests/wscript
+@@ -58,16 +58,6 @@ def build(ctx):
+         "libntp/ymd2yd.c"
+     ] + common_source
+ 
+-    ctx.ntp_test(
+-        features="c cprogram test",
+-        target="test_libntp",
+-        install_path=None,
+-        defines=unity_config + ["TEST_LIBNTP=1"],
+-        includes=[ctx.bldnode.parent.abspath(), "../include", "unity", "common"],
+-        use="unity ntp parse M PTHREAD CRYPTO RT SOCKET NSL",
+-        source=libntp_source,
+-    )
+-
+     if ctx.env.REFCLOCK_GENERIC or ctx.env.REFCLOCK_TRIMBLE:
+         # libparse available/required with generic and Trimble refclocks
+ 
+@@ -106,17 +96,6 @@ def build(ctx):
+         "ntpd/nts_extens.c",
+     ]
+ 
+-    ctx.ntp_test(
+-        defines=unity_config + ["TEST_NTPD=1"],
+-        features="c cprogram test",
+-        includes=[ctx.bldnode.parent.abspath(), "../include", "unity", "../ntpd", "common", "../libaes_siv"],
+-        install_path=None,
+-        source=ntpd_source,
+-        target="test_ntpd",
+-        use="ntpd_lib libntpd_obj unity ntp aes_siv "
+-            "M PTHREAD CRYPTO RT SOCKET NSL",
+-    )
+-
+     testpylib.get_bld().mkdir()
+ 
+     if 'none' == ctx.env['ntpc']:


### PR DESCRIPTION
Patches disable tests that use low level openssl CMAC calls which the provider model doesn't support. Also disables tests that use MD5 for FIPS testing which is in the `test_libntp` test.