### PR TITLE
Add curl patch for wolfProvider

### DIFF
--- a/wolfProvider/curl/README.md
+++ b/wolfProvider/curl/README.md
@@ -1,0 +1,4 @@
+`wolfProvider/curl/curl-8_4_0-wolfprov.patch` adds support for testing curl 
+`8.4.0` with wolfProvider FIPS in Jenkins. This patch is only needed when 
+testing curl with Jenkins. It disables a non crypto related test that IDN 
+with different languages.

--- a/wolfProvider/curl/curl-8_4_0-wolfprov.patch
+++ b/wolfProvider/curl/curl-8_4_0-wolfprov.patch
@@ -1,0 +1,11 @@
+diff --git a/tests/data/DISABLED b/tests/data/DISABLED
+index 308d27e..5d69f92 100644
+--- a/tests/data/DISABLED
++++ b/tests/data/DISABLED
+@@ -115,3 +115,6 @@
+ %if bearssl
+ 313
+ %endif
++# test 1560 requires IDN support - wolfProvider works locally in Jenkins
++# this fails even with the dependency installed
++1560


### PR DESCRIPTION
# Description 

In Jenkins curl has started failing test 1560 which does not test crypto. It works locally, verified it is not using crypto. Tested with same version of dockerfile in dockerhub and still only fails in Jenkins. This seems to be the only way we can get around this error. 