### PR TITLE
Add Fedora openssh-10.2p1 FIPS patch for wolfProvider

### DIFF
--- a/wolfProvider/openssh/README.md
+++ b/wolfProvider/openssh/README.md
@@ -1,5 +1,25 @@
-These patches are needed to run a full openssh test suite with wolfProvider.
-For V_9_9_P1 testing use the patch `openssh-V_9_9_P1-wolfprov.patch`
-For V_10_0_P2 testing use the patch `openssh-V_10_0_P2-wolfprov.patch`
-For V_10_0_P2 or V_9_9_P1 FIPS testing support use the patch `openssh-FIPS-wolfprov.patch`
-Note: use either the FIPS patch or the normal ones not both.
+These patches adapt the OpenSSH regress test suite to run against
+wolfProvider. Pick the one matching the OpenSSH source you are
+exercising, and pick FIPS or non-FIPS to match the wolfProvider
+build mode.
+
+Non-FIPS:
+
+- `openssh-V_9_9_P1-wolfprov.patch` — upstream openssh-portable, tag
+  `V_9_9_P1`.
+- `openssh-V_10_0_P2-wolfprov.patch` — upstream openssh-portable, tag
+  `V_10_0_P2`.
+
+FIPS:
+
+- `openssh-V_9_6_P1-FIPS-wolfprov.patch` — upstream openssh-portable,
+  tag `V_9_6_P1`.
+- `openssh-RHEL-9.9p1-FIPS-wolfprov.patch` — CentOS Stream 10 / RHEL 10
+  dist-git build of openssh-9.9p1 (the RHEL patch set adds the
+  SSHKDF-routing patch that makes wolfProvider's SSHKDF actually
+  fire during KEX).
+- `openssh-RHEL-10.2p1-FIPS-wolfprov.patch` — Fedora 44 dist-git
+  build of openssh-10.2p1 (same RHEL patch set, newer openssh).
+
+Use either the FIPS patch or the non-FIPS one for a given OpenSSH
+version, not both.

