### PR TITLE
Index all openssh patches in README

### DIFF
--- a/wolfProvider/openssh/README.md
+++ b/wolfProvider/openssh/README.md
@@ -1,5 +1,25 @@
-These patches are needed to run a full openssh test suite with wolfProvider.
-For V_9_9_P1 testing use the patch `openssh-V_9_9_P1-wolfprov.patch`
-For V_10_0_P2 testing use the patch `openssh-V_10_0_P2-wolfprov.patch`
-For V_10_0_P2 or V_9_9_P1 FIPS testing support use the patch `openssh-FIPS-wolfprov.patch`
-Note: use either the FIPS patch or the normal ones not both.
+These patches adapt the OpenSSH regress test suite to run against
+wolfProvider. Pick the one matching the OpenSSH source you are
+exercising, and pick FIPS or non-FIPS to match the wolfProvider
+build mode.
+
+Non-FIPS:
+
+- `openssh-V_9_9_P1-wolfprov.patch` — upstream openssh-portable, tag
+  `V_9_9_P1`.
+- `openssh-V_10_0_P2-wolfprov.patch` — upstream openssh-portable, tag
+  `V_10_0_P2`.
+
+FIPS:
+
+- `openssh-V_9_6_P1-FIPS-wolfprov.patch` — upstream openssh-portable,
+  tag `V_9_6_P1`.
+- `openssh-RHEL-9.9p1-FIPS-wolfprov.patch` — CentOS Stream 10 / RHEL 10
+  dist-git build of openssh-9.9p1 (the RHEL patch set adds the
+  SSHKDF-routing patch that makes wolfProvider's SSHKDF actually
+  fire during KEX).
+- `openssh-RHEL-10.2p1-FIPS-wolfprov.patch` — Fedora 44 dist-git
+  build of openssh-10.2p1 (same RHEL patch set, newer openssh).
+
+Use either the FIPS patch or the non-FIPS one for a given OpenSSH
+version, not both.


### PR DESCRIPTION
## Summary

The wolfProvider openssh README listed only the two non-FIPS patches plus a stale reference to a `openssh-FIPS-wolfprov.patch` that does not exist in this directory. Three FIPS patches that have landed since (or are landing in flight) had no entries:

- `openssh-V_9_6_P1-FIPS-wolfprov.patch` — upstream openssh-9.6p1
- `openssh-RHEL-9.9p1-FIPS-wolfprov.patch` — RHEL/CentOS Stream 10 dist-git openssh-9.9p1 (#332)
- `openssh-RHEL-10.2p1-FIPS-wolfprov.patch` — Fedora 44 dist-git openssh-10.2p1 (#334)

Rewrites the README with non-FIPS / FIPS sections and a per-patch description of the OpenSSH source it targets. Drops the dangling `openssh-FIPS-wolfprov.patch` reference.

The 10.2p1 entry references a file landing via #334 — once #332 and #334 are merged, every filename in the README resolves. The README change is text-only; merge order doesn't matter mechanically, only stylistically.

## Test plan
- [x] README parses cleanly as Markdown
- [x] Every filename listed exists in the directory after #332 and #334 merge