### PR TITLE
Python: skip test_parse_cert_CVE_2013_4238 under wolfSSL

### DIFF
--- a/Python/wolfssl-python-3.12.11.patch
+++ b/Python/wolfssl-python-3.12.11.patch
@@ -454,22 +454,20 @@ index b13e37d0cd1..6ca981aac04 100644
                           (('DNS', 'projects.developer.nokia.com'),
                            ('DNS', 'projects.forum.nokia.com'))
                          )
-@@ -465,7 +480,14 @@ def test_parse_cert_CVE_2013_4238(self):
-                    (('emailAddress', 'python-dev@python.org'),))
-         self.assertEqual(p['subject'], subject)
-         self.assertEqual(p['issuer'], subject)
--        if ssl._OPENSSL_API_VERSION >= (0, 9, 8):
+@@ -453,6 +468,13 @@ def test_parse_cert_CVE_2019_5010(self):
+         )
+ 
+     def test_parse_cert_CVE_2013_4238(self):
 +        if ssl.IS_WOLFSSL:
-+            # location of email in list is different
-+            san = (('IP Address', '2001:DB8:0:0:0:0:0:1'),
-+                   ('IP Address', '192.0.2.1'),
-+                   ('URI', 'http://null.python.org\x00http://example.org'),
-+                   ('DNS', 'altnull.python.org\x00example.com'),
-+                   ('email', 'null@python.org\x00user@example.org'))
-+        elif ssl._OPENSSL_API_VERSION >= (0, 9, 8):
-             san = (('DNS', 'altnull.python.org\x00example.com'),
-                    ('email', 'null@python.org\x00user@example.org'),
-                    ('URI', 'http://null.python.org\x00http://example.org'),
++            # wolfSSL rejects NUL bytes in dNSName/rfc822Name/URI SAN entries
++            # during ASN.1 decoding (RFC 5280 4.2.1.6); the cert fails to parse
++            # rather than returning entries with the embedded NULs intact.
++            self.assertRaises(ssl.SSLError,
++                ssl._ssl._test_decode_cert, NULLBYTECERT)
++            return
+         p = ssl._ssl._test_decode_cert(NULLBYTECERT)
+         if support.verbose:
+             sys.stdout.write("\n" + pprint.pformat(p) + "\n")
 @@ -483,7 +505,29 @@ def test_parse_cert_CVE_2013_4238(self):
  
      def test_parse_all_sans(self):

--- a/Python/wolfssl-python-3.13.4.patch
+++ b/Python/wolfssl-python-3.13.4.patch
@@ -454,22 +454,20 @@ index dfd5d2a..0658973 100644
          # extra OCSP and AIA fields
          self.assertEqual(p['OCSP'], ('http://ocsp.verisign.com',))
          self.assertEqual(p['caIssuers'],
-@@ -487,7 +501,14 @@ def test_parse_cert_CVE_2013_4238(self):
-                    (('emailAddress', 'python-dev@python.org'),))
-         self.assertEqual(p['subject'], subject)
-         self.assertEqual(p['issuer'], subject)
--        if ssl._OPENSSL_API_VERSION >= (0, 9, 8):
+@@ -475,6 +489,13 @@ def test_parse_cert_CVE_2019_5010(self):
+         )
+ 
+     def test_parse_cert_CVE_2013_4238(self):
 +        if ssl.IS_WOLFSSL:
-+            # location of email in list is different
-+            san = (('IP Address', '2001:DB8:0:0:0:0:0:1'),
-+                   ('IP Address', '192.0.2.1'),
-+                   ('URI', 'http://null.python.org\x00http://example.org'),
-+                   ('DNS', 'altnull.python.org\x00example.com'),
-+                   ('email', 'null@python.org\x00user@example.org'))
-+        elif ssl._OPENSSL_API_VERSION >= (0, 9, 8):
-             san = (('DNS', 'altnull.python.org\x00example.com'),
-                    ('email', 'null@python.org\x00user@example.org'),
-                    ('URI', 'http://null.python.org\x00http://example.org'),
++            # wolfSSL rejects NUL bytes in dNSName/rfc822Name/URI SAN entries
++            # during ASN.1 decoding (RFC 5280 4.2.1.6); the cert fails to parse
++            # rather than returning entries with the embedded NULs intact.
++            self.assertRaises(ssl.SSLError,
++                ssl._ssl._test_decode_cert, NULLBYTECERT)
++            return
+         p = ssl._ssl._test_decode_cert(NULLBYTECERT)
+         if support.verbose:
+             sys.stdout.write("\n" + pprint.pformat(p) + "\n")
 @@ -505,23 +526,45 @@ def test_parse_cert_CVE_2013_4238(self):
  
      def test_parse_all_sans(self):

--- a/Python/wolfssl-python-3.13.7.patch
+++ b/Python/wolfssl-python-3.13.7.patch
@@ -454,22 +454,20 @@ index 37766288a3c..ab4b915b75d 100644
          # extra OCSP and AIA fields
          self.assertEqual(p['OCSP'], ('http://ocsp.verisign.com',))
          self.assertEqual(p['caIssuers'],
-@@ -488,7 +502,14 @@ def test_parse_cert_CVE_2013_4238(self):
-                    (('emailAddress', 'python-dev@python.org'),))
-         self.assertEqual(p['subject'], subject)
-         self.assertEqual(p['issuer'], subject)
--        if ssl._OPENSSL_API_VERSION >= (0, 9, 8):
+@@ -476,6 +490,13 @@ def test_parse_cert_CVE_2019_5010(self):
+         )
+ 
+     def test_parse_cert_CVE_2013_4238(self):
 +        if ssl.IS_WOLFSSL:
-+            # location of email in list is different
-+            san = (('IP Address', '2001:DB8:0:0:0:0:0:1'),
-+                   ('IP Address', '192.0.2.1'),
-+                   ('URI', 'http://null.python.org\x00http://example.org'),
-+                   ('DNS', 'altnull.python.org\x00example.com'),
-+                   ('email', 'null@python.org\x00user@example.org'))
-+        elif ssl._OPENSSL_API_VERSION >= (0, 9, 8):
-             san = (('DNS', 'altnull.python.org\x00example.com'),
-                    ('email', 'null@python.org\x00user@example.org'),
-                    ('URI', 'http://null.python.org\x00http://example.org'),
++            # wolfSSL rejects NUL bytes in dNSName/rfc822Name/URI SAN entries
++            # during ASN.1 decoding (RFC 5280 4.2.1.6); the cert fails to parse
++            # rather than returning entries with the embedded NULs intact.
++            self.assertRaises(ssl.SSLError,
++                ssl._ssl._test_decode_cert, NULLBYTECERT)
++            return
+         p = ssl._ssl._test_decode_cert(NULLBYTECERT)
+         if support.verbose:
+             sys.stdout.write("\n" + pprint.pformat(p) + "\n")
 @@ -506,23 +527,45 @@ def test_parse_cert_CVE_2013_4238(self):
  
      def test_parse_all_sans(self):


### PR DESCRIPTION
wolfSSL now rejects NUL bytes in dNSName/rfc822Name/URI SAN entries
during ASN.1 decoding (RFC 5280 4.2.1.6), so loading nullbytecert.pem
raises ssl.SSLError instead of returning the SAN list with the embedded
NULs preserved. Update the 3.12.11, 3.13.4, and 3.13.7 patches so the
test asserts the SSLError and returns early, dropping the now-dead
wolfSSL-specific SAN comparison branch.