--- a/wolfProvider/openssh/openssh-RHEL-10.2p1-FIPS-wolfprov.patch
+++ b/wolfProvider/openssh/openssh-RHEL-10.2p1-FIPS-wolfprov.patch
@@ -1,0 +1,163 @@
+From: wolfSSL Inc.
+Subject: OpenSSH RHEL 10.2p1 FIPS mode test adjustments for wolfProvider
+Upstream-Status: Inappropriate [wolfSSL-specific FIPS testing for RHEL openssh]
+
+Adjusts the regress test suite of Fedora 44's patched openssh-10.2p1
+(Fedora ships 59 patches on top of upstream 10.2p1, including the
+SSHKDF routing patch openssh-8.0p1-openssl-kdf.patch and the FIPS
+adaptation patch openssh-7.7p1-fips.patch) for FIPS-mode compatibility
+with wolfProvider. Run-time FIPS enforcement, whether the RHEL/Fedora
+FIPS_mode() policy layer or a FIPS-restricted OpenSSL such as the
+wolfProvider fips-baseline build, refuses operations that several of
+openssh's own tests deliberately exercise: MD5 fingerprints, Ed25519
+keys, small RSA, curve25519 kex, SHA1 MACs, chacha20, SHA1-signed DH,
+and post-quantum kex (MLKEM, sntrup761).
+
+These are test-fixture decisions, not defects in the code under test.
+Patch philosophy follows the existing openssh-RHEL-9.9p1-FIPS-wolfprov
+patch: skip aggressively, re-enable selectively if a specific test
+proves useful. For test_kex the approach pins a FIPS-compliant
+cipher/MAC proposal and drops non-FIPS key/kex types, so the unit test
+still runs and exercises SSHKDF.
+
+Differences from the 9.9p1 sibling patch:
+  * t6 and t8 are not dropped: upstream openssh removed the DSA
+    ssh-keygen tests in 10.x, so the targets no longer exist.
+  * test_kex.c gained cipher/mac/key parameters in the
+    do_kex_with_key() signature; the FIPS-compliant cipher/MAC pins
+    are applied unconditionally inside the function body to override
+    callers that pass NULL.
+  * The do_kex() helper now contains a benchmark path keyed on
+    test_is_benchmark(). Regular `make tests` does not enter that
+    path, so the patch leaves it untouched.
+  * Drops the now-redundant direct `#include "ssh-pkcs11-uri.h"` in
+    ssh-pkcs11.c. Fedora's 0052-openssh-10.2p1-pkcs11-uri.patch adds
+    the same include to ssh-pkcs11.h, leaving both pulled into the
+    same translation unit; without include guards on the URI header
+    the struct pkcs11_uri redefinition refuses to compile. Removing
+    the direct include lets the transitive one stand.
+
+Affected files:
+
+  regress/Makefile
+    - REGRESS_TARGETS: drop t1 (RSA-1024 fixture rejected in FIPS),
+      t4 (MD5), t10 and t12 (Ed25519 keygen).
+    - unit: skip test_sshkey, test_sshsig, test_authopt, test_hostkeys.
+      Their testdata/ uses Ed25519/DSA keys that FIPS refuses.
+
+  regress/unittests/kex/test_kex.c
+    - do_kex_with_key: pin FIPS-compliant cipher and MAC proposals
+      (AES-CTR/GCM, HMAC-SHA2) unconditionally so negotiation does not
+      try chacha20 or SHA1 MACs.
+    - do_kex: drop the KEY_ED25519 host-key invocation.
+    - kex_tests: drop curve25519, DH-SHA1, sntrup761, and MLKEM kex
+      invocations. (Fedora's crypto-policies activate the PQ entries
+      that upstream 10.2p1 leaves dormant; the strip is RHEL-specific.)
+
+  ssh-pkcs11.c
+    - Drop the duplicate `#include "ssh-pkcs11-uri.h"`. Fedora's
+      pkcs11-uri patch makes ssh-pkcs11.h pull in the URI header,
+      and the unguarded URI header otherwise produces a struct
+      redefinition error during compile.
+
+Signed-off-by: wolfSSL Inc.
+
+diff --git a/regress/Makefile b/regress/Makefile
+--- a/regress/Makefile
++++ b/regress/Makefile
+@@ -2,7 +2,7 @@
+
+ tests:		prep file-tests t-exec unit
+
+-REGRESS_TARGETS=	t1 t2 t3 t4 t5 t7 t9 t10 t11 t12
++REGRESS_TARGETS=	t2 t3 t5 t7 t9 t11
+
+ # File based tests
+ file-tests: $(REGRESS_TARGETS)
+@@ -293,16 +293,8 @@ unit unit-bench: regress-unit-binaries
+ 		test "x${UNITTEST_BENCH_ONLY}" = "x" || ARGS="$$ARGS -O ${UNITTEST_BENCH_ONLY}"; \
+ 		 $$V ${.OBJDIR}/unittests/pkcs11/test_pkcs11 ; \
+ 		 $$V ${.OBJDIR}/unittests/sshbuf/test_sshbuf $${ARGS}; \
+-		 $$V ${.OBJDIR}/unittests/sshkey/test_sshkey \
+-			-d ${.CURDIR}/unittests/sshkey/testdata $${ARGS}; \
+-		$$V ${.OBJDIR}/unittests/sshsig/test_sshsig \
+-			-d ${.CURDIR}/unittests/sshsig/testdata $${ARGS}; \
+-		$$V ${.OBJDIR}/unittests/authopt/test_authopt \
+-			-d ${.CURDIR}/unittests/authopt/testdata $${ARGS}; \
+ 		$$V ${.OBJDIR}/unittests/bitmap/test_bitmap $${ARGS}; \
+ 		$$V ${.OBJDIR}/unittests/conversion/test_conversion $${ARGS}; \
+ 		$$V ${.OBJDIR}/unittests/kex/test_kex $${ARGS}; \
+-		$$V ${.OBJDIR}/unittests/hostkeys/test_hostkeys \
+-			-d ${.CURDIR}/unittests/hostkeys/testdata $${ARGS}; \
+ 		$$V ${.OBJDIR}/unittests/match/test_match $${ARGS}; \
+ 		$$V ${.OBJDIR}/unittests/misc/test_misc $${ARGS}; \
+ 		if test "x${TEST_SSH_UTF8}" = "xyes"  ; then \
+diff --git a/regress/unittests/kex/test_kex.c b/regress/unittests/kex/test_kex.c
+--- a/regress/unittests/kex/test_kex.c
++++ b/regress/unittests/kex/test_kex.c
+@@ -102,14 +102,10 @@ do_kex_with_key(char *kex, char *cipher, char *mac,
+ 	memcpy(kex_params.proposal, myproposal, sizeof(myproposal));
+ 	if (kex != NULL)
+ 		kex_params.proposal[PROPOSAL_KEX_ALGS] = kex;
+-	if (cipher != NULL) {
+-		kex_params.proposal[PROPOSAL_ENC_ALGS_CTOS] = cipher;
+-		kex_params.proposal[PROPOSAL_ENC_ALGS_STOC] = cipher;
+-	}
+-	if (mac != NULL) {
+-		kex_params.proposal[PROPOSAL_MAC_ALGS_CTOS] = mac;
+-		kex_params.proposal[PROPOSAL_MAC_ALGS_STOC] = mac;
+-	}
++	kex_params.proposal[PROPOSAL_ENC_ALGS_CTOS] = "aes128-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com";
++	kex_params.proposal[PROPOSAL_ENC_ALGS_STOC] = "aes128-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com";
++	kex_params.proposal[PROPOSAL_MAC_ALGS_CTOS] = "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512";
++	kex_params.proposal[PROPOSAL_MAC_ALGS_STOC] = "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512";
+ 	keyname = (strcmp(sshkey_ssh_name(private), "ssh-rsa")) ?
+ 		strdup(sshkey_ssh_name(private)) : strdup("rsa-sha2-256");
+ 	ASSERT_PTR_NE(keyname, NULL);
+@@ -228,13 +224,11 @@ do_kex(char *kex)
+ 	do_kex_with_key(kex, NULL, NULL, NULL, KEY_ECDSA, 256);
+ # endif /* OPENSSL_HAS_ECC */
+ #endif /* WITH_OPENSSL */
+-	do_kex_with_key(kex, NULL, NULL, NULL, KEY_ED25519, 256);
+ }
+
+ void
+ kex_tests(void)
+ {
+-	do_kex("curve25519-sha256");
+ #ifdef WITH_OPENSSL
+ #ifdef OPENSSL_HAS_ECC
+ 	do_kex("ecdh-sha2-nistp256");
+@@ -242,21 +236,10 @@ kex_tests(void)
+ 	do_kex("ecdh-sha2-nistp521");
+ #endif /* OPENSSL_HAS_ECC */
+ 	do_kex("diffie-hellman-group-exchange-sha256");
+-	do_kex("diffie-hellman-group-exchange-sha1");
+-	do_kex("diffie-hellman-group14-sha1");
+-	do_kex("diffie-hellman-group1-sha1");
+ 	if (test_is_benchmark()) {
+ 		do_kex("diffie-hellman-group14-sha256");
+ 		do_kex("diffie-hellman-group16-sha512");
+ 		do_kex("diffie-hellman-group18-sha512");
+ 	}
+-# ifdef USE_MLKEM768X25519
+-	do_kex("mlkem768x25519-sha256");
+-	do_kex("mlkem768nistp256-sha256");
+-	do_kex("mlkem1024nistp384-sha384");
+-# endif /* USE_MLKEM768X25519 */
+-# ifdef USE_SNTRUP761X25519
+-	do_kex("sntrup761x25519-sha512");
+-# endif /* USE_SNTRUP761X25519 */
+ #endif /* WITH_OPENSSL */
+ }
+diff --git a/ssh-pkcs11.c b/ssh-pkcs11.c
+--- a/ssh-pkcs11.c
++++ b/ssh-pkcs11.c
+@@ -52,7 +52,6 @@
+ #include "misc.h"
+ #include "sshbuf.h"
+ #include "ssh-pkcs11.h"
+-#include "ssh-pkcs11-uri.h"
+ #include "digest.h"
+ #include "xmalloc.h"
+ #include "crypto_api.h"


