### PR TITLE
python cryptography ossl hardload patch

### DIFF
--- a/wolfProvider/python-cryptography/README.md
+++ b/wolfProvider/python-cryptography/README.md
@@ -1,0 +1,1 @@
+Removes the openssl hardloads in favor of libwolfprov in python cryptography version 38.0.4

--- a/wolfProvider/python-cryptography/python-cryptography-38.0.4-wolfprov.patch
+++ b/wolfProvider/python-cryptography/python-cryptography-38.0.4-wolfprov.patch
@@ -1,0 +1,71 @@
+diff --git a/src/cryptography/hazmat/bindings/openssl/binding.py b/src/cryptography/hazmat/bindings/openssl/binding.py
+index 2b4c574b4..a089a4221 100644
+--- a/src/cryptography/hazmat/bindings/openssl/binding.py
++++ b/src/cryptography/hazmat/bindings/openssl/binding.py
+@@ -170,18 +170,36 @@ class Binding:
+                 # are ugly legacy, but we aren't going to get rid of them
+                 # any time soon.
+                 if cls.lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER:
+-                    cls._legacy_provider = cls.lib.OSSL_PROVIDER_load(
+-                        cls.ffi.NULL, b"legacy"
+-                    )
+-                    _openssl_assert(
+-                        cls.lib, cls._legacy_provider != cls.ffi.NULL
+-                    )
+-                    cls._default_provider = cls.lib.OSSL_PROVIDER_load(
+-                        cls.ffi.NULL, b"default"
+-                    )
+-                    _openssl_assert(
+-                        cls.lib, cls._default_provider != cls.ffi.NULL
+-                    )
++                    # Check if wolfProvider is configured via OPENSSL_CONF
++                    import os
++                    openssl_conf = os.environ.get('OPENSSL_CONF', '')
++                    if openssl_conf and 'wolfProvider' in openssl_conf:
++                        # Load wolfProvider instead of default providers
++                        cls._legacy_provider = cls.lib.OSSL_PROVIDER_load(
++                            cls.ffi.NULL, b"libwolfprov"
++                        )
++                        _openssl_assert(
++                            cls.lib, cls._legacy_provider != cls.ffi.NULL
++                        )
++                        cls._default_provider = cls.lib.OSSL_PROVIDER_load(
++                            cls.ffi.NULL, b"libwolfprov"
++                        )
++                        _openssl_assert(
++                            cls.lib, cls._default_provider != cls.ffi.NULL
++                        )
++                    else:
++                        cls._legacy_provider = cls.lib.OSSL_PROVIDER_load(
++                            cls.ffi.NULL, b"legacy"
++                        )
++                        _openssl_assert(
++                            cls.lib, cls._legacy_provider != cls.ffi.NULL
++                        )
++                        cls._default_provider = cls.lib.OSSL_PROVIDER_load(
++                            cls.ffi.NULL, b"default"
++                        )
++                        _openssl_assert(
++                            cls.lib, cls._default_provider != cls.ffi.NULL
++                        )
+
+     @classmethod
+     def init_static_locks(cls):
+diff --git a/tests/hazmat/backends/test_openssl_memleak.py b/tests/hazmat/backends/test_openssl_memleak.py
+index 2605566bd..406a4d2e0 100644
+--- a/tests/hazmat/backends/test_openssl_memleak.py
++++ b/tests/hazmat/backends/test_openssl_memleak.py
+@@ -97,8 +97,10 @@ def main(argv):
+         gc.collect()
+
+         if lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER:
+-            lib.OSSL_PROVIDER_unload(backend._binding._legacy_provider)
+-            lib.OSSL_PROVIDER_unload(backend._binding._default_provider)
++            if backend._binding._legacy_provider is not None:
++                lib.OSSL_PROVIDER_unload(backend._binding._legacy_provider)
++            if backend._binding._default_provider is not None:
++                lib.OSSL_PROVIDER_unload(backend._binding._default_provider)
+
+         if lib.Cryptography_HAS_OPENSSL_CLEANUP:
+             lib.OPENSSL_cleanup()
+


### PR DESCRIPTION
Removes the openssl hard loading in favor of libwolfprov in python cryptography version 38.0.4. Main branch doesn't have hard loading and does not need this patch.