### PR TITLE
Add libcryptsetup support for wolfProvider

### DIFF
--- a/wolfProvider/libcryptsetup/README.md
+++ b/wolfProvider/libcryptsetup/README.md
@@ -1,0 +1,5 @@
+`libcryptsetup-v2.6.1-wolfprov.patch` adds FIPS and non FIPS wolfProvider 
+support for libcryptsetup `v2.6.1`. It disables various tests that use out 
+of bounds or not supported crypto. examples include: `ripemd160`, `whirlpool`, 
+`blake2b-512`, `blake2s-256`, `stribog512`, `kuznyechik`, `argon2i`, `argon2id`, 
+and `pbkdf2`.

--- a/wolfProvider/libcryptsetup/libcryptsetup-v2.6.1-wolfprov.patch
+++ b/wolfProvider/libcryptsetup/libcryptsetup-v2.6.1-wolfprov.patch
@@ -1,0 +1,452 @@
+diff --git a/configure.ac b/configure.ac
+index ccf2112..8800e53 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -681,7 +681,7 @@ AC_DEFUN([CS_ABSPATH], [
+ ])
+ 
+ dnl ==========================================================================
+-CS_STR_WITH([plain-hash],   [password hashing function for plain mode], [ripemd160])
++CS_STR_WITH([plain-hash],   [password hashing function for plain mode], [sha256])
+ CS_STR_WITH([plain-cipher], [cipher for plain mode], [aes])
+ CS_STR_WITH([plain-mode],   [cipher mode for plain mode], [cbc-essiv:sha256])
+ CS_NUM_WITH([plain-keybits],[key length in bits for plain mode], [256])
+diff --git a/lib/crypto_backend/crypto_openssl.c b/lib/crypto_backend/crypto_openssl.c
+index 607ec38..86c0d9f 100644
+--- a/lib/crypto_backend/crypto_openssl.c
++++ b/lib/crypto_backend/crypto_openssl.c
+@@ -171,20 +171,20 @@ static int openssl_backend_init(bool fips)
+ 		if (!ossl_ctx)
+ 			return -EINVAL;
+ 
+-		ossl_default = OSSL_PROVIDER_try_load(ossl_ctx, "default", 0);
++		ossl_default = OSSL_PROVIDER_try_load(ossl_ctx, "libwolfprov", 0);
+ 		if (!ossl_default) {
+ 			OSSL_LIB_CTX_free(ossl_ctx);
+ 			return -EINVAL;
+ 		}
+ 
+-		/* Optional */
+-		ossl_legacy = OSSL_PROVIDER_try_load(ossl_ctx, "legacy", 0);
++		/* Load wolfProvider instead of legacy */
++		ossl_legacy = OSSL_PROVIDER_try_load(ossl_ctx, "libwolfprov", 0);
+ 	}
+ 
+ 	r = snprintf(backend_version, sizeof(backend_version), "%s %s%s%s",
+ 		OpenSSL_version(OPENSSL_VERSION),
+-		ossl_default ? "[default]" : "",
+-		ossl_legacy  ? "[legacy]" : "",
++		ossl_default ? "[libwolfprov]" : "",
++		ossl_legacy  ? "[libwolfprov]" : "",
+ 		fips  ? "[fips]" : "");
+ 
+ 	if (r < 0 || (size_t)r >= sizeof(backend_version)) {
+diff --git a/tests/compat-test b/tests/compat-test
+index 6dc8004..3aff32d 100755
+--- a/tests/compat-test
++++ b/tests/compat-test
+@@ -226,81 +226,7 @@ if [ $(id -u) != 0 ]; then
+ 		skip "WARNING: Cannot run test without kernel userspace crypto API, test skipped."
+ fi
+ 
+-prepare "Image in file tests (root capabilities not required)" file
+-echo "[1] format"
+-echo $PWD1 | $CRYPTSETUP luksFormat --type luks1 $IMG $FAST_PBKDF_OPT || fail
+-echo "[2] open"
+-echo $PWD0 | $CRYPTSETUP luksOpen $IMG --test-passphrase 2>/dev/null && fail
+-[ $? -ne 2 ] && fail "luksOpen should return EPERM exit code"
+-echo $PWD1 | $CRYPTSETUP luksOpen $IMG --test-passphrase || fail
+-# test detached header --test-passphrase
+-echo $PWD1 | $CRYPTSETUP -q luksFormat --type luks1 $FAST_PBKDF_OPT --header $HEADER_IMG $IMG || fail
+-echo $PWD1 | $CRYPTSETUP open --test-passphrase $HEADER_IMG || fail
+-rm -f $HEADER_IMG
+-echo "[3] add key"
+-echo $PWD1 | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT 2>/dev/null && fail
+-echo -e "$PWD1\n$PWD2" | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT || fail
+-echo -e "$PWD0\n$PWD1" | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT 2>/dev/null && fail
+-echo "[4] change key"
+-echo -e "$PWD1\n$PWD0\n" | $CRYPTSETUP luksChangeKey $FAST_PBKDF_OPT $IMG || fail
+-echo -e "$PWD1\n$PWD2\n" | $CRYPTSETUP luksChangeKey $FAST_PBKDF_OPT $IMG 2>/dev/null && fail
+-[ $? -ne 2 ] && fail "luksChangeKey should return EPERM exit code"
+-echo "[5] remove key"
+-# delete active keys PWD0, PWD2
+-echo $PWD1 | $CRYPTSETUP luksRemoveKey $IMG 2>/dev/null && fail
+-[ $? -ne 2 ] && fail "luksRemove should return EPERM exit code"
+-echo $PWD0 | $CRYPTSETUP luksRemoveKey $IMG || fail
+-echo $PWD2 | $CRYPTSETUP luksRemoveKey $IMG || fail
+-# check if keys were deleted
+-echo $PWD0 | $CRYPTSETUP luksOpen $IMG --test-passphrase 2>/dev/null && fail
+-[ $? -ne 1 ] && fail "luksOpen should return ENOENT exit code"
+-echo $PWD2 | $CRYPTSETUP luksOpen $IMG --test-passphrase 2>/dev/null && fail
+-[ $? -ne 1 ] && fail "luksOpen should return ENOENT exit code"
+-echo "[6] kill slot"
+-# format new luks device with active keys PWD1, PWD2
+-echo $PWD1 | $CRYPTSETUP -q luksFormat --type luks1 $IMG $FAST_PBKDF_OPT || fail
+-echo -e "$PWD1\n$PWD2" | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT || fail
+-# deactivate keys by killing slots
+-$CRYPTSETUP luksDump $IMG | grep -q "Key Slot 0: ENABLED" || fail
+-$CRYPTSETUP luksDump $IMG | grep -q "Key Slot 1: ENABLED" || fail
+-$CRYPTSETUP luksDump $IMG | grep -q "Key Slot 2: DISABLED" || fail
+-echo $PWD1 | $CRYPTSETUP -q luksKillSlot $IMG 0 2>/dev/null && fail
+-echo $PWD2 | $CRYPTSETUP -q luksKillSlot $IMG 0 || fail
+-$CRYPTSETUP luksDump $IMG | grep -q "Key Slot 0: DISABLED" || fail
+-echo $PWD1 | $CRYPTSETUP -q luksKillSlot $IMG 1 2>/dev/null && fail
+-[ $? -ne 2 ] && fail "luksKill should return EPERM exit code"
+-echo $PWD2 | $CRYPTSETUP -q luksKillSlot $IMG 1 || fail
+-$CRYPTSETUP luksDump $IMG | grep -q "Key Slot 1: DISABLED" || fail
+-# check if keys were deactivated
+-echo $PWD1 | $CRYPTSETUP luksOpen $IMG --test-passphrase 2>/dev/null && fail
+-echo $PWD2 | $CRYPTSETUP luksOpen $IMG --test-passphrase 2>/dev/null && fail
+-echo "[7] header backup"
+-echo $PWD1 | $CRYPTSETUP -q luksFormat --type luks1 $IMG $FAST_PBKDF_OPT || fail
+-$CRYPTSETUP luksHeaderBackup $IMG --header-backup-file $HEADER_IMG || fail
+-echo $PWD1 | $CRYPTSETUP luksRemoveKey $IMG || fail
+-echo $PWD1 | $CRYPTSETUP luksOpen $IMG --test-passphrase 2>/dev/null && fail
+-echo "[8] header restore"
+-$CRYPTSETUP luksHeaderRestore -q $IMG --header-backup-file $HEADER_IMG || fail
+-echo $PWD1 | $CRYPTSETUP luksOpen $IMG --test-passphrase || fail
+-echo "[9] luksDump"
+-echo $PWD1 | $CRYPTSETUP -q luksFormat --type luks1 $FAST_PBKDF_OPT --uuid $TEST_UUID $IMG $KEY1 || fail
+-echo $PWD1 | $CRYPTSETUP luksAddKey $FAST_PBKDF_OPT $IMG -d $KEY1 || fail
+-$CRYPTSETUP luksDump $IMG | grep -q "Key Slot 0: ENABLED" || fail
+-$CRYPTSETUP luksDump $IMG | grep -q $TEST_UUID || fail
+-echo $PWDW | $CRYPTSETUP luksDump $IMG --dump-volume-key 2>/dev/null && fail
+-echo $PWDW | $CRYPTSETUP luksDump $IMG --dump-master-key 2>/dev/null && fail
+-echo $PWD1 | $CRYPTSETUP luksDump $IMG --dump-volume-key | grep -q "MK dump:" || fail
+-echo $PWD1 | $CRYPTSETUP luksDump $IMG --dump-master-key | grep -q "MK dump:" || fail
+-$CRYPTSETUP luksDump -q $IMG --dump-volume-key -d $KEY1 | grep -q "MK dump:" || fail
+-echo $PWD1 | $CRYPTSETUP luksDump -q $IMG --dump-master-key --master-key-file $VK_FILE >/dev/null || fail
+-rm -f $VK_FILE
+-echo $PWD1 | $CRYPTSETUP luksDump -q $IMG --dump-volume-key --volume-key-file $VK_FILE >/dev/null || fail
+-echo $PWD1 | $CRYPTSETUP luksDump -q $IMG --dump-volume-key --volume-key-file $VK_FILE 2>/dev/null && fail
+-echo $PWD1 | $CRYPTSETUP luksAddKey $FAST_PBKDF_OPT --volume-key-file $VK_FILE $IMG || fail
+-
+-echo "[10] uuid"
+-echo $PWD1 | $CRYPTSETUP -q luksFormat --type luks1 $FAST_PBKDF_OPT --uuid $TEST_UUID $IMG || fail
+-$CRYPTSETUP -q luksUUID $IMG | grep -q $TEST_UUID || fail
++# Removed PBKDF2-based LUKS1 tests: wolfProvider FIPS does not support PBKDF2.
+ 
+ [ $(id -u) != 0 ] && skip "WARNING: You must be root to run this test, test skipped."
+ [ -z "$LOOPDEV" ] && skip "WARNING: Cannot find free loop device, test skipped."
+diff --git a/tests/crypto-vectors.c b/tests/crypto-vectors.c
+index ae8dd68..1aafc54 100644
+--- a/tests/crypto-vectors.c
++++ b/tests/crypto-vectors.c
+@@ -26,6 +26,7 @@
+ #include <fcntl.h>
+ 
+ #include "crypto_backend/crypto_backend.h"
++#include "config.h"
+ 
+ #ifndef ARRAY_SIZE
+ # define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+@@ -60,6 +61,11 @@ static bool fips_mode(void)
+ 	return (buf == '1');
+ }
+ 
++/*
++ * Note: wolfProvider FIPS does not support ripemd160, whirlpool, blake2b-512, blake2s-256
++ * These test vectors have been removed for wolfProvider compatibility
++ */
++
+ /*
+  * KDF tests
+  */
+@@ -270,15 +276,7 @@ static struct kdf_test_vector kdf_test_vectors[] = {
+ 		"\x7d\x8e\xdd\x58\x01\xb4\x59\x72"
+ 		"\x99\x92\x16\x30\x5e\xa4\x36\x8d"
+ 		"\x76\x14\x80\xf3\xe3\x7a\x22\xb9", 32
+-	}, {
+-		"pbkdf2", "whirlpool", 64, 1200, 0, 0,
+-		"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+-		"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", 65,
+-		"pass phrase exceeds block size", 30,
+-		"\x9c\x1c\x74\xf5\x88\x26\xe7\x6a"
+-		"\x53\x58\xf4\x0c\x39\xe7\x80\x89"
+-		"\x07\xc0\x31\x19\x9a\x50\xa2\x48"
+-		"\xf1\xd9\xfe\x78\x64\xe5\x84\x50", 32
++	/* Removed pbkdf2-whirlpool test - whirlpool not supported by wolfProvider FIPS */
+ 	}
+ };
+ 
+@@ -306,17 +304,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\xd6\x20\xe4\x05\x0b\x57\x15\xdc\x83\xf4\xa9\x21\xd3\x6c\xe9\xce"
+ 			   "\x47\xd0\xd1\x3c\x5d\x85\xf2\xb0\xff\x83\x18\xd2\x87\x7e\xec\x2f"
+ 			   "\x63\xb9\x31\xbd\x47\x41\x7a\x81\xa5\x38\x32\x7a\xf9\x27\xda\x3e" },
+-	{ "ripemd160", 20, "\x9c\x11\x85\xa5\xc5\xe9\xfc\x54\x61\x28\x08\x97\x7e\xe8\xf5\x48\xb2\x25\x8d\x31" },
+-	{ "whirlpool", 64, "\x19\xfa\x61\xd7\x55\x22\xa4\x66\x9b\x44\xe3\x9c\x1d\x2e\x17\x26"
+-			   "\xc5\x30\x23\x21\x30\xd4\x07\xf8\x9a\xfe\xe0\x96\x49\x97\xf7\xa7"
+-			   "\x3e\x83\xbe\x69\x8b\x28\x8f\xeb\xcf\x88\xe3\xe0\x3c\x4f\x07\x57"
+-			   "\xea\x89\x64\xe5\x9b\x63\xd9\x37\x08\xb1\x38\xcc\x42\xa6\x6e\xb3" },
+-	{ "blake2b-512",64,"\x78\x6a\x02\xf7\x42\x01\x59\x03\xc6\xc6\xfd\x85\x25\x52\xd2\x72"
+-			   "\x91\x2f\x47\x40\xe1\x58\x47\x61\x8a\x86\xe2\x17\xf7\x1f\x54\x19"
+-			   "\xd2\x5e\x10\x31\xaf\xee\x58\x53\x13\x89\x64\x44\x93\x4e\xb0\x4b"
+-			   "\x90\x3a\x68\x5b\x14\x48\xb7\x55\xd5\x6f\x70\x1a\xfe\x9b\xe2\xce" },
+-	{ "blake2s-256",32,"\x69\x21\x7a\x30\x79\x90\x80\x94\xe1\x11\x21\xd0\x42\x35\x4a\x7c"
+-			   "\x1f\x55\xb6\x48\x2c\xa1\xa5\x1e\x1b\x25\x0d\xfd\x1e\xd0\xee\xf9" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }},{
+ 	"a", 1, {
+ 	{ "crc32",      4, "\xe8\xb7\xbe\x43" },
+@@ -327,17 +318,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\xd5\xd7\xd2\x8e\x18\x33\x5d\xe0\x5a\xbc\x54\xd0\x56\x0e\x0f\x53"
+ 			   "\x02\x86\x0c\x65\x2b\xf0\x8d\x56\x02\x52\xaa\x5e\x74\x21\x05\x46"
+ 			   "\xf3\x69\xfb\xbb\xce\x8c\x12\xcf\xc7\x95\x7b\x26\x52\xfe\x9a\x75" },
+-	{ "ripemd160", 20, "\x0b\xdc\x9d\x2d\x25\x6b\x3e\xe9\xda\xae\x34\x7b\xe6\xf4\xdc\x83\x5a\x46\x7f\xfe" },
+-	{ "whirlpool", 64, "\x8a\xca\x26\x02\x79\x2a\xec\x6f\x11\xa6\x72\x06\x53\x1f\xb7\xd7"
+-			   "\xf0\xdf\xf5\x94\x13\x14\x5e\x69\x73\xc4\x50\x01\xd0\x08\x7b\x42"
+-			   "\xd1\x1b\xc6\x45\x41\x3a\xef\xf6\x3a\x42\x39\x1a\x39\x14\x5a\x59"
+-			   "\x1a\x92\x20\x0d\x56\x01\x95\xe5\x3b\x47\x85\x84\xfd\xae\x23\x1a" },
+-	{ "blake2b-512",64,"\x33\x3f\xcb\x4e\xe1\xaa\x7c\x11\x53\x55\xec\x66\xce\xac\x91\x7c"
+-			   "\x8b\xfd\x81\x5b\xf7\x58\x7d\x32\x5a\xec\x18\x64\xed\xd2\x4e\x34"
+-			   "\xd5\xab\xe2\xc6\xb1\xb5\xee\x3f\xac\xe6\x2f\xed\x78\xdb\xef\x80"
+-			   "\x2f\x2a\x85\xcb\x91\xd4\x55\xa8\xf5\x24\x9d\x33\x08\x53\xcb\x3c" },
+-	{ "blake2s-256",32,"\x4a\x0d\x12\x98\x73\x40\x30\x37\xc2\xcd\x9b\x90\x48\x20\x36\x87"
+-			   "\xf6\x23\x3f\xb6\x73\x89\x56\xe0\x34\x9b\xd4\x32\x0f\xec\x3e\x90" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }},{
+ 	"abc", 3, {
+ 	{ "crc32",      4, "\x35\x24\x41\xc2" },
+@@ -348,17 +332,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\x12\xe6\xfa\x4e\x89\xa9\x7e\xa2\x0a\x9e\xee\xe6\x4b\x55\xd3\x9a"
+ 			   "\x21\x92\x99\x2a\x27\x4f\xc1\xa8\x36\xba\x3c\x23\xa3\xfe\xeb\xbd"
+ 			   "\x45\x4d\x44\x23\x64\x3c\xe8\x0e\x2a\x9a\xc9\x4f\xa5\x4c\xa4\x9f" },
+-	{ "ripemd160", 20, "\x8e\xb2\x08\xf7\xe0\x5d\x98\x7a\x9b\x04\x4a\x8e\x98\xc6\xb0\x87\xf1\x5a\x0b\xfc" },
+-	{ "whirlpool", 64, "\x4e\x24\x48\xa4\xc6\xf4\x86\xbb\x16\xb6\x56\x2c\x73\xb4\x02\x0b"
+-			   "\xf3\x04\x3e\x3a\x73\x1b\xce\x72\x1a\xe1\xb3\x03\xd9\x7e\x6d\x4c"
+-			   "\x71\x81\xee\xbd\xb6\xc5\x7e\x27\x7d\x0e\x34\x95\x71\x14\xcb\xd6"
+-			   "\xc7\x97\xfc\x9d\x95\xd8\xb5\x82\xd2\x25\x29\x20\x76\xd4\xee\xf5" },
+-	{ "blake2b-512",64,"\xba\x80\xa5\x3f\x98\x1c\x4d\x0d\x6a\x27\x97\xb6\x9f\x12\xf6\xe9"
+-			   "\x4c\x21\x2f\x14\x68\x5a\xc4\xb7\x4b\x12\xbb\x6f\xdb\xff\xa2\xd1"
+-			   "\x7d\x87\xc5\x39\x2a\xab\x79\x2d\xc2\x52\xd5\xde\x45\x33\xcc\x95"
+-			   "\x18\xd3\x8a\xa8\xdb\xf1\x92\x5a\xb9\x23\x86\xed\xd4\x00\x99\x23" },
+-	{ "blake2s-256",32,"\x50\x8c\x5e\x8c\x32\x7c\x14\xe2\xe1\xa7\x2b\xa3\x4e\xeb\x45\x2f"
+-			   "\x37\x45\x8b\x20\x9e\xd6\x3a\x29\x4d\x99\x9b\x4c\x86\x67\x59\x82" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }},{
+ 	"abcdefghijklmnopqrstuvwxyz", 26, {
+ 	{ "crc32",      4, "\x4c\x27\x50\xbd" },
+@@ -369,17 +346,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\xc9\x7f\x17\x53\xbc\xe3\x61\x90\x34\x89\x8f\xaa\x1a\xab\xe4\x29"
+ 			   "\x95\x5a\x1b\xf8\xec\x48\x3d\x74\x21\xfe\x3c\x16\x46\x61\x3a\x59"
+ 			   "\xed\x54\x41\xfb\x0f\x32\x13\x89\xf7\x7f\x48\xa8\x79\xc7\xb1\xf1" },
+-	{ "ripemd160", 20, "\xf7\x1c\x27\x10\x9c\x69\x2c\x1b\x56\xbb\xdc\xeb\x5b\x9d\x28\x65\xb3\x70\x8d\xbc" },
+-	{ "whirlpool", 64, "\xf1\xd7\x54\x66\x26\x36\xff\xe9\x2c\x82\xeb\xb9\x21\x2a\x48\x4a"
+-			   "\x8d\x38\x63\x1e\xad\x42\x38\xf5\x44\x2e\xe1\x3b\x80\x54\xe4\x1b"
+-			   "\x08\xbf\x2a\x92\x51\xc3\x0b\x6a\x0b\x8a\xae\x86\x17\x7a\xb4\xa6"
+-			   "\xf6\x8f\x67\x3e\x72\x07\x86\x5d\x5d\x98\x19\xa3\xdb\xa4\xeb\x3b" },
+-	{ "blake2b-512",64,"\xc6\x8e\xde\x14\x3e\x41\x6e\xb7\xb4\xaa\xae\x0d\x8e\x48\xe5\x5d"
+-			   "\xd5\x29\xea\xfe\xd1\x0b\x1d\xf1\xa6\x14\x16\x95\x3a\x2b\x0a\x56"
+-			   "\x66\xc7\x61\xe7\xd4\x12\xe6\x70\x9e\x31\xff\xe2\x21\xb7\xa7\xa7"
+-			   "\x39\x08\xcb\x95\xa4\xd1\x20\xb8\xb0\x90\xa8\x7d\x1f\xbe\xdb\x4c" },
+-	{ "blake2s-256",32,"\xbd\xf8\x8e\xb1\xf8\x6a\x0c\xdf\x0e\x84\x0b\xa8\x8f\xa1\x18\x50"
+-			   "\x83\x69\xdf\x18\x6c\x73\x55\xb4\xb1\x6c\xf7\x9f\xa2\x71\x0a\x12" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }},{
+ 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", 62, {
+ 	{ "crc32",      4, "\x1f\xc2\xe6\xd2" },
+@@ -390,17 +360,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\x52\x51\x5a\x97\x0e\x92\x53\xc2\x6f\x53\x6c\xfc\x7a\x99\x96\xc4"
+ 			   "\x5c\x83\x70\x58\x3e\x0a\x78\xfa\x4a\x90\x04\x1d\x71\xa4\xce\xab"
+ 			   "\x74\x23\xf1\x9c\x71\xb9\xd5\xa3\xe0\x12\x49\xf0\xbe\xbd\x58\x94" },
+-	{ "ripemd160", 20, "\xb0\xe2\x0b\x6e\x31\x16\x64\x02\x86\xed\x3a\x87\xa5\x71\x30\x79\xb2\x1f\x51\x89" },
+-	{ "whirlpool", 64, "\xdc\x37\xe0\x08\xcf\x9e\xe6\x9b\xf1\x1f\x00\xed\x9a\xba\x26\x90"
+-			   "\x1d\xd7\xc2\x8c\xde\xc0\x66\xcc\x6a\xf4\x2e\x40\xf8\x2f\x3a\x1e"
+-			   "\x08\xeb\xa2\x66\x29\x12\x9d\x8f\xb7\xcb\x57\x21\x1b\x92\x81\xa6"
+-			   "\x55\x17\xcc\x87\x9d\x7b\x96\x21\x42\xc6\x5f\x5a\x7a\xf0\x14\x67" },
+-	{ "blake2b-512",64,"\x99\x96\x48\x02\xe5\xc2\x5e\x70\x37\x22\x90\x5d\x3f\xb8\x00\x46"
+-			   "\xb6\xbc\xa6\x98\xca\x9e\x2c\xc7\xe4\x9b\x4f\xe1\xfa\x08\x7c\x2e"
+-			   "\xdf\x03\x12\xdf\xbb\x27\x5c\xf2\x50\xa1\xe5\x42\xfd\x5d\xc2\xed"
+-			   "\xd3\x13\xf9\xc4\x91\x12\x7c\x2e\x8c\x0c\x9b\x24\x16\x8e\x2d\x50" },
+-	{ "blake2s-256",32,"\xc7\x54\x39\xea\x17\xe1\xde\x6f\xa4\x51\x0c\x33\x5d\xc3\xd3\xf3"
+-			   "\x43\xe6\xf9\xe1\xce\x27\x73\xe2\x5b\x41\x74\xf1\xdf\x8b\x11\x9b" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }},{
+ 	"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", 56, {
+ 	{ "crc32",      4, "\x17\x1a\x3f\x5f" },
+@@ -411,17 +374,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\x57\xc1\x6e\xf4\x68\xb2\x28\xa8\x27\x9b\xe3\x31\xa7\x03\xc3\x35"
+ 			   "\x96\xfd\x15\xc1\x3b\x1b\x07\xf9\xaa\x1d\x3b\xea\x57\x78\x9c\xa0"
+ 			   "\x31\xad\x85\xc7\xa7\x1d\xd7\x03\x54\xec\x63\x12\x38\xca\x34\x45" },
+-	{ "ripemd160", 20, "\x12\xa0\x53\x38\x4a\x9c\x0c\x88\xe4\x05\xa0\x6c\x27\xdc\xf4\x9a\xda\x62\xeb\x2b" },
+-	{ "whirlpool", 64, "\x52\x6b\x23\x94\xd8\x56\x83\xe2\x4b\x29\xac\xd0\xfd\x37\xf7\xd5"
+-			   "\x02\x7f\x61\x36\x6a\x14\x07\x26\x2d\xc2\xa6\xa3\x45\xd9\xe2\x40"
+-			   "\xc0\x17\xc1\x83\x3d\xb1\xe6\xdb\x6a\x46\xbd\x44\x4b\x0c\x69\x52"
+-			   "\x0c\x85\x6e\x7c\x6e\x9c\x36\x6d\x15\x0a\x7d\xa3\xae\xb1\x60\xd1" },
+-	{ "blake2b-512",64,"\x72\x85\xff\x3e\x8b\xd7\x68\xd6\x9b\xe6\x2b\x3b\xf1\x87\x65\xa3"
+-			   "\x25\x91\x7f\xa9\x74\x4a\xc2\xf5\x82\xa2\x08\x50\xbc\x2b\x11\x41"
+-			   "\xed\x1b\x3e\x45\x28\x59\x5a\xcc\x90\x77\x2b\xdf\x2d\x37\xdc\x8a"
+-			   "\x47\x13\x0b\x44\xf3\x3a\x02\xe8\x73\x0e\x5a\xd8\xe1\x66\xe8\x88" },
+-	{ "blake2s-256",32,"\x6f\x4d\xf5\x11\x6a\x6f\x33\x2e\xda\xb1\xd9\xe1\x0e\xe8\x7d\xf6"
+-			   "\x55\x7b\xea\xb6\x25\x9d\x76\x63\xf3\xbc\xd5\x72\x2c\x13\xf1\x89" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }},{
+ 	"message digest", 14, {
+ 	{ "crc32",      4, "\x20\x15\x9d\x7f" },
+@@ -432,17 +388,10 @@ static struct hash_test_vector hash_test_vectors[] = {
+ 			   "\xbc\x52\x68\xc2\xbe\x16\xd6\xc1\x34\x92\xea\x45\xb0\x19\x9f\x33"
+ 			   "\x09\xe1\x64\x55\xab\x1e\x96\x11\x8e\x8a\x90\x5d\x55\x97\xb7\x20"
+ 			   "\x38\xdd\xb3\x72\xa8\x98\x26\x04\x6d\xe6\x66\x87\xbb\x42\x0e\x7c" },
+-	{ "ripemd160", 20, "\x5d\x06\x89\xef\x49\xd2\xfa\xe5\x72\xb8\x81\xb1\x23\xa8\x5f\xfa\x21\x59\x5f\x36" },
+-	{ "whirlpool", 64, "\x37\x8c\x84\xa4\x12\x6e\x2d\xc6\xe5\x6d\xcc\x74\x58\x37\x7a\xac"
+-			   "\x83\x8d\x00\x03\x22\x30\xf5\x3c\xe1\xf5\x70\x0c\x0f\xfb\x4d\x3b"
+-			   "\x84\x21\x55\x76\x59\xef\x55\xc1\x06\xb4\xb5\x2a\xc5\xa4\xaa\xa6"
+-			   "\x92\xed\x92\x00\x52\x83\x8f\x33\x62\xe8\x6d\xbd\x37\xa8\x90\x3e" },
+-	{ "blake2b-512",64,"\x3c\x26\xce\x48\x7b\x1c\x0f\x06\x23\x63\xaf\xa3\xc6\x75\xeb\xdb"
+-			   "\xf5\xf4\xef\x9b\xdc\x02\x2c\xfb\xef\x91\xe3\x11\x1c\xdc\x28\x38"
+-			   "\x40\xd8\x33\x1f\xc3\x0a\x8a\x09\x06\xcf\xf4\xbc\xdb\xcd\x23\x0c"
+-			   "\x61\xaa\xec\x60\xfd\xfa\xd4\x57\xed\x96\xb7\x09\xa3\x82\x35\x9a" },
+-	{ "blake2s-256",32,"\xfa\x10\xab\x77\x5a\xcf\x89\xb7\xd3\xc8\xa6\xe8\x23\xd5\x86\xf6"
+-			   "\xb6\x7b\xdb\xac\x4c\xe2\x07\xfe\x14\x5b\x7d\x3a\xc2\x5c\xd2\x8c" },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL },
++	{ NULL, 0, NULL }
+ }}};
+ 
+ /*
+@@ -1030,7 +979,11 @@ static int pbkdf_test_vectors(void)
+ 		crypt_backend_memzero(result, sizeof(result));
+ 		vec = &kdf_test_vectors[i];
+ 		printf("PBKDF vector %02d %s ", i, vec->type);
+-		if (vec->hash && crypt_hmac_size(vec->hash) < 0) {
++		/* Skip unsupported algorithms */
++		if (vec->hash && (strcmp(vec->hash, "ripemd160") == 0 ||
++		    strcmp(vec->hash, "whirlpool") == 0 ||
++		    strcmp(vec->hash, "blake2b-512") == 0 ||
++		    strcmp(vec->hash, "blake2s-256") == 0)) {
+ 			printf("[%s N/A]\n", vec->hash);
+ 			continue;
+ 		}
+@@ -1089,6 +1042,11 @@ static int hash_test(void)
+ 
+ 		for (j = 0; j < ARRAY_SIZE(vector->out); j++) {
+ 
++			/* Skip NULL entries (removed algorithms) */
++			if (!vector->out[j].name) {
++				continue;
++			}
++
+ 			// CRC32 vector test is special
+ 			if (!strcmp("crc32", vector->out[j].name)) {
+ 				if (crc32_test(vector, j) < 0)
+@@ -1097,7 +1055,11 @@ static int hash_test(void)
+ 				continue;
+ 			}
+ 
+-			if (crypt_hash_size(vector->out[j].name) < 0) {
++			/* Skip unsupported algorithms */
++			if (strcmp(vector->out[j].name, "ripemd160") == 0 ||
++			    strcmp(vector->out[j].name, "whirlpool") == 0 ||
++			    strcmp(vector->out[j].name, "blake2b-512") == 0 ||
++			    strcmp(vector->out[j].name, "blake2s-256") == 0) {
+ 				printf("[%s N/A]", vector->out[j].name);
+ 				continue;
+ 			}
+@@ -1172,7 +1134,11 @@ static int hmac_test(void)
+ 
+ 		for(j = 0; j < ARRAY_SIZE(vector->out); j++) {
+ 
+-			if (crypt_hmac_size(vector->out[j].name) < 0) {
++			/* Skip unsupported algorithms */
++			if (strcmp(vector->out[j].name, "ripemd160") == 0 ||
++			    strcmp(vector->out[j].name, "whirlpool") == 0 ||
++			    strcmp(vector->out[j].name, "blake2b-512") == 0 ||
++			    strcmp(vector->out[j].name, "blake2s-256") == 0) {
+ 				printf("[%s N/A]", vector->out[j].name);
+ 				continue;
+ 			}
+diff --git a/tests/fvault2-compat-test b/tests/fvault2-compat-test
+index 45022d2..165e891 100755
+--- a/tests/fvault2-compat-test
++++ b/tests/fvault2-compat-test
+@@ -1,5 +1,8 @@
+ #!/bin/bash
+ 
++# wolfProvider FIPS does not support PBKDF2 for volume key retrieval
++# FileVault2 header parsing works fine, but volume key retrieval requires PBKDF2
++
+ [ -z "$CRYPTSETUP_PATH" ] && CRYPTSETUP_PATH=".."
+ CRYPTSETUP=$CRYPTSETUP_PATH/cryptsetup
+ MAP=fvault2test
+@@ -112,23 +115,12 @@ check_dump "$dump" 'Logical volume offset' '67108864 [bytes]'
+ check_dump "$dump" 'Logical volume size' '167772160 [bytes]'
+ check_dump "$dump" 'PBKDF2 iterations' 204222
+ check_dump "$dump" 'PBKDF2 salt' '2c 24 9e db 66 63 d6 fb cc 79 05 b7 a4 d7 27 52'
+-dump=$(produce_dump_key $IMG heslo123)
+-check_dump "$dump" 'Volume key' '20 73 4d 33 89 21 27 74 d7 61 0c 29 d7 32 88 09 16 f3 be 14 c4 b1 2a c7 aa f0 7e 5c cc 77 b3 19'
+-echo $PWD | $CRYPTSETUP open --type fvault2 --test-passphrase $IMG || fail
+-echo " [OK]"
+ 
+-if [ $(id -u) != 0 ]; then
+-	echo "WARNING: You must be root to run activation part of test, test skipped."
+-	remove_mapping
+-	exit 0
+-fi
++# Removed volume key retrieval test - wolfProvider FIPS does not support PBKDF2
+ 
+-echo "ACTIVATION CHECK"
+-echo -n " $IMG"
+-create_mapping $IMG heslo123
+-check_uuid de124d8a-2164-394e-924f-8e28db0a09cb
+-check_sha256 2c662e36c0f7e2f5583e6a939bbcbdc660805692d0fccaa45ad4052beb3b8e18
+ echo " [OK]"
+ 
++# Removed activation check - wolfProvider FIPS does not support PBKDF2 for volume key derivation
++
+ remove_mapping
+ exit 0
+diff --git a/tests/luks2-reencryption-mangle-test b/tests/luks2-reencryption-mangle-test
+index 5aa62e4..47b6bce 100755
+--- a/tests/luks2-reencryption-mangle-test
++++ b/tests/luks2-reencryption-mangle-test
+@@ -1,5 +1,12 @@
+ #!/bin/bash
+ 
++# DISABLED: wolfProvider FIPS does not support any PBKDF algorithms
++# This test requires PBKDF functionality which is not available in wolfProvider FIPS mode
++
++echo "SKIP: luks2-reencryption-mangle-test - LUKS2 reencryption test disabled"
++echo "wolfProvider FIPS does not support any PBKDF algorithms (pbkdf2, argon2i, argon2id)"
++exit 77
++
+ PS4='$LINENO:'
+ [ -z "$CRYPTSETUP_PATH" ] && CRYPTSETUP_PATH=".."
+ CRYPTSETUP=$CRYPTSETUP_PATH/cryptsetup
+diff --git a/tests/tcrypt-compat-test b/tests/tcrypt-compat-test
+index c0fc50a..8aa64a8 100755
+--- a/tests/tcrypt-compat-test
++++ b/tests/tcrypt-compat-test
+@@ -1,6 +1,14 @@
+ #!/bin/bash
+ 
+ # check tcrypt images parsing
++# DISABLED: wolfProvider FIPS does not support TrueCrypt algorithms (ripemd160,
++# whirlpool, stribog512, kuznyechik)
++# Most test images contain unsupported algorithms that cause failures
++
++echo "tcrypt-compat-test - TrueCrypt compatibility test disabled"
++echo "wolfProvider FIPS does not support TrueCrypt algorithms"
++echo "(ripemd160, whirlpool, stribog512, kuznyechik)"
++exit 77
+ 
+ [ -z "$CRYPTSETUP_PATH" ] && CRYPTSETUP_PATH=".."
+ CRYPTSETUP=$CRYPTSETUP_PATH/cryptsetup

--- a/wolfProvider/libcryptsetup/libcryptsetup-v2.6.1-wolfprov.patch
+++ b/wolfProvider/libcryptsetup/libcryptsetup-v2.6.1-wolfprov.patch
@@ -12,10 +12,10 @@ index ccf2112..8800e53 100644
  CS_STR_WITH([plain-mode],   [cipher mode for plain mode], [cbc-essiv:sha256])
  CS_NUM_WITH([plain-keybits],[key length in bits for plain mode], [256])
 diff --git a/lib/crypto_backend/crypto_openssl.c b/lib/crypto_backend/crypto_openssl.c
-index 607ec38..86c0d9f 100644
+index 607ec38..73b137c 100644
 --- a/lib/crypto_backend/crypto_openssl.c
 +++ b/lib/crypto_backend/crypto_openssl.c
-@@ -171,20 +171,20 @@ static int openssl_backend_init(bool fips)
+@@ -171,20 +171,19 @@ static int openssl_backend_init(bool fips)
  		if (!ossl_ctx)
  			return -EINVAL;
  
@@ -28,8 +28,7 @@ index 607ec38..86c0d9f 100644
  
 -		/* Optional */
 -		ossl_legacy = OSSL_PROVIDER_try_load(ossl_ctx, "legacy", 0);
-+		/* Load wolfProvider instead of legacy */
-+		ossl_legacy = OSSL_PROVIDER_try_load(ossl_ctx, "libwolfprov", 0);
++		ossl_legacy = ossl_default;
  	}
  
  	r = snprintf(backend_version, sizeof(backend_version), "%s %s%s%s",


### PR DESCRIPTION
# Description 

- Disables unsupported algos for FIPS and non FIPS tests
- Loads libwolfprov and does not allow for default and legacy to be an option
