### PR TITLE
(wireguard-go) Use Wc_HmacAllocAligned and Wc_HmacFreeAllocAligned

### DIFF
--- a/wireguard-go/Wireguard-Go-FIPS-wolfCrypt-port.patch
+++ b/wireguard-go/Wireguard-Go-FIPS-wolfCrypt-port.patch
@@ -5,22 +5,22 @@ Subject: [PATCH] FIPS wolfCrypt port
 
 ---
  Makefile                 |  10 +-
- device/cookie.go         | 202 +++++++++++++++++++++--------------
+ device/cookie.go         | 210 +++++++++++++++++++++--------------
  device/cookie_test.go    |   7 --
  device/device_test.go    |   7 +-
  device/indextable.go     |  17 ++-
  device/kdf_test.go       |  35 +++---
  device/keypair.go        |   5 +-
- device/noise-helpers.go  | 169 ++++++++++++++++++++---------
- device/noise-protocol.go | 223 ++++++++++++++++++++++-----------------
+ device/noise-helpers.go  | 171 +++++++++++++++++++---------
+ device/noise-protocol.go | 233 ++++++++++++++++++++++-----------------
  device/noise-types.go    |  10 +-
- device/noise_test.go     |  45 ++++++--
- device/receive.go        |  27 ++---
- device/send.go           |  20 ++--
+ device/noise_test.go     |  52 +++++++--
+ device/receive.go        |  28 +++--
+ device/send.go           |  21 ++--
  device/uapi.go           |  11 +-
  main.go                  |   4 +-
  main_windows.go          |   2 +-
- 16 files changed, 477 insertions(+), 317 deletions(-)
+ 16 files changed, 505 insertions(+), 318 deletions(-)
 
 diff --git a/Makefile b/Makefile
 index 3f6e407..09e19ef 100644
@@ -51,7 +51,7 @@ index 3f6e407..09e19ef 100644
  
  .PHONY: all clean test install generate-version-and-build
 diff --git a/device/cookie.go b/device/cookie.go
-index 876f05d..b428eda 100644
+index 876f05d..01fd512 100644
 --- a/device/cookie.go
 +++ b/device/cookie.go
 @@ -6,38 +6,36 @@
@@ -60,9 +60,9 @@ index 876f05d..b428eda 100644
  import (
 -	"crypto/hmac"
 -	"crypto/rand"
++	"errors"
  	"sync"
  	"time"
-+	"errors"
  
 -	"golang.org/x/crypto/blake2s"
 -	"golang.org/x/crypto/chacha20poly1305"
@@ -135,7 +135,7 @@ index 876f05d..b428eda 100644
  	}()
  
  	st.mac2.secretSet = time.Time{}
-@@ -71,16 +73,19 @@ func (st *CookieChecker) CheckMAC1(msg []byte) bool {
+@@ -71,16 +73,20 @@ func (st *CookieChecker) CheckMAC1(msg []byte) bool {
  	defer st.RUnlock()
  
  	size := len(msg)
@@ -150,19 +150,20 @@ index 876f05d..b428eda 100644
 -	mac, _ := blake2s.New128(st.mac1.key[:])
 -	mac.Write(msg[:smac1])
 -	mac.Sum(mac1[:0])
-+        var hmac wolfSSL.Hmac
-+        wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, st.mac1.key[:], len(st.mac1.key[:]))
-+        wolfSSL.Wc_HmacUpdate(&hmac, msg[:smac1], len(msg[:smac1]))
-+        wolfSSL.Wc_HmacFinal(&hmac, mac1[:])
-+        wolfSSL.Wc_HmacFree(&hmac)
++        hmac := wolfSSL.Wc_HmacAllocAligned()
++        wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, st.mac1.key[:], len(st.mac1.key[:]))
++        wolfSSL.Wc_HmacUpdate(hmac, msg[:smac1], len(msg[:smac1]))
++        wolfSSL.Wc_HmacFinal(hmac, mac1[:])
++        wolfSSL.Wc_HmacFree(hmac)
++        wolfSSL.Wc_HmacFreeAllocAligned(hmac)
  
 -	return hmac.Equal(mac1[:], msg[smac1:smac2])
 +        return wolfSSL.ConstantCompare(mac1[:], msg[smac1:smac2], len(mac1)) == 1
  }
  
  func (st *CookieChecker) CheckMAC2(msg, src []byte) bool {
-@@ -93,25 +98,31 @@ func (st *CookieChecker) CheckMAC2(msg, src []byte) bool {
+@@ -93,25 +99,33 @@ func (st *CookieChecker) CheckMAC2(msg, src []byte) bool {
  
  	// derive cookie key
  
@@ -173,12 +174,13 @@ index 876f05d..b428eda 100644
 -		mac.Write(src)
 -		mac.Sum(cookie[:0])
 -	}()
-+                var hmac wolfSSL.Hmac
-+                wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, st.mac2.secret[:], len(st.mac2.secret[:]))
-+                wolfSSL.Wc_HmacUpdate(&hmac, src, len(src))
-+                wolfSSL.Wc_HmacFinal(&hmac, cookie[:])
-+                wolfSSL.Wc_HmacFree(&hmac)
++                hmac := wolfSSL.Wc_HmacAllocAligned()
++                wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, st.mac2.secret[:], len(st.mac2.secret[:]))
++                wolfSSL.Wc_HmacUpdate(hmac, src, len(src))
++                wolfSSL.Wc_HmacFinal(hmac, cookie[:])
++                wolfSSL.Wc_HmacFree(hmac)
++                wolfSSL.Wc_HmacFreeAllocAligned(hmac)
 +        }()
  
  	// calculate mac of packet (including mac1)