### PR DESCRIPTION
## Summary

Adds `openssh-RHEL-10.2p1-FIPS-wolfprov.patch`, sibling to #332 (openssh-9.9p1). Targets Fedora 44's patched openssh-10.2p1, which carries the SSHKDF routing patch (`openssh-8.0p1-openssl-kdf.patch`) and the FIPS adaptation patch (`openssh-7.7p1-fips.patch`) — the same Red Hat-derived test-fixture hostility to FIPS-restricted crypto we hit on 9.9p1.

The patch:
- drops `t1` (RSA-1024), `t4` (MD5), `t10` and `t12` (Ed25519 keygen) from `REGRESS_TARGETS` (`t6`/`t8` were removed upstream when DSA was deleted);
- skips `test_sshkey`, `test_sshsig`, `test_authopt`, `test_hostkeys` whose testdata trees use Ed25519/DSA/short-RSA keys;
- pins FIPS-compliant ciphers/MACs in `regress/unittests/kex/test_kex.c`, drops the Ed25519 host-key path, and strips curve25519/DH-SHA1/MLKEM/sntrup761 from `kex_tests` so SSHKDF still runs through ECDH-NIST + DH-GEX-SHA256;
- removes a redundant `#include "ssh-pkcs11-uri.h"` from `ssh-pkcs11.c` to work around an unrelated build break in Fedora's `0052-openssh-10.2p1-pkcs11-uri.patch` (the URI header lacks include guards and ends up pulled into the same TU twice — once direct, once via `ssh-pkcs11.h`).