@@ -195,19 +197,20 @@ index 876f05d..b428eda 100644
 -	}()
 -
 -	return hmac.Equal(mac2[:], msg[smac2:])
-+                var hmac wolfSSL.Hmac
-+                wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, cookie[:], len(cookie[:]))
-+                wolfSSL.Wc_HmacUpdate(&hmac, msg[:smac2], len(msg[:smac2]))
-+                wolfSSL.Wc_HmacFinal(&hmac, mac2[:])
-+                wolfSSL.Wc_HmacFree(&hmac)
++                hmac := wolfSSL.Wc_HmacAllocAligned()
++                wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, cookie[:], len(cookie[:]))
++                wolfSSL.Wc_HmacUpdate(hmac, msg[:smac2], len(msg[:smac2]))
++                wolfSSL.Wc_HmacFinal(hmac, mac2[:])
++                wolfSSL.Wc_HmacFree(hmac)
++                wolfSSL.Wc_HmacFreeAllocAligned(hmac)
 +        }()
 +
 +        return wolfSSL.ConstantCompare(mac2[:], msg[smac2:], len(mac2)) == 1
  }
  
  func (st *CookieChecker) CreateReply(
-@@ -126,44 +137,56 @@ func (st *CookieChecker) CreateReply(
+@@ -126,44 +140,58 @@ func (st *CookieChecker) CreateReply(
  	if time.Since(st.mac2.secretSet) > CookieRefreshTime {
  		st.RUnlock()
  		st.Lock()
@@ -237,12 +240,13 @@ index 876f05d..b428eda 100644
 -		mac.Write(src)
 -		mac.Sum(cookie[:0])
 -	}()
-+                var hmac wolfSSL.Hmac
-+                wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, st.mac2.secret[:], len(st.mac2.secret[:]))
-+                wolfSSL.Wc_HmacUpdate(&hmac, src, len(src))
-+                wolfSSL.Wc_HmacFinal(&hmac, cookie[:])
-+                wolfSSL.Wc_HmacFree(&hmac)
++                hmac := wolfSSL.Wc_HmacAllocAligned()
++                wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, st.mac2.secret[:], len(st.mac2.secret[:]))
++                wolfSSL.Wc_HmacUpdate(hmac, src, len(src))
++                wolfSSL.Wc_HmacFinal(hmac, cookie[:])
++                wolfSSL.Wc_HmacFree(hmac)
++                wolfSSL.Wc_HmacFreeAllocAligned(hmac)
 +        }()
  
  	// encrypt cookie
@@ -273,15 +277,16 @@ index 876f05d..b428eda 100644
  
 -	xchapoly, _ := chacha20poly1305.NewX(st.mac2.encryptionKey[:])
 -	xchapoly.Seal(reply.Cookie[:0], reply.Nonce[:], cookie[:], msg[smac1:smac2])
-+        var aes wolfSSL.Aes
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, reply.Cookie[:], cookie[:], reply.Nonce[:], msg[smac1:smac2])
-+        wolfSSL.Wc_AesFree(&aes)
++	aes := wolfSSL.Wc_AesAllocAligned()
++	wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
++        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, reply.Cookie[:], cookie[:], reply.Nonce[:], msg[smac1:smac2])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
  
  	st.RUnlock()
  
-@@ -175,18 +198,24 @@ func (st *CookieGenerator) Init(pk NoisePublicKey) {
+@@ -175,18 +203,24 @@ func (st *CookieGenerator) Init(pk NoisePublicKey) {
  	defer st.Unlock()
  
  	func() {
@@ -316,7 +321,7 @@ index 876f05d..b428eda 100644
  
  	st.mac2.cookieSet = time.Time{}
  }
-@@ -199,11 +228,16 @@ func (st *CookieGenerator) ConsumeReply(msg *MessageCookieReply) bool {
+@@ -199,11 +233,17 @@ func (st *CookieGenerator) ConsumeReply(msg *MessageCookieReply) bool {
  		return false
  	}
  
@@ -327,17 +332,18 @@ index 876f05d..b428eda 100644
 -	xchapoly, _ := chacha20poly1305.NewX(st.mac2.encryptionKey[:])
 -	_, err := xchapoly.Open(cookie[:0], msg.Nonce[:], msg.Cookie[:], st.mac2.lastMAC1[:])
 -	if err != nil {
-+        var aes wolfSSL.Aes
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
-+        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, cookie[:], msg.Cookie[:], msg.Nonce[:], st.mac2.lastMAC1[:])
-+        wolfSSL.Wc_AesFree(&aes)
++	aes := wolfSSL.Wc_AesAllocAligned()
++        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
++        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, cookie[:], msg.Cookie[:], msg.Nonce[:], st.mac2.lastMAC1[:])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
 +	if ret < 0 {
  		return false
  	}
  
-@@ -215,8 +249,8 @@ func (st *CookieGenerator) ConsumeReply(msg *MessageCookieReply) bool {
+@@ -215,8 +255,8 @@ func (st *CookieGenerator) ConsumeReply(msg *MessageCookieReply) bool {
  func (st *CookieGenerator) AddMacs(msg []byte) {
  	size := len(msg)
  
@@ -348,7 +354,7 @@ index 876f05d..b428eda 100644
  
  	mac1 := msg[smac1:smac2]
  	mac2 := msg[smac2:]
-@@ -227,10 +261,13 @@ func (st *CookieGenerator) AddMacs(msg []byte) {
+@@ -227,10 +267,14 @@ func (st *CookieGenerator) AddMacs(msg []byte) {
  	// set mac1
  
  	func() {
@@ -356,17 +362,18 @@ index 876f05d..b428eda 100644
 -		mac.Write(msg[:smac1])
 -		mac.Sum(mac1[:0])
 -	}()
-+                var hmac wolfSSL.Hmac
-+                wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, st.mac1.key[:], len(st.mac1.key[:]))
-+                wolfSSL.Wc_HmacUpdate(&hmac, msg[:smac1], len(msg[:smac1]))
-+                wolfSSL.Wc_HmacFinal(&hmac, mac1[:])
-+                wolfSSL.Wc_HmacFree(&hmac)
++                hmac := wolfSSL.Wc_HmacAllocAligned()
++                wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, st.mac1.key[:], len(st.mac1.key[:]))
++                wolfSSL.Wc_HmacUpdate(hmac, msg[:smac1], len(msg[:smac1]))
++                wolfSSL.Wc_HmacFinal(hmac, mac1[:])
++                wolfSSL.Wc_HmacFree(hmac)
++                wolfSSL.Wc_HmacFreeAllocAligned(hmac)
 +        }()
  	copy(st.mac2.lastMAC1[:], mac1)
  	st.mac2.hasLastMAC1 = true
  
-@@ -241,8 +278,11 @@ func (st *CookieGenerator) AddMacs(msg []byte) {
+@@ -241,8 +285,12 @@ func (st *CookieGenerator) AddMacs(msg []byte) {
  	}
  
  	func() {
@@ -374,12 +381,13 @@ index 876f05d..b428eda 100644
 -		mac.Write(msg[:smac2])
 -		mac.Sum(mac2[:0])
 -	}()
-+                var hmac wolfSSL.Hmac
-+                wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, st.mac2.cookie[:], len(st.mac2.cookie[:]))
-+                wolfSSL.Wc_HmacUpdate(&hmac, msg[:smac2], len(msg[:smac2]))
-+                wolfSSL.Wc_HmacFinal(&hmac, mac2[:])
-+                wolfSSL.Wc_HmacFree(&hmac)
++                hmac := wolfSSL.Wc_HmacAllocAligned()
++                wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, st.mac2.cookie[:], len(st.mac2.cookie[:]))
++                wolfSSL.Wc_HmacUpdate(hmac, msg[:smac2], len(msg[:smac2]))
++                wolfSSL.Wc_HmacFinal(hmac, mac2[:])
++                wolfSSL.Wc_HmacFree(hmac)
++                wolfSSL.Wc_HmacFreeAllocAligned(hmac)
 +        }()
  }
 diff --git a/device/cookie_test.go b/device/cookie_test.go
@@ -562,10 +570,10 @@ index e3540d7..4062e01 100644
  	isInitiator  bool
  	created      time.Time
 diff --git a/device/noise-helpers.go b/device/noise-helpers.go
-index c2f356b..85c0a54 100644
+index c2f356b..43d0aab 100644
 --- a/device/noise-helpers.go
 +++ b/device/noise-helpers.go
-@@ -6,56 +6,50 @@
+@@ -6,56 +6,52 @@
  package device
  
  import (
@@ -594,12 +602,13 @@ index c2f356b..85c0a54 100644
 -	mac.Write(in0)
 -	mac.Sum(sum[:0])
 +func HMAC1(sum []byte, key, in0 []byte) {
-+        var hmac wolfSSL.Hmac
-+        wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, key, len(key[:]))
-+        wolfSSL.Wc_HmacUpdate(&hmac, in0, len(in0[:]))
-+        wolfSSL.Wc_HmacFinal(&hmac, sum)
-+        wolfSSL.Wc_HmacFree(&hmac)
++        hmac := wolfSSL.Wc_HmacAllocAligned()
++        wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, key, len(key[:]))
++        wolfSSL.Wc_HmacUpdate(hmac, in0, len(in0[:]))
++        wolfSSL.Wc_HmacFinal(hmac, sum)
++        wolfSSL.Wc_HmacFree(hmac)
++        wolfSSL.Wc_HmacFreeAllocAligned(hmac)
  }
  
 -func HMAC2(sum *[blake2s.Size]byte, key, in0, in1 []byte) {
@@ -611,13 +620,14 @@ index c2f356b..85c0a54 100644
 -	mac.Write(in1)
 -	mac.Sum(sum[:0])
 +func HMAC2(sum []byte, key, in0, in1 []byte) {
-+        var hmac wolfSSL.Hmac
-+        wolfSSL.Wc_HmacInit(&hmac, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_HmacSetKey(&hmac, wolfSSL.WC_SHA256, key, len(key[:]))
-+        wolfSSL.Wc_HmacUpdate(&hmac, in0, len(in0[:]))
-+        wolfSSL.Wc_HmacUpdate(&hmac, in1, len(in1[:]))
-+        wolfSSL.Wc_HmacFinal(&hmac, sum)
-+        wolfSSL.Wc_HmacFree(&hmac)
++        hmac := wolfSSL.Wc_HmacAllocAligned()
++        wolfSSL.Wc_HmacInit(hmac, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_HmacSetKey(hmac, wolfSSL.WC_SHA256, key, len(key[:]))
++        wolfSSL.Wc_HmacUpdate(hmac, in0, len(in0[:]))
++        wolfSSL.Wc_HmacUpdate(hmac, in1, len(in1[:]))
++        wolfSSL.Wc_HmacFinal(hmac, sum)
++        wolfSSL.Wc_HmacFree(hmac)
++        wolfSSL.Wc_HmacFreeAllocAligned(hmac)
  }
  
 -func KDF1(t0 *[blake2s.Size]byte, key, input []byte) {
@@ -646,7 +656,7 @@ index c2f356b..85c0a54 100644
  	HMAC1(t0, prk[:], []byte{0x1})
  	HMAC2(t1, prk[:], t0[:], []byte{0x2})
  	HMAC2(t2, prk[:], t1[:], []byte{0x3})
-@@ -63,11 +57,11 @@ func KDF3(t0, t1, t2 *[blake2s.Size]byte, key, input []byte) {
+@@ -63,11 +59,11 @@ func KDF3(t0, t1, t2 *[blake2s.Size]byte, key, input []byte) {
  }
  
  func isZero(val []byte) bool {
@@ -663,7 +673,7 @@ index c2f356b..85c0a54 100644
  }
  
  /* This function is not used as pervasively as it should because this is mostly impossible in Go at the moment */
-@@ -77,32 +71,103 @@ func setZero(arr []byte) {
+@@ -77,32 +73,103 @@ func setZero(arr []byte) {
  	}
  }
  
@@ -785,7 +795,7 @@ index c2f356b..85c0a54 100644
  }
 +
 diff --git a/device/noise-protocol.go b/device/noise-protocol.go
-index e8f6145..bb1d6e0 100644
+index e8f6145..984e09d 100644
 --- a/device/noise-protocol.go
 +++ b/device/noise-protocol.go
 @@ -10,10 +10,9 @@ import (
@@ -948,7 +958,7 @@ index e8f6145..bb1d6e0 100644
  }
  
  func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, error) {
-@@ -206,15 +214,19 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
+@@ -206,15 +214,20 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
  	if err != nil {
  		return nil, err
  	}
@@ -965,15 +975,16 @@ index e8f6145..bb1d6e0 100644
 -	aead, _ := chacha20poly1305.New(key[:])
 -	aead.Seal(msg.Static[:0], ZeroNonce[:], device.staticIdentity.publicKey[:], handshake.hash[:])
 +
-+        var aes wolfSSL.Aes
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, msg.Static[:], device.staticIdentity.publicKey[:], ZeroNonce[:], handshake.hash[:])
-+        wolfSSL.Wc_AesFree(&aes)
++	aes := wolfSSL.Wc_AesAllocAligned()
++        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
++        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, msg.Static[:], device.staticIdentity.publicKey[:], ZeroNonce[:], handshake.hash[:])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
  	handshake.mixHash(msg.Static[:])
  
  	// encrypt timestamp
-@@ -222,16 +234,18 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
+@@ -222,16 +235,20 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
  		return nil, errInvalidPublicKey
  	}
  	KDF2(
@@ -987,17 +998,20 @@ index e8f6145..bb1d6e0 100644
  	timestamp := tai64n.Now()
 -	aead, _ = chacha20poly1305.New(key[:])
 -	aead.Seal(msg.Timestamp[:0], ZeroNonce[:], timestamp[:], handshake.hash[:])
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, msg.Timestamp[:], timestamp[:], ZeroNonce[:], handshake.hash[:])
-+        wolfSSL.Wc_AesFree(&aes)
- 
+-
 -	// assign index
++	aes = wolfSSL.Wc_AesAllocAligned()
++        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
++        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, msg.Timestamp[:], timestamp[:], ZeroNonce[:], handshake.hash[:])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
++
 +        // assign index
  	device.indexTable.Delete(handshake.localIndex)
  	msg.Sender, err = device.indexTable.NewIndexForHandshake(peer, handshake)
  	if err != nil {
-@@ -246,8 +260,8 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
+@@ -246,8 +263,8 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
  
  func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
  	var (
@@ -1008,7 +1022,7 @@ index e8f6145..bb1d6e0 100644
  	)
  
  	if msg.Type != MessageInitiationType {
-@@ -257,24 +271,24 @@ func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
+@@ -257,24 +274,25 @@ func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
  	device.staticIdentity.RLock()
  	defer device.staticIdentity.RUnlock()
  
@@ -1035,16 +1049,17 @@ index e8f6145..bb1d6e0 100644
 -	}
 -	mixHash(&hash, &hash, msg.Static[:])
 +        KDF2(chainKey[:], key[:], chainKey[:], ss[:])
-+        var aes wolfSSL.Aes
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, peerPK[:], msg.Static[:], ZeroNonce[:], hash[:])
-+        wolfSSL.Wc_AesFree(&aes)
++	aes := wolfSSL.Wc_AesAllocAligned()
++        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
++        wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, peerPK[:], msg.Static[:], ZeroNonce[:], hash[:])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
 +        mixHash(hash[:], hash[:], msg.Static[:])
  
  	// lookup peer
  