Also refreshes `wolfProvider/openssh/README.md`, which listed only the two original non-FIPS patches plus a stale reference to a `openssh-FIPS-wolfprov.patch` that does not exist in this directory. Indexes the three FIPS patches now present (`openssh-V_9_6_P1-FIPS-wolfprov`, `openssh-RHEL-9.9p1-FIPS-wolfprov` from #332, and the new `openssh-RHEL-10.2p1-FIPS-wolfprov`) with one line per patch describing the OpenSSH source it targets.

Validated on a CentOS Stream 10 FIPS-enabled VM (`fips=1`, `update-crypto-policies --set FIPS`) against three stacks:

| Stack | Result |
|---|---|
| Stock `openssl-3.5.5-2.el10` (no patch) | red — `t1`/`t4`/`t10`/`t12` + `test_sshkey` (RSA-1024) fail in FIPS |
| `wolfProvider` fips-baseline patched OpenSSL 3.5.5 + this patch | green |
| `wolfProvider` + FIPS wolfSSL (5.9.1-fips-ready) + this patch | green |

`test_kex` runs all 90 cases under wolfProvider-as-default-OpenSSL-provider, so SSHKDF routes through wolfSSL's FIPS module via the openssl-kdf RHEL patch.

## Test plan
- [x] `rpmbuild --short-circuit -bc` of Fedora f44 dist-git openssh-10.2p1 against system OpenSSL 3.5.5 in FIPS mode (with this patch applied — without it the pkcs11 hunk above blocks the build)
- [x] Baseline regress (no patch) reproduces the expected RHEL+FIPS failure pattern (RSA-1024, MD5, Ed25519, RSA-1024-in-test_sshkey)
- [x] With patch + fips-baseline OpenSSL: `make -k file-tests interop-tests extra-tests unit` is green
- [x] With patch + wolfProvider+FIPS wolfSSL: same target set is green
- [x] `regress/unittests/kex/test_kex` exercises SSHKDF via the `openssl-kdf` RHEL patch under wolfProvider's `EVP_KDF` SSHKDF implementation
- [x] README parses cleanly as Markdown; every filename listed exists in the directory after this PR and #332 merge