-@@ -296,18 +310,20 @@ func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
+@@ -296,18 +314,22 @@ func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
  		return nil
  	}
  	KDF2(
@@ -1058,10 +1073,12 @@ index e8f6145..bb1d6e0 100644
 -	aead, _ = chacha20poly1305.New(key[:])
 -	_, err = aead.Open(timestamp[:0], ZeroNonce[:], msg.Timestamp[:], hash[:])
 -	if err != nil {
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
-+        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, timestamp[:], msg.Timestamp[:], ZeroNonce[:], hash[:])
-+        wolfSSL.Wc_AesFree(&aes)
++	aes = wolfSSL.Wc_AesAllocAligned()
++        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
++        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, timestamp[:], msg.Timestamp[:], ZeroNonce[:], hash[:])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
 +        if ret < 0 {
  		handshake.mutex.RUnlock()
  		return nil
@@ -1071,7 +1088,7 @@ index e8f6145..bb1d6e0 100644
  
  	// protect against replay & flood
  
-@@ -394,21 +410,25 @@ func (device *Device) CreateMessageResponse(peer *Peer) (*MessageResponse, error
+@@ -394,21 +416,26 @@ func (device *Device) CreateMessageResponse(peer *Peer) (*MessageResponse, error
  
  	// add preshared key
  
@@ -1095,16 +1112,17 @@ index e8f6145..bb1d6e0 100644
  
 -	aead, _ := chacha20poly1305.New(key[:])
 -	aead.Seal(msg.Empty[:0], ZeroNonce[:], nil, handshake.hash[:])
-+        var aes wolfSSL.Aes
-+        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, msg.Empty[:], nil, ZeroNonce[:], handshake.hash[:])
-+        wolfSSL.Wc_AesFree(&aes)
++	aes := wolfSSL.Wc_AesAllocAligned()
++        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
++        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, msg.Empty[:], nil, ZeroNonce[:], handshake.hash[:])
++        wolfSSL.Wc_AesFree(aes)
++	wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
  	handshake.mixHash(msg.Empty[:])
  
  	handshake.state = handshakeResponseCreated
-@@ -430,8 +450,8 @@ func (device *Device) ConsumeMessageResponse(msg *MessageResponse) *Peer {
+@@ -430,8 +457,8 @@ func (device *Device) ConsumeMessageResponse(msg *MessageResponse) *Peer {
  	}
  
  	var (
@@ -1115,7 +1133,7 @@ index e8f6145..bb1d6e0 100644
  	)
  
  	ok := func() bool {
-@@ -451,44 +471,49 @@ func (device *Device) ConsumeMessageResponse(msg *MessageResponse) *Peer {
+@@ -451,44 +478,50 @@ func (device *Device) ConsumeMessageResponse(msg *MessageResponse) *Peer {
  
  		// finish 3-way DH
  
@@ -1166,11 +1184,12 @@ index e8f6145..bb1d6e0 100644
 -		if err != nil {
 -			return false
 +                var authTag [wolfSSL.AES_BLOCK_SIZE]byte
-+                var aes wolfSSL.Aes
-+                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
-+        	wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, authTag[:], nil, ZeroNonce[:], hash[:])
-+                wolfSSL.Wc_AesFree(&aes)
++		aes := wolfSSL.Wc_AesAllocAligned()
++                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
++        	wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, authTag[:], nil, ZeroNonce[:], hash[:])
++                wolfSSL.Wc_AesFree(aes)
++		wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
 +                if !bytes.Equal(authTag[:], msg.Empty[:]) {
 +                    return false
@@ -1180,7 +1199,7 @@ index e8f6145..bb1d6e0 100644
  		return true
  	}()
  
-@@ -525,21 +550,21 @@ func (peer *Peer) BeginSymmetricSession() error {
+@@ -525,21 +558,21 @@ func (peer *Peer) BeginSymmetricSession() error {
  	// derive keys
  
  	var isInitiator bool
@@ -1208,7 +1227,7 @@ index e8f6145..bb1d6e0 100644
  			handshake.chainKey[:],
  			nil,
  		)
-@@ -558,13 +583,13 @@ func (peer *Peer) BeginSymmetricSession() error {
+@@ -558,13 +591,13 @@ func (peer *Peer) BeginSymmetricSession() error {
  	// create AEAD instances
  
  	keypair := new(Keypair)
@@ -1278,7 +1297,7 @@ index e850359..fa2450a 100644
  
  func (key *NoisePresharedKey) FromHex(src string) error {
 diff --git a/device/noise_test.go b/device/noise_test.go
-index 2dd5324..ee166a4 100644
+index 2dd5324..defb692 100644
 --- a/device/noise_test.go
 +++ b/device/noise_test.go
 @@ -10,6 +10,7 @@ import (
@@ -1302,7 +1321,7 @@ index 2dd5324..ee166a4 100644
  func TestNoiseHandshake(t *testing.T) {
  	dev1 := randDevice(t)
  	dev2 := randDevice(t)
-@@ -157,23 +164,41 @@ func TestNoiseHandshake(t *testing.T) {
+@@ -157,23 +164,48 @@ func TestNoiseHandshake(t *testing.T) {
  
  	func() {
  		testMsg := []byte("wireguard test message 1")
@@ -1313,17 +1332,21 @@ index 2dd5324..ee166a4 100644
 -		out, err = key2.receive.Open(out[:0], nonce[:], out, nil)
 -		assertNil(t, err)
 -		assertEqual(t, out, testMsg)
-+                var aes wolfSSL.Aes
 +
-+                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(&aes, key1.send[:], len(key1.send[:]))
-+                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, out, testMsg, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(&aes)
++		aes := wolfSSL.Wc_AesAllocAligned()
++                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_AesGcmSetKey(aes, key1.send[:], len(key1.send[:]))
++                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, out, testMsg, nonce[:], nil)
++                wolfSSL.Wc_AesFree(aes)
++		wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
-+                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(&aes, key2.receive[:], len(key2.receive[:]))
-+                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, out, out, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(&aes)
++
++		aes = wolfSSL.Wc_AesAllocAligned()
++                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_AesGcmSetKey(aes, key2.receive[:], len(key2.receive[:]))
++                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, out, out, nonce[:], nil)
++                wolfSSL.Wc_AesFree(aes)
++		wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
 +		assertIntEqual(t, ret, 0)
 +                assertEqual(t, out[:len(out)-wolfSSL.AES_BLOCK_SIZE], testMsg)
@@ -1338,24 +1361,27 @@ index 2dd5324..ee166a4 100644
 -		out, err = key1.receive.Open(out[:0], nonce[:], out, nil)
 -		assertNil(t, err)
 -		assertEqual(t, out, testMsg)
-+                var aes wolfSSL.Aes
 +
-+                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(&aes, key2.send[:], len(key2.send[:]))
-+                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, out, testMsg, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(&aes)
++		aes := wolfSSL.Wc_AesAllocAligned()
++                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_AesGcmSetKey(aes, key2.send[:], len(key2.send[:]))
++                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, out, testMsg, nonce[:], nil)
++                wolfSSL.Wc_AesFree(aes)
++		wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
-+                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(&aes, key1.receive[:], len(key1.receive[:]))
-+                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, out, out, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(&aes)
++		aes = wolfSSL.Wc_AesAllocAligned()
++                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                wolfSSL.Wc_AesGcmSetKey(aes, key1.receive[:], len(key1.receive[:]))
++                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, out, out, nonce[:], nil)
++                wolfSSL.Wc_AesFree(aes)
++		wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
 +		assertIntEqual(t, ret, 0)
 +                assertEqual(t, out[:len(out)-wolfSSL.AES_BLOCK_SIZE], testMsg)
  	}()
  }
 diff --git a/device/receive.go b/device/receive.go
-index 1ab3e29..38ab0ed 100644
+index 1ab3e29..bcf679a 100644
 --- a/device/receive.go
 +++ b/device/receive.go
 @@ -13,7 +13,7 @@ import (
@@ -1376,7 +1402,7 @@ index 1ab3e29..38ab0ed 100644
  
  	defer device.log.Verbosef("Routine: decryption worker %d - stopped", id)
  	device.log.Verbosef("Routine: decryption worker %d - started", id)
-@@ -249,20 +249,23 @@ func (device *Device) RoutineDecryption(id int) {
+@@ -249,20 +249,24 @@ func (device *Device) RoutineDecryption(id int) {
  			content := elem.packet[MessageTransportOffsetContent:]
  
  			// decrypt and release to consumer
@@ -1392,11 +1418,12 @@ index 1ab3e29..38ab0ed 100644
 -			)
 -			if err != nil {
 +
-+                        var aes wolfSSL.Aes
-+                        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                        wolfSSL.Wc_AesGcmSetKey(&aes, elem.keypair.receive[:], len(elem.keypair.receive[:]))
-+                        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, content, content, nonce[:], nil)
-+                        wolfSSL.Wc_AesFree(&aes)
++			aes := wolfSSL.Wc_AesAllocAligned()
++                        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                        wolfSSL.Wc_AesGcmSetKey(aes, elem.keypair.receive[:], len(elem.keypair.receive[:]))
++                        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, content, content, nonce[:], nil)
++                        wolfSSL.Wc_AesFree(aes)
++			wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
 +			if ret < 0 {
  				elem.packet = nil
@@ -1411,7 +1438,7 @@ index 1ab3e29..38ab0ed 100644
  	}
  }
 diff --git a/device/send.go b/device/send.go
-index 769720a..458b63f 100644
+index 769720a..45c2382 100644
 --- a/device/send.go
 +++ b/device/send.go
 @@ -14,7 +14,7 @@ import (
@@ -1432,7 +1459,7 @@ index 769720a..458b63f 100644
  
  	defer device.log.Verbosef("Routine: encryption worker %d - stopped", id)
  	device.log.Verbosef("Routine: encryption worker %d - started", id)
-@@ -468,13 +468,15 @@ func (device *Device) RoutineEncryption(id int) {
+@@ -468,13 +468,16 @@ func (device *Device) RoutineEncryption(id int) {
  			// encrypt content and release to consumer
  
  			binary.LittleEndian.PutUint64(nonce[4:], elem.nonce)
@@ -1444,11 +1471,12 @@ index 769720a..458b63f 100644
 -			)
 -		}
 +
-+                        var aes wolfSSL.Aes
-+                        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
-+                        wolfSSL.Wc_AesGcmSetKey(&aes, elem.keypair.send[:], len(elem.keypair.send[:]))
-+                        elem.packet, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, elem.packet, elem.packet, nonce[:], nil)
-+                        wolfSSL.Wc_AesFree(&aes)
++			aes := wolfSSL.Wc_AesAllocAligned()
++                        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
++                        wolfSSL.Wc_AesGcmSetKey(aes, elem.keypair.send[:], len(elem.keypair.send[:]))
++                        elem.packet, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, elem.packet, elem.packet, nonce[:], nil)
++                        wolfSSL.Wc_AesFree(aes)
++			wolfSSL.Wc_AesFreeAllocAligned(aes)
 +
 +                        elem.packet = append(header[:], elem.packet[:]...)
 +                    }
@@ -1534,266 +1562,5 @@ index a4dc46f..7bc6b6b 100644
  	tun, err := tun.CreateTUN(interfaceName, 0)
  	if err == nil {
 -- 
-diff --git a/device/cookie.go b/device/cookie.go
-index b428eda..a6d3c12 100644
---- a/device/cookie.go
-+++ b/device/cookie.go
-@@ -182,11 +182,12 @@ func (st *CookieChecker) CreateReply(
-                 return nil, errors.New("RNG failed")
-         }
- 
--        var aes wolfSSL.Aes
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
--        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, reply.Cookie[:], cookie[:], reply.Nonce[:], msg[smac1:smac2])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes := wolfSSL.Wc_AesAllocAligned()
-+	wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, reply.Cookie[:], cookie[:], reply.Nonce[:], msg[smac1:smac2])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
- 	st.RUnlock()
- 
-@@ -231,11 +232,12 @@ func (st *CookieGenerator) ConsumeReply(msg *MessageCookieReply) bool {
- 	var cookie [wolfSSL.WC_SHA256_DIGEST_SIZE]byte
- 
- 
--        var aes wolfSSL.Aes
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
--        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, cookie[:], msg.Cookie[:], msg.Nonce[:], st.mac2.lastMAC1[:])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes := wolfSSL.Wc_AesAllocAligned()
-+        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, st.mac2.encryptionKey[:], len(st.mac2.encryptionKey[:]))
-+        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, cookie[:], msg.Cookie[:], msg.Nonce[:], st.mac2.lastMAC1[:])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
- 	if ret < 0 {
- 		return false
-diff --git a/device/noise-protocol.go b/device/noise-protocol.go
-index bb1d6e0..984e09d 100644
---- a/device/noise-protocol.go
-+++ b/device/noise-protocol.go
-@@ -222,11 +222,12 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
- 		ss[:],
- 	)
- 
--        var aes wolfSSL.Aes
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
--        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, msg.Static[:], device.staticIdentity.publicKey[:], ZeroNonce[:], handshake.hash[:])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes := wolfSSL.Wc_AesAllocAligned()
-+        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, msg.Static[:], device.staticIdentity.publicKey[:], ZeroNonce[:], handshake.hash[:])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
- 	handshake.mixHash(msg.Static[:])
- 
- 	// encrypt timestamp
-@@ -240,10 +241,12 @@ func (device *Device) CreateMessageInitiation(peer *Peer) (*MessageInitiation, e
- 		handshake.precomputedStaticStatic[:],
- 	)
- 	timestamp := tai64n.Now()
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
--        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, msg.Timestamp[:], timestamp[:], ZeroNonce[:], handshake.hash[:])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes = wolfSSL.Wc_AesAllocAligned()
-+        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, msg.Timestamp[:], timestamp[:], ZeroNonce[:], handshake.hash[:])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
-         // assign index
- 	device.indexTable.Delete(handshake.localIndex)
-@@ -283,11 +286,12 @@ func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
- 		return nil
- 	}
-         KDF2(chainKey[:], key[:], chainKey[:], ss[:])
--        var aes wolfSSL.Aes
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
--        wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, peerPK[:], msg.Static[:], ZeroNonce[:], hash[:])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes := wolfSSL.Wc_AesAllocAligned()
-+        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, peerPK[:], msg.Static[:], ZeroNonce[:], hash[:])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
-         mixHash(hash[:], hash[:], msg.Static[:])
- 
- 	// lookup peer
-@@ -315,10 +319,12 @@ func (device *Device) ConsumeMessageInitiation(msg *MessageInitiation) *Peer {
- 		chainKey[:],
- 		handshake.precomputedStaticStatic[:],
- 	)
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
--        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, timestamp[:], msg.Timestamp[:], ZeroNonce[:], hash[:])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes = wolfSSL.Wc_AesAllocAligned()
-+        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
-+        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, timestamp[:], msg.Timestamp[:], ZeroNonce[:], hash[:])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
-         if ret < 0 {
- 		handshake.mutex.RUnlock()
- 		return nil
-@@ -423,11 +429,12 @@ func (device *Device) CreateMessageResponse(peer *Peer) (*MessageResponse, error
- 
- 	handshake.mixHash(tau[:])
- 
--        var aes wolfSSL.Aes
--        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--        wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
--        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, msg.Empty[:], nil, ZeroNonce[:], handshake.hash[:])
--        wolfSSL.Wc_AesFree(&aes)
-+	aes := wolfSSL.Wc_AesAllocAligned()
-+        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+        wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
-+        wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, msg.Empty[:], nil, ZeroNonce[:], handshake.hash[:])
-+        wolfSSL.Wc_AesFree(aes)
-+	wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
- 	handshake.mixHash(msg.Empty[:])
- 
-@@ -504,11 +511,12 @@ func (device *Device) ConsumeMessageResponse(msg *MessageResponse) *Peer {
- 		// authenticate transcript
- 
-                 var authTag [wolfSSL.AES_BLOCK_SIZE]byte
--                var aes wolfSSL.Aes
--                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                wolfSSL.Wc_AesGcmSetKey(&aes, key[:], len(key[:]))
--        	wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, authTag[:], nil, ZeroNonce[:], hash[:])
--                wolfSSL.Wc_AesFree(&aes)
-+		aes := wolfSSL.Wc_AesAllocAligned()
-+                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(aes, key[:], len(key[:]))
-+        	wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, authTag[:], nil, ZeroNonce[:], hash[:])
-+                wolfSSL.Wc_AesFree(aes)
-+		wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
-                 if !bytes.Equal(authTag[:], msg.Empty[:]) {
-                     return false
-diff --git a/device/noise_test.go b/device/noise_test.go
-index ee166a4..defb692 100644
---- a/device/noise_test.go
-+++ b/device/noise_test.go
-@@ -166,17 +166,21 @@ func TestNoiseHandshake(t *testing.T) {
- 		testMsg := []byte("wireguard test message 1")
- 		var out []byte
- 		var nonce [12]byte
--                var aes wolfSSL.Aes
- 
--                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                wolfSSL.Wc_AesGcmSetKey(&aes, key1.send[:], len(key1.send[:]))
--                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, out, testMsg, nonce[:], nil)
--                wolfSSL.Wc_AesFree(&aes)
-+		aes := wolfSSL.Wc_AesAllocAligned()
-+                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(aes, key1.send[:], len(key1.send[:]))
-+                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, out, testMsg, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(aes)
-+		wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
--                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                wolfSSL.Wc_AesGcmSetKey(&aes, key2.receive[:], len(key2.receive[:]))
--                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, out, out, nonce[:], nil)
--                wolfSSL.Wc_AesFree(&aes)
-+
-+		aes = wolfSSL.Wc_AesAllocAligned()
-+                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(aes, key2.receive[:], len(key2.receive[:]))
-+                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, out, out, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(aes)
-+		wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
- 		assertIntEqual(t, ret, 0)
-                 assertEqual(t, out[:len(out)-wolfSSL.AES_BLOCK_SIZE], testMsg)
-@@ -186,17 +190,20 @@ func TestNoiseHandshake(t *testing.T) {
- 		testMsg := []byte("wireguard test message 2")
- 		var out []byte
- 		var nonce [12]byte
--                var aes wolfSSL.Aes
--
--                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                wolfSSL.Wc_AesGcmSetKey(&aes, key2.send[:], len(key2.send[:]))
--                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, out, testMsg, nonce[:], nil)
--                wolfSSL.Wc_AesFree(&aes)
- 
--                wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                wolfSSL.Wc_AesGcmSetKey(&aes, key1.receive[:], len(key1.receive[:]))
--                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, out, out, nonce[:], nil)
--                wolfSSL.Wc_AesFree(&aes)
-+		aes := wolfSSL.Wc_AesAllocAligned()
-+                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(aes, key2.send[:], len(key2.send[:]))
-+                out, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, out, testMsg, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(aes)
-+		wolfSSL.Wc_AesFreeAllocAligned(aes)
-+
-+		aes = wolfSSL.Wc_AesAllocAligned()
-+                wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                wolfSSL.Wc_AesGcmSetKey(aes, key1.receive[:], len(key1.receive[:]))
-+                ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, out, out, nonce[:], nil)
-+                wolfSSL.Wc_AesFree(aes)
-+		wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
- 		assertIntEqual(t, ret, 0)
-                 assertEqual(t, out[:len(out)-wolfSSL.AES_BLOCK_SIZE], testMsg)
-diff --git a/device/receive.go b/device/receive.go
-index 38ab0ed..bcf679a 100644
---- a/device/receive.go
-+++ b/device/receive.go
-@@ -253,11 +253,12 @@ func (device *Device) RoutineDecryption(id int) {
- 			// copy counter to nonce
- 			binary.LittleEndian.PutUint64(nonce[0x4:0xc], elem.counter)
- 
--                        var aes wolfSSL.Aes
--                        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                        wolfSSL.Wc_AesGcmSetKey(&aes, elem.keypair.receive[:], len(elem.keypair.receive[:]))
--                        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(&aes, content, content, nonce[:], nil)
--                        wolfSSL.Wc_AesFree(&aes)
-+			aes := wolfSSL.Wc_AesAllocAligned()
-+                        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                        wolfSSL.Wc_AesGcmSetKey(aes, elem.keypair.receive[:], len(elem.keypair.receive[:]))
-+                        ret := wolfSSL.Wc_AesGcm_Appended_Tag_Decrypt(aes, content, content, nonce[:], nil)
-+                        wolfSSL.Wc_AesFree(aes)
-+			wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
- 			if ret < 0 {
- 				elem.packet = nil
-diff --git a/device/send.go b/device/send.go
-index 458b63f..45c2382 100644
---- a/device/send.go
-+++ b/device/send.go
-@@ -469,11 +469,12 @@ func (device *Device) RoutineEncryption(id int) {
- 
- 			binary.LittleEndian.PutUint64(nonce[4:], elem.nonce)
- 
--                        var aes wolfSSL.Aes
--                        wolfSSL.Wc_AesInit(&aes, nil, wolfSSL.INVALID_DEVID)
--                        wolfSSL.Wc_AesGcmSetKey(&aes, elem.keypair.send[:], len(elem.keypair.send[:]))
--                        elem.packet, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(&aes, elem.packet, elem.packet, nonce[:], nil)
--                        wolfSSL.Wc_AesFree(&aes)
-+			aes := wolfSSL.Wc_AesAllocAligned()
-+                        wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
-+                        wolfSSL.Wc_AesGcmSetKey(aes, elem.keypair.send[:], len(elem.keypair.send[:]))
-+                        elem.packet, _ = wolfSSL.Wc_AesGcm_Appended_Tag_Encrypt(aes, elem.packet, elem.packet, nonce[:], nil)
-+                        wolfSSL.Wc_AesFree(aes)
-+			wolfSSL.Wc_AesFreeAllocAligned(aes)
- 
-                         elem.packet = append(header[:], elem.packet[:]...)
-                     }
--- 
-2.39.5 (Apple Git-154)
+2.53.0
 


### PR DESCRIPTION
This is similar to the already existing Wc_AesAllocAligned and Wc_AesFreeAllocAligned. It's needed because Go stack allocation is 8-byte aligned, while certain wolfCrypt functions (namely InitSha256 in this case) rely on 16-byte alignment due to inline asm or compiler optimizations.