### PR TITLE
Add support for Zephyr 4.4

### DIFF
--- a/zephyr/4.3/README.md
+++ b/zephyr/4.3/README.md
@@ -10,10 +10,20 @@ This integration depends on new Kconfig options added to the wolfSSL Zephyr modu
 revision that includes the PR adding Zephyr 4.3 default TLS support (`WOLFSSL_SESSION_EXPORT`,
 `WOLFSSL_KEEP_PEER_CERT`, `WOLFSSL_ALWAYS_VERIFY_CB`, and the `native_sim` timer gate extension).
 
-Once the west manifest has been updated, run west update, then run the following command to patch the sources
+Once the west manifest has been updated, run west update, then patch the Zephyr tree (run inside the
+`zephyr` directory). The integration ships as two patches:
+
+- **`zephyr-tls-4.3.0.patch`** — the core wolfSSL backend (the BSD-sockets TLS layer and the
+  RNG/CSPRNG). This is all that is required to use wolfSSL for TLS sockets.
+- **`zephyr-tls-4.3.0-tests.patch`** — the wolfSSL twister test scenarios and the echo_server
+  sample overlay. Apply it only if you want to run the test suite yourself; it is not needed to
+  use the integration. It depends on the core patch, so apply the core patch first.
 
 ```
+# required:
 patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.0.patch
+# optional, only to run the tests:
+patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.0-tests.patch
 ```
 
 ### Minimum prj.conf

--- a/zephyr/4.3/zephyr-tls-4.3.0-tests.patch
+++ b/zephyr/4.3/zephyr-tls-4.3.0-tests.patch
@@ -1,0 +1,1846 @@
+diff --git a/samples/net/sockets/echo_server/overlay-wolfssl.conf b/samples/net/sockets/echo_server/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..b3a539a5e0a
+--- /dev/null
++++ b/samples/net/sockets/echo_server/overlay-wolfssl.conf
+@@ -0,0 +1,26 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MAIN_STACK_SIZE=3072
++CONFIG_NET_BUF_RX_COUNT=80
++CONFIG_NET_BUF_TX_COUNT=80
++
++# TLS configuration
++CONFIG_MBEDTLS=n
++CONFIG_NET_SAMPLE_CERTS_WITH_SC=y
++
++CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
++CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=6
++CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
++CONFIG_NET_SOCKETS_DTLS_MAX_FRAGMENT_LENGTH=2048
++CONFIG_ZVFS_OPEN_MAX=20
++
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++
++
+diff --git a/samples/net/sockets/echo_server/sample.yaml b/samples/net/sockets/echo_server/sample.yaml
+index 5c075eacc0a..a31d22e0e8d 100644
+--- a/samples/net/sockets/echo_server/sample.yaml
++++ b/samples/net/sockets/echo_server/sample.yaml
+@@ -134,6 +134,22 @@ tests:
+       - qemu_x86_64
+     integration_platforms:
+       - qemu_x86
++  sample.net.sockets.echo_server.wolfssl:
++    tags: net socket tls wolfssl
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_args:
++      - EXTRA_CONF_FILE="overlay-wolfssl.conf"
++    harness: console
++    harness_config:
++      type: multi_line
++      ordered: false
++      regex:
++        - "Waiting for TCP.*IPv4"
++        - "Waiting for UDP.*IPv4"
+   sample.net.sockets.echo_server.nsos:
+     harness: console
+     platform_allow:
+diff --git a/tests/net/lib/coap_server/common/overlay-wolfssl.conf b/tests/net/lib/coap_server/common/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..ef9ade38ce3
+--- /dev/null
++++ b/tests/net/lib/coap_server/common/overlay-wolfssl.conf
+@@ -0,0 +1,14 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++#
++# Switch the secure CoAP server test from the mbedTLS backend to wolfSSL,
++# exercising DTLS server-side under the wolfSSL TLS sockets integration.
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+diff --git a/tests/net/lib/coap_server/common/testcase.yaml b/tests/net/lib/coap_server/common/testcase.yaml
+index 4bfa4556a61..c2b22fabfa3 100644
+--- a/tests/net/lib/coap_server/common/testcase.yaml
++++ b/tests/net/lib/coap_server/common/testcase.yaml
+@@ -17,3 +17,17 @@ tests:
+     extra_configs:
+       - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
+       - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++  net.coap.server.secure.wolfssl:
++    tags:
++      - tls
++      - wolfssl
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_configs:
++      - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
++      - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
+diff --git a/tests/net/lib/http_server/tls/overlay-wolfssl.conf b/tests/net/lib/http_server/tls/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..9a24eb7a931
+--- /dev/null
++++ b/tests/net/lib/http_server/tls/overlay-wolfssl.conf
+@@ -0,0 +1,14 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++#
++# Switch the http_server TLS test from the mbedTLS backend to wolfSSL.
++
++CONFIG_MBEDTLS=n
++CONFIG_MBEDTLS_BUILTIN=n
++CONFIG_MBEDTLS_ENABLE_HEAP=n
++
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++
++CONFIG_WOLFSSL=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+diff --git a/tests/net/lib/http_server/tls/src/main.c b/tests/net/lib/http_server/tls/src/main.c
+index 6d710eb350e..ec076b4e4c7 100644
+--- a/tests/net/lib/http_server/tls/src/main.c
++++ b/tests/net/lib/http_server/tls/src/main.c
+@@ -160,7 +160,12 @@ static void test_tls(void)
+ 		const sec_tag_t *sec_tag_list;
+ 		size_t sec_tag_list_size;
+ 
+-		sec_tag_list_size = sizeof(sec_tag_list);
++		/* sizeof(sec_tag_list_verify_none), not sizeof(sec_tag_list)
++		 * — the latter is sizeof(pointer), which on 64-bit hosts
++		 * (e.g. native_sim/native/64) feeds an extra garbage sec_tag
++		 * into setsockopt and breaks credential lookup.
++		 */
++		sec_tag_list_size = sizeof(sec_tag_list_verify_none);
+ 		sec_tag_list = sec_tag_list_verify_none;
+ 
+ 		ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_SEC_TAG_LIST,
+diff --git a/tests/net/lib/http_server/tls/testcase.yaml b/tests/net/lib/http_server/tls/testcase.yaml
+index ef398a2f09d..78668f40e61 100644
+--- a/tests/net/lib/http_server/tls/testcase.yaml
++++ b/tests/net/lib/http_server/tls/testcase.yaml
+@@ -20,3 +20,12 @@ tests:
+     integration_toolchains:
+       - host
+       - llvm
++  net.http.server.tls.wolfssl:
++    tags: http net server socket wolfssl
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
+diff --git a/tests/net/lib/tls_credentials/testcase.yaml b/tests/net/lib/tls_credentials/testcase.yaml
+index 1e812e2164b..2b1440179f7 100644
+--- a/tests/net/lib/tls_credentials/testcase.yaml
++++ b/tests/net/lib/tls_credentials/testcase.yaml
+@@ -11,3 +11,24 @@ tests:
+       - net
+       - tls
+       - trusted-firmware-m
++  net.tls_credentials.wolfssl:
++    # Exercises the credentials API alongside a WOLFSSL=y build to catch
++    # symbol/include collisions in a TLS-credentials-only configuration
++    # (no NET_SOCKETS_SOCKOPT_TLS). The API itself is backend-agnostic.
++    tags:
++      - net
++      - tls
++      - wolfssl
++    depends_on: netif
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_configs:
++      - CONFIG_MBEDTLS=n
++      - CONFIG_POSIX_API=y
++      - CONFIG_POSIX_TIMERS=y
++      - CONFIG_POSIX_THREADS=y
++      - CONFIG_WOLFSSL=y
++      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+diff --git a/tests/net/socket/register/testcase.yaml b/tests/net/socket/register/testcase.yaml
+index efbf8725023..ea6c154e3d5 100644
+--- a/tests/net/socket/register/testcase.yaml
++++ b/tests/net/socket/register/testcase.yaml
+@@ -22,3 +22,21 @@ tests:
+       - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
+       - CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
+       - CONFIG_MAIN_STACK_SIZE=2048
++  net.socket.register.tls.wolfssl:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    tags: net socket socket.register wolfssl
++    extra_configs:
++      - CONFIG_MBEDTLS=n
++      - CONFIG_POSIX_API=y
++      - CONFIG_POSIX_TIMERS=y
++      - CONFIG_POSIX_THREADS=y
++      - CONFIG_WOLFSSL=y
++      - CONFIG_WOLFSSL_DTLS=y
++      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++      - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
++      - CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=6
++      - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++      - CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
++      - CONFIG_MAIN_STACK_SIZE=2048
+diff --git a/tests/net/socket/tls/overlay-wolfssl.conf b/tests/net/socket/tls/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..1e3851d3c9a
+--- /dev/null
++++ b/tests/net/socket/tls/overlay-wolfssl.conf
+@@ -0,0 +1,20 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=100000
++CONFIG_WOLFSSL_ALPN=y
++CONFIG_WOLFSSL_PSK=y
++CONFIG_MBEDTLS_ENABLE_HEAP=n
++CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED=n
++CONFIG_MBEDTLS_HASH_ALL_ENABLED=n
++CONFIG_MBEDTLS_CMAC=n
++CONFIG_MBEDTLS_SSL_ALPN=n
++CONFIG_WOLFSSL_TLS_VERSION_1_3=y
++CONFIG_WOLFSSL_SESSION_EXPORT=y
++CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
+diff --git a/tests/net/socket/tls/prj.conf b/tests/net/socket/tls/prj.conf
+index 24058c31dd7..9e87ecf9e64 100644
+--- a/tests/net/socket/tls/prj.conf
++++ b/tests/net/socket/tls/prj.conf
+@@ -46,7 +46,15 @@ CONFIG_ZTEST=y
+ CONFIG_ZTEST_STACK_SIZE=4096
+ 
+ CONFIG_MBEDTLS_ENABLE_HEAP=y
+-CONFIG_MBEDTLS_HEAP_SIZE=18000
++# Empirically determined: the suite hangs at test_v4_msg_trunc with
++# CONFIG_MBEDTLS_HEAP_SIZE <= 18000 (upstream's value) once the fork's
++# added ALPN/PSK/timeout tests + CONFIG_MBEDTLS_SSL_ALPN=y are in play.
++# 19000 was the empirical floor; 22000 keeps ~3 KB headroom. If you add
++# more mbedTLS-allocating tests and start seeing the same flake, bump
++# this rather than chasing a phantom leak.
++CONFIG_MBEDTLS_HEAP_SIZE=22000
+ CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED=y
+ CONFIG_MBEDTLS_HASH_ALL_ENABLED=y
+ CONFIG_MBEDTLS_CMAC=y
++CONFIG_MBEDTLS_SSL_ALPN=y
++CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS=3
+diff --git a/tests/net/socket/tls/src/main.c b/tests/net/socket/tls/src/main.c
+index 8186ba7dbe9..4375fd04c5e 100644
+--- a/tests/net/socket/tls/src/main.c
++++ b/tests/net/socket/tls/src/main.c
+@@ -12,15 +12,54 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ #include <zephyr/net/loopback.h>
+ #include <zephyr/net/socket.h>
+ #include <zephyr/net/tls_credentials.h>
++/* IANA TLS ciphersuite IDs used by this file's set_ciphersuites tests.
++ * Names match RFC 4279. Don't introduce a public Zephyr-wide header just
++ * for these two — both backends accept IANA IDs verbatim via the byte-
++ * list cipher API.
++ */
++#define TLS_PSK_WITH_AES_128_CBC_SHA  0x008C
++#define TLS_PSK_WITH_AES_256_CBC_SHA  0x008D
++
++#if defined(CONFIG_WOLFSSL)
++#ifndef WOLFSSL_USER_SETTINGS
++#include <user_settings.h>
++#endif
++#include <wolfssl/ssl.h>
++WOLFSSL *ztls_get_wolfssl_context(int fd);
++int SendAlert(WOLFSSL *ssl, int severity, int type);
++#endif
++
++#if defined(CONFIG_MBEDTLS)
+ #include <mbedtls/ssl.h>
++mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd);
++#endif
+ 
+ #include "../../socket_helpers.h"
+ 
++static const int cipher_list_psk[] = {
++	TLS_PSK_WITH_AES_128_CBC_SHA,
++	TLS_PSK_WITH_AES_256_CBC_SHA
++};
++
++/* Test test_set_ciphersuites() assumes [0] of this list is the
++ * cipher that will be negotiated */
++static const int cipher_list_psk2[] = {
++	TLS_PSK_WITH_AES_128_CBC_SHA,
++};
++
++static const int cipher_list_psk3[] = {
++	TLS_PSK_WITH_AES_256_CBC_SHA,
++};
++
+ #define TEST_STR_SMALL "test"
+ 
+ #define MY_IPV4_ADDR "127.0.0.1"
+ #define MY_IPV6_ADDR "::1"
+ 
++#ifndef MY_DEFLT_HOSTNAME
++#define MY_DEFLT_HOSTNAME "localhost"
++#endif
++
+ #define ANY_PORT 0
+ #define SERVER_PORT 4242
+ 
+@@ -118,6 +157,20 @@ static void test_connect(int sock, struct sockaddr *addr, socklen_t addrlen)
+ 	}
+ }
+ 
++static void test_connect_err(int sock, struct sockaddr *addr, socklen_t addrlen)
++{
++	k_yield();
++
++	zassert_equal(zsock_connect(sock, addr, addrlen),
++		      -1,
++		      "connect expected to fail but succeeded");
++
++	if (IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)) {
++		/* Let the connection proceed */
++		k_yield();
++	}
++}
++
+ static void test_send(int sock, const void *buf, size_t len, int flags)
+ {
+ 	zassert_equal(zsock_send(sock, buf, len, flags),
+@@ -149,6 +202,15 @@ static void test_accept(int sock, int *new_sock, struct sockaddr *addr,
+ 	zassert_true(*new_sock >= 0, "accept failed");
+ }
+ 
++static void test_accept_err(int sock, int *new_sock, struct sockaddr *addr,
++			    socklen_t *addrlen)
++{
++	zassert_not_null(new_sock, "null newsock");
++
++	*new_sock = zsock_accept(sock, addr, addrlen);
++	zassert_true(*new_sock < 0, "accept expected to fail but succeeded");
++}
++
+ static void test_shutdown(int sock, int how)
+ {
+ 	zassert_equal(zsock_shutdown(sock, how),
+@@ -290,6 +352,16 @@ static void client_connect_work_handler(struct k_work *work)
+ 		     sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+ }
+ 
++static void client_connect_work_handler_err(struct k_work *work)
++{
++	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
++	struct connect_data *data =
++		CONTAINER_OF(dwork, struct connect_data, work);
++
++	test_connect_err(data->sock, data->addr, data->addr->sa_family == AF_INET ?
++			 sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
++}
++
+ static void dtls_client_connect_send_work_handler(struct k_work *work)
+ {
+ 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+@@ -407,6 +479,71 @@ static void test_prepare_dtls_connection(sa_family_t family)
+ 	test_work_wait(&test_data.work);
+ }
+ 
++/* Function pointer type for function to be called after socket creation but
++ * before any bind/listen/connect operations */
++typedef void (*tls_pre_cb)(void);
++/* Function pointer type for function to be used to perform client work
++ * instead of client_connect_work_handler() */
++typedef void (*client_work_func)(struct k_work *work);
++
++static void test_prepare_tls_connection_ex(sa_family_t family, bool accept_err,
++					   tls_pre_cb cb, client_work_func cw)
++{
++	struct sockaddr c_saddr;
++	struct sockaddr s_saddr;
++	socklen_t exp_addrlen = family == AF_INET6 ?
++				sizeof(struct sockaddr_in6) :
++				sizeof(struct sockaddr_in);
++	struct sockaddr addr;
++	socklen_t addrlen = sizeof(addr);
++	struct connect_data test_data;
++
++	if (family == AF_INET6) {
++		prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock,
++				    (struct sockaddr_in6 *)&c_saddr,
++				    IPPROTO_TLS_1_2);
++		prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock,
++				    (struct sockaddr_in6 *)&s_saddr,
++				    IPPROTO_TLS_1_2);
++	} else {
++		prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock,
++				    (struct sockaddr_in *)&c_saddr,
++				    IPPROTO_TLS_1_2);
++		prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &s_sock,
++				    (struct sockaddr_in *)&s_saddr,
++				    IPPROTO_TLS_1_2);
++	}
++
++	if (NULL != cb) {
++		cb();
++	}
++
++	test_config_psk(s_sock, c_sock);
++
++	test_bind(s_sock, &s_saddr, exp_addrlen);
++	test_listen(s_sock);
++
++	/* Helper work for the connect operation - need to handle client/server
++	 * in parallel due to handshake.
++	 */
++	test_data.sock = c_sock;
++	test_data.addr = &s_saddr;
++	if (cw != NULL) {
++		k_work_init_delayable(&test_data.work, cw);
++	} else {
++		k_work_init_delayable(&test_data.work, client_connect_work_handler);
++	}
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	if (accept_err == true) {
++		test_accept_err(s_sock, &new_sock, &addr, &addrlen);
++	} else {
++		test_accept(s_sock, &new_sock, &addr, &addrlen);
++		zassert_equal(addrlen, exp_addrlen, "Wrong addrlen");
++	}
++	test_work_wait(&test_data.work);
++}
++
+ ZTEST(net_socket_tls, test_v4_msg_waitall)
+ {
+ 	struct test_msg_waitall_data test_data = {
+@@ -537,6 +674,7 @@ static void send_work_handler(struct k_work *work)
+ 
+ void test_msg_trunc(sa_family_t family)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	int rv;
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+ 	struct send_data test_data = {
+@@ -571,6 +709,9 @@ void test_msg_trunc(sa_family_t family)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_v4_msg_trunc)
+@@ -665,18 +806,26 @@ static void test_dtls_sendmsg_no_buf(sa_family_t family)
+ 
+ ZTEST(net_socket_tls, test_v4_dtls_sendmsg_no_buf)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE > 0) {
+ 		ztest_test_skip();
+ 	}
++#else
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg_no_buf(AF_INET);
+ }
+ 
+ ZTEST(net_socket_tls, test_v6_dtls_sendmsg_no_buf)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE > 0) {
+ 		ztest_test_skip();
+ 	}
++#else
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg_no_buf(AF_INET6);
+ }
+@@ -785,18 +934,22 @@ static void test_dtls_sendmsg(sa_family_t family)
+ 
+ ZTEST(net_socket_tls, test_v4_dtls_sendmsg)
+ {
+-	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE == 0) {
+-		ztest_test_skip();
+-	}
++#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	ztest_test_skip();
++#elif CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE <= 0
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg(AF_INET);
+ }
+ 
+ ZTEST(net_socket_tls, test_v6_dtls_sendmsg)
+ {
+-	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE == 0) {
+-		ztest_test_skip();
+-	}
++#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	ztest_test_skip();
++#elif CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE <= 0
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg(AF_INET6);
+ }
+@@ -1165,7 +1318,21 @@ ZTEST(net_socket_tls, test_recv_eof_on_close)
+ 	k_sleep(TCP_TEARDOWN_TIMEOUT);
+ }
+ 
++/* Per-record framing overhead the test uses to right-size SO_RCVBUF for
++ * exactly one TLS application record carrying TEST_STR_SMALL. Both numbers
++ * are observed values for these suites' default ciphersuite (TLS 1.2 AES
++ * GCM), measured by running the suite with an oversized buffer and printing
++ * the inbound record length. Different values per backend reflect different
++ * implementation choices for the record-layer framing (header layout, IV
++ * placement, padding) — they are not part of any wire-format ABI. If a
++ * test starts failing here after a backend or ciphersuite change, re-measure
++ * with an oversized buffer and update.
++ */
++#if defined(CONFIG_WOLFSSL)
++#define TLS_RECORD_OVERHEAD 29
++#else
+ #define TLS_RECORD_OVERHEAD 81
++#endif
+ 
+ ZTEST(net_socket_tls, test_send_non_block)
+ {
+@@ -1316,7 +1483,7 @@ ZTEST(net_socket_tls, test_send_on_close)
+ 	new_sock = -1;
+ 
+ 	/* Small delay for packets to propagate. */
+-	k_msleep(10);
++	k_msleep(20);
+ 
+ 	/* Verify send() reports an error after connection is closed. */
+ 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
+@@ -1338,7 +1505,7 @@ ZTEST(net_socket_tls, test_send_on_close)
+ 	new_sock = -1;
+ 
+ 	/* Small delay for packets to propagate. */
+-	k_msleep(10);
++	k_msleep(20);
+ 
+ 	/* Graceful connection close should be reported first. */
+ 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
+@@ -1489,10 +1656,13 @@ ZTEST(net_socket_tls, test_shutdown_rd_while_recv)
+ 
+ 	test_prepare_tls_connection(AF_INET6);
+ 
+-	/* Schedule reception shutdown from workqueue */
++	/* Schedule reception shutdown from workqueue. 50ms margin guards
++	 * against slow CI runners where recv() hasn't reached its blocking
++	 * point at the 10ms mark.
++	 */
+ 	k_work_init_delayable(&test_data.work, shutdown_work);
+ 	test_data.sock = c_sock;
+-	test_work_reschedule(&test_data.work, K_MSEC(10));
++	test_work_reschedule(&test_data.work, K_MSEC(50));
+ 
+ 	/* EOF should be notified by recv() */
+ 	test_eof(c_sock);
+@@ -1502,6 +1672,78 @@ ZTEST(net_socket_tls, test_shutdown_rd_while_recv)
+ 	k_sleep(TCP_TEARDOWN_TIMEOUT);
+ }
+ 
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++/* wolfSSL-only: exercises the recv_eof shortcut in
++ * recvfrom_dtls_common_wolfssl that turns local SHUT_RD/SHUT_RDWR into
++ * an EOF on the next recv(). The mbedTLS backend matches upstream
++ * Zephyr behavior (no local-shutdown shortcut on DTLS), so this test
++ * is gated to wolfSSL builds to preserve the upstream interface
++ * contract for mbedTLS users.
++ */
++static void test_dtls_shutdown_synchronous_body(sa_family_t family, int how)
++{
++	test_prepare_dtls_connection(family);
++
++	test_shutdown(c_sock, how);
++
++	/* EOF should be notified by recv() */
++	test_eof(c_sock);
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++#endif
++
++ZTEST(net_socket_tls, test_dtls_shutdown_rd_synchronous_v6)
++{
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++	test_dtls_shutdown_synchronous_body(AF_INET6, ZSOCK_SHUT_RD);
++#else
++	ztest_test_skip();
++#endif
++}
++
++ZTEST(net_socket_tls, test_dtls_shutdown_rd_synchronous_v4)
++{
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++	test_dtls_shutdown_synchronous_body(AF_INET, ZSOCK_SHUT_RD);
++#else
++	ztest_test_skip();
++#endif
++}
++
++ZTEST(net_socket_tls, test_dtls_shutdown_rd_while_recv)
++{
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++	struct shutdown_data test_data = {
++		.how = ZSOCK_SHUT_RD,
++	};
++
++	test_prepare_dtls_connection(AF_INET6);
++
++	/* Schedule reception shutdown from workqueue while recv() is blocked
++	 * — exercises the recv_eof check inside the wolfSSL DTLS recv loop
++	 * (recvfrom_dtls_common_wolfssl). The TCP/TLS variant lives in
++	 * test_shutdown_rd_while_recv. 50ms margin guards against slow CI
++	 * runners where recv() hasn't reached its blocking point yet at the
++	 * 10ms mark — short enough to keep the test fast.
++	 */
++	k_work_init_delayable(&test_data.work, shutdown_work);
++	test_data.sock = c_sock;
++	test_work_reschedule(&test_data.work, K_MSEC(50));
++
++	/* EOF should be notified by recv() */
++	test_eof(c_sock);
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#else
++	ztest_test_skip();
++#endif
++}
++
+ ZTEST(net_socket_tls, test_send_while_recv)
+ {
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+@@ -1542,6 +1784,433 @@ ZTEST(net_socket_tls, test_send_while_recv)
+ 	k_sleep(TCP_TEARDOWN_TIMEOUT);
+ }
+ 
++void tls_set_cs_cb(void)
++{
++	int ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
++				   (void *)cipher_list_psk, sizeof(cipher_list_psk));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on server");
++	ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
++			       (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on client");
++}
++
++void tls_set_cs_mismatch_cb(void)
++{
++	/* Set mismatched ciphersuites, should not connect */
++	int ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
++				   (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on client");
++	ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
++			       (void *)cipher_list_psk3, sizeof(cipher_list_psk3));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on server");
++}
++
++ZTEST(net_socket_tls, test_set_ciphersuites)
++{
++#define TLS_CS_TEST_MAX_CS_NUM 3
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++	int ciphersuites[TLS_CS_TEST_MAX_CS_NUM];
++	int cs_len = sizeof(ciphersuites);
++	int curr_cipher = 0;
++	int cc_len = sizeof(int);
++	int i;
++
++	for (i = 0; i < TLS_CS_TEST_MAX_CS_NUM; i++) {
++		ciphersuites[i] = 0;
++	}
++
++	test_prepare_tls_connection_ex(AF_INET, false, tls_set_cs_cb, NULL);
++
++	/* Verify the ciphersuite list is what we set for server */
++	ret = zsock_getsockopt(s_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
++			       (void *)ciphersuites, (socklen_t *)&cs_len);
++	zassert_equal(ret, 0, "Unable to get ciphersuites for server");
++	zassert_equal(cs_len, sizeof(cipher_list_psk), "Incorrect get ciphersuite len");
++
++	for (i = 0; i < cs_len / sizeof(int); i++) {
++		zassert_equal(ciphersuites[i], cipher_list_psk[i],
++			      "Retrieved ciphersuite list element does not match set value");
++	}
++
++	/* Same for client */
++	for (i = 0; i < TLS_CS_TEST_MAX_CS_NUM; i++) {
++		ciphersuites[i] = 0;
++	}
++
++	cs_len = sizeof(ciphersuites);
++	ret = zsock_getsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
++			       (void *)ciphersuites, (socklen_t *)&cs_len);
++	zassert_equal(ret, 0, "Unable to get ciphersuites for client");
++	zassert_equal(cs_len, sizeof(cipher_list_psk2), "Incorrect get ciphersuite len");
++
++	for (i = 0; i < cs_len / sizeof(int); i++) {
++		zassert_equal(ciphersuites[i], cipher_list_psk2[i],
++			      "Retrieved ciphersuite list element does not match set value");
++	}
++
++	/* Check that the actual negotiated cipher is correct for server */
++	ret = zsock_getsockopt(new_sock, SOL_TLS, TLS_CIPHERSUITE_USED,
++			       (void *)&curr_cipher, (socklen_t *)&cc_len);
++	zassert_equal(ret, 0, "Unable to get current ciphersuite for server");
++	zassert_equal(curr_cipher, cipher_list_psk2[0]);
++
++	/* Same for the client */
++	curr_cipher = 0;
++	ret = zsock_getsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_USED,
++			       (void *)&curr_cipher, (socklen_t *)&cc_len);
++	zassert_equal(ret, 0, "Unable to get current ciphersuite for client");
++	zassert_equal(curr_cipher, cipher_list_psk2[0]);
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++ZTEST(net_socket_tls, test_set_ciphersuites_err)
++{
++	/* Expect failure to connect and accept due to mismatched ciphersuites */
++	test_prepare_tls_connection_ex(AF_INET, true,
++		tls_set_cs_mismatch_cb, client_connect_work_handler_err);
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++void tls_set_hostname_cb(void)
++{
++	int ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_HOSTNAME,
++				   (void *)MY_DEFLT_HOSTNAME, strlen(MY_DEFLT_HOSTNAME));
++	zassert_equal(ret, 0, "Unable to set hostname on client");
++}
++
++ZTEST(net_socket_tls, test_set_hostname)
++{
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++
++	test_prepare_tls_connection_ex(AF_INET, false, tls_set_hostname_cb, NULL);
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++void tls_set_session_cache_cb(void)
++{
++	int t = TLS_SESSION_CACHE_ENABLED;
++	int l = sizeof(int);
++
++	int ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_SESSION_CACHE,
++				   (void *)&t, l);
++	zassert_equal(ret, 0, "Unable to set session cache on server");
++}
++
++ZTEST(net_socket_tls, test_session_cache)
++{
++	int ret;
++	int enabled = 0;
++	int len = sizeof(int);
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++
++	test_prepare_tls_connection_ex(AF_INET, false, tls_set_session_cache_cb, NULL);
++
++	/* Check that the session cache is enabled */
++	ret = zsock_getsockopt(s_sock, SOL_TLS, TLS_SESSION_CACHE,
++			       (void *)&enabled, (socklen_t *)&len);
++	zassert_equal(ret, 0, "Unable to get session cache enabled status");
++	zassert_equal(enabled, TLS_SESSION_CACHE_ENABLED,
++		      "Session cache value does not match what was set");
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++/* Helper enabling session cache on both client and server sockets. Used by
++ * test_session_cache_client_resume to exercise the wolfSSL tls_session_store /
++ * tls_session_restore marshalling code path.
++ */
++static void tls_set_session_cache_client_cb(void)
++{
++	int t = TLS_SESSION_CACHE_ENABLED;
++	int l = sizeof(int);
++	int ret;
++
++	ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_SESSION_CACHE,
++			       (void *)&t, l);
++	zassert_equal(ret, 0, "Unable to set session cache on server");
++	ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_SESSION_CACHE,
++			       (void *)&t, l);
++	zassert_equal(ret, 0, "Unable to set session cache on client");
++}
++
++/* Sets up a TLS client/server connection on a FIXED server port so two
++ * consecutive connections present the same peer address (which is the key
++ * into client_cache). Used by test_session_cache_client_resume — the
++ * main test_prepare_* helpers use ANY_PORT, which prevents resumption
++ * lookup from matching across connections.
++ */
++static void prepare_tls_session_resume_connection(uint16_t server_port)
++{
++	struct sockaddr_in c_saddr;
++	struct sockaddr_in s_saddr;
++	struct sockaddr addr;
++	socklen_t addrlen = sizeof(addr);
++	struct connect_data test_data;
++	int reuse = 1;
++	int ret;
++
++	prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr,
++			    IPPROTO_TLS_1_2);
++	prepare_sock_tls_v4(MY_IPV4_ADDR, server_port, &s_sock, &s_saddr,
++			    IPPROTO_TLS_1_2);
++
++	tls_set_session_cache_client_cb();
++
++	test_config_psk(s_sock, c_sock);
++
++	/* Fixed server port + back-to-back binds in the same suite: ask the
++	 * stack to allow rebind so the test isn't fragile if a previous
++	 * teardown's TIME_WAIT entry is still around.
++	 */
++	ret = zsock_setsockopt(s_sock, SOL_SOCKET, SO_REUSEADDR,
++			       &reuse, sizeof(reuse));
++	zassert_equal(ret, 0, "SO_REUSEADDR on server socket failed");
++
++	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
++	test_listen(s_sock);
++
++	test_data.sock = c_sock;
++	test_data.addr = (struct sockaddr *)&s_saddr;
++	k_work_init_delayable(&test_data.work, client_connect_work_handler);
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	test_accept(s_sock, &new_sock, &addr, &addrlen);
++	test_work_wait(&test_data.work);
++}
++
++/* Verifies that the second connect to the same peer actually resumes via the
++ * client-side session marshalling (mbedTLS: tls_session_save/get; wolfSSL:
++ * wolfSSL_i2d_SSL_SESSION / wolfSSL_d2i_SSL_SESSION in tls_session_store /
++ * tls_session_restore). Purges first so state is isolated.
++ */
++ZTEST(net_socket_tls, test_session_cache_client_resume)
++{
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1,
++	};
++	int ret;
++
++	/* Purge any sessions left by earlier tests so we can observe the
++	 * transition from "no cached session" to "cached session".
++	 */
++	{
++		int dummy = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
++
++		zassert_true(dummy >= 0, "purge socket open failed");
++		ret = zsock_setsockopt(dummy, SOL_TLS, TLS_SESSION_CACHE_PURGE,
++				       NULL, 0);
++		zassert_equal(ret, 0, "purge setsockopt failed");
++		zsock_close(dummy);
++	}
++
++	/* First connection — should perform full handshake, then store. */
++	prepare_tls_session_resume_connection(SERVER_PORT);
++
++#if defined(CONFIG_WOLFSSL)
++	{
++		WOLFSSL *ssl = ztls_get_wolfssl_context(c_sock);
++		int reused;
++
++		zassert_not_null(ssl, "Failed to get wolfSSL context");
++		reused = wolfSSL_session_reused(ssl);
++		zassert_equal(reused, 0,
++			      "First connect should not be a resumption (got %d)",
++			      reused);
++	}
++#endif
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++
++	test_sockets_close();
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++
++	/* Second connection to the SAME server port — should restore the
++	 * stored session and resume.
++	 */
++	prepare_tls_session_resume_connection(SERVER_PORT);
++
++#if defined(CONFIG_WOLFSSL)
++	{
++		WOLFSSL *ssl = ztls_get_wolfssl_context(c_sock);
++		int reused;
++
++		zassert_not_null(ssl, "Failed to get wolfSSL context");
++		reused = wolfSSL_session_reused(ssl);
++		zassert_not_equal(reused, 0,
++				  "Second connect did not reuse session");
++	}
++#endif
++
++	memset(rx_buf, 0, sizeof(rx_buf));
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++/* Smoke test for M01: verify that a TLS handshake completes when wolfSSL
++ * secure renegotiation is enabled. With HAVE_SECURE_RENEGOTIATION the TLS
++ * init path calls wolfSSL_UseSecureRenegotiation() on each new SSL object;
++ * a failure there fails ztls_connect_ctx/ztls_accept_ctx. A successful
++ * handshake proves the call is reachable and the API is wired up. A full
++ * renegotiation round-trip would require additional hooks into the Zephyr
++ * TLS socket API which are out of scope here.
++ */
++ZTEST(net_socket_tls, test_tls_renegotiation_smoke)
++{
++#if defined(CONFIG_WOLFSSL)
++#if !defined(HAVE_SECURE_RENEGOTIATION)
++	ztest_test_skip();
++	return;
++#endif
++#elif !defined(CONFIG_MBEDTLS_SSL_RENEGOTIATION)
++	ztest_test_skip();
++	return;
++#endif
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1,
++	};
++	int ret;
++
++	test_prepare_tls_connection(AF_INET);
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++const char *alpn_list[] = {
++	"http/1.0",
++	"http/1.1"
++};
++
++void tls_set_alpn_cb(void)
++{
++	socklen_t len = sizeof(alpn_list);
++	int ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_ALPN_LIST,
++				   (void *)alpn_list, len);
++	zassert_equal(ret, 0, "Unable to set alpn on server");
++}
++
++ZTEST(net_socket_tls, test_alpn)
++{
++#if CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS > 0
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++	const char *alpn_buf[2];
++	int alpn_len = sizeof(alpn_buf);
++
++	alpn_buf[0] = NULL;
++	alpn_buf[1] = NULL;
++
++	test_prepare_tls_connection_ex(AF_INET, false, tls_set_alpn_cb, NULL);
++
++	/* Check that the ALPN list is the one we set */
++	ret = zsock_getsockopt(s_sock, SOL_TLS, TLS_ALPN_LIST,
++			       (void *)alpn_buf, (socklen_t *)&alpn_len);
++	zassert_equal(ret, 0, "Unable to get alpn list");
++	zassert_equal(alpn_len, sizeof(alpn_list), "Retrieved ALPN list length incorrect");
++	zassert_equal(strlen(alpn_buf[0]), strlen(alpn_list[0]),
++		      "Retrieved ALPN list element length incorrect");
++	zassert_mem_equal(alpn_buf[0], alpn_list[0], strlen(alpn_list[0]),
++			  "Retrieved ALPN element does not match what was set");
++	zassert_equal(strlen(alpn_buf[1]), strlen(alpn_list[1]),
++		      "Retrieved ALPN list element length incorrect");
++	zassert_mem_equal(alpn_buf[1], alpn_list[1], strlen(alpn_list[1]),
++			  "Retrieved ALPN element does not match what was set");
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#else
++	ztest_test_skip();
++#endif
++}
++
+ ZTEST(net_socket_tls, test_poll_tls_pollin)
+ {
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+@@ -1575,6 +2244,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollin)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollin)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+ 	struct send_data test_data = {
+ 		.data = TEST_STR_SMALL,
+@@ -1608,6 +2278,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollin)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_poll_tls_pollout)
+@@ -1660,6 +2333,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollout)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollout)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	struct zsock_pollfd fds[1];
+ 	int ret;
+ 
+@@ -1677,6 +2351,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollout)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_poll_tls_pollhup)
+@@ -1709,6 +2386,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollhup)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollhup)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	struct zsock_pollfd fds[1];
+ 	uint8_t rx_buf;
+ 	int ret;
+@@ -1734,10 +2412,11 @@ ZTEST(net_socket_tls, test_poll_dtls_pollhup)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+-mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd);
+-
+ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ {
+ 	uint8_t rx_buf;
+@@ -1745,7 +2424,11 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ 	struct zsock_pollfd fds[1];
+ 	int optval;
+ 	socklen_t optlen = sizeof(optval);
++#if defined(CONFIG_WOLFSSL)
++	WOLFSSL *ssl_ctx;
++#else
+ 	mbedtls_ssl_context *ssl_ctx;
++#endif
+ 
+ 	test_prepare_tls_connection(AF_INET6);
+ 
+@@ -1753,9 +2436,14 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ 	fds[0].events = ZSOCK_POLLIN;
+ 
+ 	/* Get access to the underlying ssl context, and send alert. */
++#if defined(CONFIG_WOLFSSL)
++	ssl_ctx = ztls_get_wolfssl_context(c_sock);
++	SendAlert(ssl_ctx, alert_fatal, wolfssl_alert_protocol_version);
++#else
+ 	ssl_ctx = ztls_get_mbedtls_ssl_context(c_sock);
+ 	mbedtls_ssl_send_alert_message(ssl_ctx, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+ 				       MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
++#endif
+ 
+ 	ret = zsock_poll(fds, 1, 100);
+ 	zassert_equal(ret, 1, "poll() should've report event");
+@@ -1777,12 +2465,17 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	uint8_t rx_buf;
+ 	int ret;
+ 	struct zsock_pollfd fds[1];
+ 	int optval;
+ 	socklen_t optlen = sizeof(optval);
++#if defined(CONFIG_WOLFSSL)
++	WOLFSSL *ssl_ctx;
++#else
+ 	mbedtls_ssl_context *ssl_ctx;
++#endif
+ 
+ 	test_prepare_dtls_connection(AF_INET6);
+ 
+@@ -1790,9 +2483,14 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
+ 	fds[0].events = ZSOCK_POLLIN;
+ 
+ 	/* Get access to the underlying ssl context, and send alert. */
++#if defined(CONFIG_WOLFSSL)
++	ssl_ctx = ztls_get_wolfssl_context(c_sock);
++	SendAlert(ssl_ctx, alert_fatal, wolfssl_alert_protocol_version);
++#else
+ 	ssl_ctx = ztls_get_mbedtls_ssl_context(c_sock);
+ 	mbedtls_ssl_send_alert_message(ssl_ctx, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+ 				       MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
++#endif
+ 
+ 	ret = zsock_poll(fds, 1, 100);
+ 	zassert_equal(ret, 1, "poll() should've report event");
+@@ -1812,6 +2510,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ #define BAD_CA_CERT_TAG 11
+@@ -1896,6 +2597,71 @@ ZTEST(net_socket_tls, test_dtls_bad_cred)
+ 	test_bad_cred_common(true);
+ }
+ 
++ZTEST(net_socket_tls, test_tls13_psk_handshake)
++{
++#if !defined(WOLFSSL_TLS13) || !defined(CONFIG_WOLFSSL)
++	ztest_test_skip();
++	return;
++#else
++	struct sockaddr_in6 c_saddr, s_saddr;
++	struct sockaddr addr;
++	socklen_t addrlen = sizeof(addr);
++	struct connect_data test_data;
++	uint8_t tx_buf[] = TEST_STR_SMALL;
++	uint8_t rx_buf[sizeof(tx_buf)];
++	int ret;
++	int optval;
++	socklen_t optlen = sizeof(optval);
++
++	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock,
++			    &c_saddr, IPPROTO_TLS_1_3);
++	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock,
++			    &s_saddr, IPPROTO_TLS_1_3);
++
++	test_config_psk(s_sock, c_sock);
++
++	test_bind(s_sock, (struct sockaddr *)&s_saddr,
++		  sizeof(struct sockaddr_in6));
++	test_listen(s_sock);
++
++	test_data.sock = c_sock;
++	test_data.addr = (struct sockaddr *)&s_saddr;
++	k_work_init_delayable(&test_data.work,
++			      client_connect_work_handler);
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	test_accept(s_sock, &new_sock, &addr, &addrlen);
++	test_work_wait(&test_data.work);
++
++	/* Verify protocol is TLS 1.3 via socket option */
++	ret = zsock_getsockopt(new_sock, SOL_SOCKET, SO_PROTOCOL,
++			       &optval, &optlen);
++	zassert_equal(ret, 0, "getsockopt failed (%d)", errno);
++	zassert_equal(optval, IPPROTO_TLS_1_3,
++		      "Expected TLS 1.3 protocol");
++
++	/* Verify TLS 1.3 was actually negotiated, not just requested */
++	{
++		WOLFSSL *ssl = ztls_get_wolfssl_context(new_sock);
++
++		zassert_not_null(ssl, "Failed to get wolfSSL context");
++		zassert_equal(wolfSSL_GetVersion(ssl), WOLFSSL_TLSV1_3,
++			      "Negotiated version is not TLS 1.3");
++	}
++
++	/* Send and receive */
++	test_send(c_sock, tx_buf, sizeof(tx_buf), 0);
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(tx_buf), "recv() failed");
++	zassert_mem_equal(rx_buf, tx_buf, sizeof(tx_buf),
++			  "Data mismatch");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#endif
++}
++
+ static void *tls_tests_setup(void)
+ {
+ 	k_work_queue_init(&tls_test_work_queue);
+diff --git a/tests/net/socket/tls/testcase.yaml b/tests/net/socket/tls/testcase.yaml
+index f652305f20b..ae875ccd726 100644
+--- a/tests/net/socket/tls/testcase.yaml
++++ b/tests/net/socket/tls/testcase.yaml
+@@ -21,3 +21,12 @@ tests:
+   net.socket.tls.sendmsg_no_buf:
+     extra_configs:
+       - CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE=0
++  net.socket.tls.wolfssl:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim
++    tags: net socket tls wolfssl
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
+diff --git a/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf b/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf
+new file mode 100644
+index 00000000000..64b08d40f32
+--- /dev/null
++++ b/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf
+@@ -0,0 +1,13 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++CONFIG_WOLFSSL_SESSION_EXPORT=y
++CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
++CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK=n
++CONFIG_WOLFSSL_VERIFY_CALLBACK=y
+diff --git a/tests/net/socket/tls_ext/overlay-wolfssl.conf b/tests/net/socket/tls_ext/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..ca2568bb15d
+--- /dev/null
++++ b/tests/net/socket/tls_ext/overlay-wolfssl.conf
+@@ -0,0 +1,11 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++CONFIG_WOLFSSL_SESSION_EXPORT=y
++CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
+diff --git a/tests/net/socket/tls_ext/src/main.c b/tests/net/socket/tls_ext/src/main.c
+index ffc4c5630fd..e2f5d8a780d 100644
+--- a/tests/net/socket/tls_ext/src/main.c
++++ b/tests/net/socket/tls_ext/src/main.c
+@@ -10,11 +10,17 @@
+ #include <zephyr/net/socket.h>
+ #include <zephyr/net/tls_credentials.h>
+ #include <zephyr/posix/unistd.h>
++#include <time.h>
+ #include <zephyr/sys/util.h>
+ #include <zephyr/ztest.h>
+ 
++#if defined(CONFIG_WOLFSSL)
++#include <wolfssl/ssl.h>
++#include <zephyr/net/tls_verify.h>
++#else
+ #include <mbedtls/x509.h>
+ #include <mbedtls/x509_crt.h>
++#endif
+ 
+ LOG_MODULE_REGISTER(tls_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ 
+@@ -434,9 +440,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
+ 
+ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_required)
+ {
++#if defined(CONFIG_WOLFSSL)
++	/* wolfSSL rejects v1 peer certificates (test uses v1 server.der as
++	 * client cert). This is a wolfSSL policy, not a bug. */
++	ztest_test_skip();
++#else
+ 	test_common(TLS_PEER_VERIFY_REQUIRED);
++#endif
+ }
+ 
++/* --- Unified cert verify result tests (both backends) --- */
++
+ static void test_tls_cert_verify_result_opt_common(uint32_t expect)
+ {
+ 	int server_fd, client_fd, ret;
+@@ -481,13 +495,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
+ 	test_tls_cert_verify_result_opt_common(MBEDTLS_X509_BADCERT_CN_MISMATCH);
+ }
+ 
++/* --- Unified cert verify callback tests (mbedTLS backend only) --- */
++
++#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK) && !defined(CONFIG_WOLFSSL)
++
+ struct test_cert_verify_ctx {
+ 	bool cb_called;
+ 	int result;
+ };
+ 
+ static int cert_verify_cb(void *ctx, mbedtls_x509_crt *crt, int depth,
+-			  uint32_t *flags)
++			   uint32_t *flags)
+ {
+ 	struct test_cert_verify_ctx *test_ctx = (struct test_cert_verify_ctx *)ctx;
+ 
+@@ -507,6 +525,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
+ 	int server_fd, client_fd, ret;
+ 	k_tid_t server_thread_id;
+ 	struct sockaddr_in sa;
++
+ 	struct test_cert_verify_ctx ctx = {
+ 		.cb_called = false,
+ 		.result = result,
+@@ -546,10 +565,49 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
+ 	test_tls_cert_verify_cb_opt_common(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED);
+ }
+ 
++#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
++
++#if defined(CONFIG_WOLFSSL) && defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
++/* Contract test: TLS_CERT_VERIFY_CALLBACK (opt 20) is the mbedTLS-style
++ * cert-verify callback. Under CONFIG_WOLFSSL the option is documented to
++ * return -ENOTSUP; users must use TLS_CERT_VERIFY_CALLBACK_WOLFSSL
++ * instead. This test pins that contract so a future setsockopt
++ * dispatcher change can't silently start accepting opt 20 under wolfSSL.
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt20_enotsup_on_wolfssl)
++{
++	int client_fd;
++	int ret;
++	struct tls_cert_verify_cb dummy = { .cb = NULL, .ctx = NULL };
++
++	client_fd = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
++	zassert_true(client_fd >= 0, "socket() failed: %d", errno);
++
++	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK,
++			       &dummy, sizeof(dummy));
++	zassert_equal(ret, -1, "setsockopt() should fail under wolfSSL");
++	zassert_equal(errno, ENOTSUP,
++		      "expected -ENOTSUP, got errno=%d", errno);
++
++	(void)zsock_close(client_fd);
++}
++#endif /* CONFIG_WOLFSSL && CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
++
+ static void *setup(void)
+ {
+ 	int r;
+ 
++	/* native_sim starts with CLOCK_REALTIME at epoch 0 (1970).
++	 * wolfSSL validates certificate dates, so set the clock to a
++	 * date within the test certificates' validity period.
++	 */
++	const struct timespec ts = {
++		.tv_sec = 1704067200, /* 2024-01-01T00:00:00Z */
++		.tv_nsec = 0,
++	};
++
++	(void)clock_settime(CLOCK_REALTIME, &ts);
++
+ 	/*
+ 	 * Load both client & server credentials
+ 	 *
+@@ -599,4 +657,328 @@ static void *setup(void)
+ 	return NULL;
+ }
+ 
++/* --- wolfSSL-style verify callback tests --- */
++
++#if defined(CONFIG_WOLFSSL_VERIFY_CALLBACK)
++
++struct wolfssl_verify_ctx {
++	bool cb_called;
++	int depth_seen;
++	int error_seen;
++	int decision;  /* 1 = accept, 0 = reject */
++};
++
++static int wolfssl_verify_cb(int preverify_ok, void *store_ctx)
++{
++	WOLFSSL_X509_STORE_CTX *store = store_ctx;
++	struct wolfssl_verify_ctx *ctx;
++
++	if (store == NULL || store->userCtx == NULL) {
++		return preverify_ok;
++	}
++
++	ctx = (struct wolfssl_verify_ctx *)store->userCtx;
++	ctx->cb_called = true;
++	ctx->depth_seen = store->error_depth;
++	ctx->error_seen = store->error;
++
++	return ctx->decision;
++}
++
++struct wolfssl_verify_inspect_ctx {
++	bool cb_called;
++	int error_depth;
++	int total_certs;
++	bool has_certs_buffer;
++	bool domain_is_localhost;
++};
++
++static int wolfssl_verify_inspect_cb(int preverify_ok, void *store_ctx)
++{
++	WOLFSSL_X509_STORE_CTX *store = store_ctx;
++	struct wolfssl_verify_inspect_ctx *ctx;
++
++	if (store == NULL || store->userCtx == NULL) {
++		return preverify_ok;
++	}
++
++	ctx = (struct wolfssl_verify_inspect_ctx *)store->userCtx;
++	ctx->cb_called = true;
++	ctx->error_depth = store->error_depth;
++	ctx->total_certs = store->totalCerts;
++	ctx->has_certs_buffer = (store->certs != NULL &&
++				 store->certs[store->error_depth].length > 0);
++
++	if (store->domain != NULL &&
++	    strcmp(store->domain, "localhost") == 0) {
++		ctx->domain_is_localhost = true;
++	}
++
++	return 1; /* accept */
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_accept)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct sockaddr_in sa;
++
++	struct wolfssl_verify_ctx ctx = {
++		.cb_called = false,
++		.decision = 1, /* accept */
++	};
++	struct tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_cb,
++		.ctx = &ctx,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  TLS_PEER_VERIFY_NONE, false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0, "failed to connect (%d)", errno);
++	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_reject)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct sockaddr_in sa;
++
++	struct wolfssl_verify_ctx ctx = {
++		.cb_called = false,
++		.decision = 0, /* reject */
++	};
++	struct tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_cb,
++		.ctx = &ctx,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  TLS_PEER_VERIFY_NONE, false, true);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
++	zassert_equal(ret, -1, "connect() should fail");
++	zassert_equal(errno, ECONNABORTED, "invalid errno");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_inspect_fields)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct sockaddr_in sa;
++
++	struct wolfssl_verify_inspect_ctx ctx = {0};
++	struct tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_inspect_cb,
++		.ctx = &ctx,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  TLS_PEER_VERIFY_NONE, false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0, "failed to connect (%d)", errno);
++
++	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
++	zassert_true(ctx.total_certs > 0, "totalCerts should be > 0");
++	zassert_true(ctx.has_certs_buffer,
++		     "certs buffer should contain DER data");
++	zassert_true(ctx.domain_is_localhost,
++		     "domain should be 'localhost'");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++static int wolfssl_verify_null_ctx_cb(int preverify_ok, void *store_ctx)
++{
++	WOLFSSL_X509_STORE_CTX *store = store_ctx;
++
++	/* When ctx is NULL, wolfSSL's default userCtx resolution applies.
++	 * store->userCtx should be NULL (ssl->verifyCbCtx is NULL by default).
++	 */
++	if (store != NULL && store->userCtx == NULL) {
++		/* This is the expected path -- userCtx is NULL because we
++		 * did not call wolfSSL_SetCertCbCtx. Accept the cert.
++		 */
++		return 1;
++	}
++
++	/* Unexpected: userCtx is non-NULL. Reject to signal test failure. */
++	return 0;
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_null_ctx)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct sockaddr_in sa;
++
++	/* Register wolfSSL-style callback with ctx set to NULL.
++	 * wolfSSL should NOT call wolfSSL_SetCertCbCtx, so
++	 * store->userCtx in the callback should be NULL.
++	 */
++	struct tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_null_ctx_cb,
++		.ctx = NULL,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  TLS_PEER_VERIFY_NONE, false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0,
++		      "connect failed -- userCtx may not be NULL (%d)", errno);
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++/* --- Server-side wolfSSL-style verify callback test --- */
++
++static struct wolfssl_verify_ctx server_wolfssl_verify_ctx;
++
++static void server_thread_wolfssl_verify_fn(void *arg0, void *arg1, void *arg2)
++{
++	const int server_fd = POINTER_TO_INT(arg0);
++	int r;
++	int client_fd;
++	socklen_t addrlen;
++	struct sockaddr_in sa;
++
++	k_thread_name_set(k_current_get(), "server");
++
++	memset(&sa, 0, sizeof(sa));
++	addrlen = sizeof(sa);
++
++	k_sem_give(&server_sem);
++	r = accept(server_fd, (struct sockaddr *)&sa, &addrlen);
++	zassert_not_equal(r, -1, "accept() failed (%d)", errno);
++	client_fd = r;
++
++	r = close(client_fd);
++	zassert_not_equal(r, -1, "close() failed on the server fd (%d)", errno);
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_server_accept)
++{
++	static const sec_tag_t server_tag_list[] = {
++		CA_CERTIFICATE_TAG,
++		SERVER_CERTIFICATE_TAG,
++	};
++	int server_fd, client_fd, ret;
++	k_tid_t tid;
++	struct sockaddr_in sa;
++	/* Use REQUIRED, not OPTIONAL. On the server side OPTIONAL maps to
++	 * plain WOLFSSL_VERIFY_PEER (request a cert, but accept the handshake
++	 * if the client doesn't present one), so a misbehaving client that
++	 * skips its certificate never triggers the verify callback. REQUIRED
++	 * adds WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, forcing the server to
++	 * actually demand a client certificate and exercise the callback.
++	 */
++	int peer_verify = TLS_PEER_VERIFY_REQUIRED;
++
++	memset(&server_wolfssl_verify_ctx, 0, sizeof(server_wolfssl_verify_ctx));
++	server_wolfssl_verify_ctx.decision = 1; /* accept */
++
++	struct tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_cb,
++		.ctx = &server_wolfssl_verify_ctx,
++	};
++
++	k_sem_init(&server_sem, 0, 1);
++
++	/* Create server socket */
++	ret = socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
++	zassert_not_equal(ret, -1, "failed to create server socket (%d)", errno);
++	server_fd = ret;
++
++	int yes = true;
++
++	ret = setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
++	zassert_not_equal(ret, -1, "failed to set SO_REUSEADDR (%d)", errno);
++
++	ret = setsockopt(server_fd, SOL_TLS, TLS_SEC_TAG_LIST,
++			 server_tag_list, sizeof(server_tag_list));
++	zassert_not_equal(ret, -1, "failed to set TLS_SEC_TAG_LIST (%d)", errno);
++
++	ret = setsockopt(server_fd, SOL_TLS, TLS_HOSTNAME, "localhost",
++			 sizeof("localhost"));
++	zassert_not_equal(ret, -1, "failed to set TLS_HOSTNAME (%d)", errno);
++
++	ret = setsockopt(server_fd, SOL_TLS, TLS_PEER_VERIFY,
++			 &peer_verify, sizeof(peer_verify));
++	zassert_not_equal(ret, -1, "failed to set TLS_PEER_VERIFY (%d)", errno);
++
++	ret = setsockopt(server_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			 &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	memset(&sa, 0, sizeof(sa));
++	sa.sin_addr.s_addr = INADDR_ANY;
++	sa.sin_family = AF_INET;
++	sa.sin_port = htons(PORT);
++
++	ret = bind(server_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_not_equal(ret, -1, "failed to bind (%d)", errno);
++
++	ret = listen(server_fd, 1);
++	zassert_not_equal(ret, -1, "failed to listen (%d)", errno);
++
++	tid = k_thread_create(&server_thread, server_stack, STACK_SIZE,
++			      server_thread_wolfssl_verify_fn,
++			      INT_TO_POINTER(server_fd), NULL, NULL,
++			      K_PRIO_PREEMPT(8), 0, K_NO_WAIT);
++
++	ret = k_sem_take(&server_sem, K_MSEC(TIMEOUT));
++	zassert_equal(0, ret, "failed to synchronize with server thread (%d)", ret);
++
++	/* Client presents its cert */
++	client_fd = test_configure_client(&sa, true, "localhost");
++
++	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0, "failed to connect (%d)", errno);
++
++	/* The server's wolfSSL-style verify callback should have been invoked
++	 * during accept() on the cloned child context.
++	 */
++	zassert_true(server_wolfssl_verify_ctx.cb_called,
++		     "server wolfSSL-style verify callback was not called");
++
++	ret = close(client_fd);
++	zassert_not_equal(-1, ret, "close() failed on client fd (%d)", errno);
++	ret = close(server_fd);
++	zassert_not_equal(-1, ret, "close() failed on server fd (%d)", errno);
++	ret = k_thread_join(&server_thread, K_FOREVER);
++	zassert_equal(0, ret, "k_thread_join() failed (%d)", ret);
++	k_yield();
++}
++
++#endif /* CONFIG_WOLFSSL_VERIFY_CALLBACK */
++
+ ZTEST_SUITE(net_socket_tls_api_extension, NULL, setup, NULL, NULL, NULL);
+diff --git a/tests/net/socket/tls_ext/testcase.yaml b/tests/net/socket/tls_ext/testcase.yaml
+index 497e5f8c65e..2da1d40d794 100644
+--- a/tests/net/socket/tls_ext/testcase.yaml
++++ b/tests/net/socket/tls_ext/testcase.yaml
+@@ -8,3 +8,19 @@ tests:
+     platform_allow: qemu_x86
+     integration_platforms:
+       - qemu_x86
++
++  net.socket.tls.ext.wolfssl:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    tags: net socket tls wolfssl
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
++
++  net.socket.tls.ext.wolfssl.verify_cb:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    tags: net socket tls wolfssl
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl-verify-cb.conf
+diff --git a/tests/subsys/random/rng/overlay-wolfssl.conf b/tests/subsys/random/rng/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..dd5f99c20d1
+--- /dev/null
++++ b/tests/subsys/random/rng/overlay-wolfssl.conf
+@@ -0,0 +1,8 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_CTR_DRBG_CSPRNG_GENERATOR=y
+diff --git a/tests/subsys/random/rng/testcase.yaml b/tests/subsys/random/rng/testcase.yaml
+index 7534548a3dc..1b7f3339618 100644
+--- a/tests/subsys/random/rng/testcase.yaml
++++ b/tests/subsys/random/rng/testcase.yaml
+@@ -24,6 +24,18 @@ tests:
+     min_ram: 16
+     integration_platforms:
+       - native_sim
++  crypto.rng.random_ctr_drbg.wolfssl:
++    extra_args:
++      - CONF_FILE=prj_ctr_drbg.conf
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
++    filter: CONFIG_ENTROPY_HAS_DRIVER
++    min_ram: 16
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim
++    tags: crypto random security wolfssl
+   drivers.rng.random_psa_crypto:
+     filter: CONFIG_BUILD_WITH_TFM
+     arch_exclude: posix

--- a/zephyr/4.3/zephyr-tls-4.3.0.patch
+++ b/zephyr/4.3/zephyr-tls-4.3.0.patch
@@ -216,65 +216,6 @@ index 00000000000..92ac4f1dd22
 +#endif
 +
 +#endif /* ZEPHYR_INCLUDE_NET_TLS_VERIFY_H_ */
-diff --git a/samples/net/sockets/echo_server/overlay-wolfssl.conf b/samples/net/sockets/echo_server/overlay-wolfssl.conf
-new file mode 100644
-index 00000000000..b3a539a5e0a
---- /dev/null
-+++ b/samples/net/sockets/echo_server/overlay-wolfssl.conf
-@@ -0,0 +1,26 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+
-+CONFIG_MAIN_STACK_SIZE=3072
-+CONFIG_NET_BUF_RX_COUNT=80
-+CONFIG_NET_BUF_TX_COUNT=80
-+
-+# TLS configuration
-+CONFIG_MBEDTLS=n
-+CONFIG_NET_SAMPLE_CERTS_WITH_SC=y
-+
-+CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
-+CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=6
-+CONFIG_NET_SOCKETS_ENABLE_DTLS=y
-+CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
-+CONFIG_NET_SOCKETS_DTLS_MAX_FRAGMENT_LENGTH=2048
-+CONFIG_ZVFS_OPEN_MAX=20
-+
-+CONFIG_POSIX_API=y
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+CONFIG_WOLFSSL=y
-+CONFIG_WOLFSSL_DTLS=y
-+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-+
-+
-diff --git a/samples/net/sockets/echo_server/sample.yaml b/samples/net/sockets/echo_server/sample.yaml
-index 5c075eacc0a..a31d22e0e8d 100644
---- a/samples/net/sockets/echo_server/sample.yaml
-+++ b/samples/net/sockets/echo_server/sample.yaml
-@@ -134,6 +134,22 @@ tests:
-       - qemu_x86_64
-     integration_platforms:
-       - qemu_x86
-+  sample.net.sockets.echo_server.wolfssl:
-+    tags: net socket tls wolfssl
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    integration_platforms:
-+      - native_sim/native/64
-+    extra_args:
-+      - EXTRA_CONF_FILE="overlay-wolfssl.conf"
-+    harness: console
-+    harness_config:
-+      type: multi_line
-+      ordered: false
-+      regex:
-+        - "Waiting for TCP.*IPv4"
-+        - "Waiting for UDP.*IPv4"
-   sample.net.sockets.echo_server.nsos:
-     harness: console
-     platform_allow:
 diff --git a/subsys/net/lib/sockets/CMakeLists.txt b/subsys/net/lib/sockets/CMakeLists.txt
 index 7e32b540ce4..a51a9a3b74d 100644
 --- a/subsys/net/lib/sockets/CMakeLists.txt
@@ -460,7 +401,7 @@ index c676c32ddf1..bd23d0f3375 100644
  config NET_SOCKETS_OFFLOAD
  	bool "Offload Socket APIs"
 diff --git a/subsys/net/lib/sockets/sockets_tls.c b/subsys/net/lib/sockets/sockets_tls.c
-index 0a0b360291d..4a4c225d03d 100644
+index 0a0b360291d..5cc70f1545e 100644
 --- a/subsys/net/lib/sockets/sockets_tls.c
 +++ b/subsys/net/lib/sockets/sockets_tls.c
 @@ -47,6 +47,12 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -476,7 +417,7 @@ index 0a0b360291d..4a4c225d03d 100644
  #endif /* CONFIG_MBEDTLS */
  
  #include "sockets_internal.h"
-@@ -56,6 +62,94 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
+@@ -56,6 +62,93 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
  #include <zephyr_mbedtls_priv.h>
  #endif
  
@@ -517,7 +458,6 @@ index 0a0b360291d..4a4c225d03d 100644
 +#include <user_settings.h>
 +#endif /* !WOLFSSL_USER_SETTINGS */
 +#include <wolfssl/ssl.h>
-+#include <wolfssl/internal.h>
 +#include <wolfssl/error-ssl.h>
 +#include <wolfssl/wolfcrypt/asn.h>
 +#include <wolfssl/wolfcrypt/error-crypt.h>
@@ -571,7 +511,7 @@ index 0a0b360291d..4a4c225d03d 100644
  #if defined(CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS)
  #define ALPN_MAX_PROTOCOLS (CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS + 1)
  #else
-@@ -114,14 +208,14 @@ struct tls_session_cache {
+@@ -114,14 +207,14 @@ struct tls_session_cache {
  	size_t session_len;
  };
  
@@ -588,7 +528,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  /** TLS context information. */
  __net_socket struct tls_context {
-@@ -143,6 +237,21 @@ __net_socket struct tls_context {
+@@ -143,6 +236,21 @@ __net_socket struct tls_context {
  	/** Session ended at the TLS/DTLS level. */
  	bool session_closed : 1;
  
@@ -610,7 +550,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	/** Socket type. */
  	enum net_sock_type type;
  
-@@ -203,22 +312,30 @@ __net_socket struct tls_context {
+@@ -203,22 +311,30 @@ __net_socket struct tls_context {
  		uint32_t dtls_handshake_timeout_min;
  		uint32_t dtls_handshake_timeout_max;
  
@@ -643,7 +583,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	/** DTLS peer address. */
  	struct sockaddr dtls_peer_addr;
-@@ -227,7 +344,36 @@ __net_socket struct tls_context {
+@@ -227,7 +343,36 @@ __net_socket struct tls_context {
  	socklen_t dtls_peer_addrlen;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
  
@@ -681,7 +621,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	/** mbedTLS context. */
  	mbedtls_ssl_context ssl;
  
-@@ -252,7 +398,31 @@ __net_socket struct tls_context {
+@@ -252,7 +397,31 @@ __net_socket struct tls_context {
  /* A global pool of TLS contexts. */
  static struct tls_context tls_contexts[CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS];
  
@@ -713,7 +653,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  #if defined(MBEDTLS_SSL_CACHE_C)
  static mbedtls_ssl_cache_context server_cache;
-@@ -266,6 +436,14 @@ static struct k_mutex context_lock;
+@@ -266,6 +435,14 @@ static struct k_mutex context_lock;
   */
  #define TLS_WAIT_MS 100
  
@@ -728,7 +668,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static void tls_session_cache_reset(void)
  {
  	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
-@@ -276,12 +454,23 @@ static void tls_session_cache_reset(void)
+@@ -276,12 +453,23 @@ static void tls_session_cache_reset(void)
  
  	(void)memset(client_cache, 0, sizeof(client_cache));
  }
@@ -755,7 +695,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int tls_ctr_drbg_random(void *ctx, unsigned char *buf, size_t len)
  {
  	ARG_UNUSED(ctx);
-@@ -294,8 +483,25 @@ static int tls_ctr_drbg_random(void *ctx, unsigned char *buf, size_t len)
+@@ -294,8 +482,25 @@ static int tls_ctr_drbg_random(void *ctx, unsigned char *buf, size_t len)
  	return 0;
  #endif
  }
@@ -782,7 +722,7 @@ index 0a0b360291d..4a4c225d03d 100644
  /* mbedTLS-defined function for setting timer. */
  static void dtls_timing_set_delay(void *data, uint32_t int_ms, uint32_t fin_ms)
  {
-@@ -357,7 +563,7 @@ static int dtls_get_remaining_timeout(struct tls_context *ctx)
+@@ -357,7 +562,7 @@ static int dtls_get_remaining_timeout(struct tls_context *ctx)
  
  	return timing->fin_ms - elapsed_ms;
  }
@@ -791,7 +731,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  /* Initialize TLS internals. */
  static int tls_init(void)
-@@ -369,7 +575,9 @@ static int tls_init(void)
+@@ -369,7 +574,9 @@ static int tls_init(void)
  #endif
  
  	(void)memset(tls_contexts, 0, sizeof(tls_contexts));
@@ -801,7 +741,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	k_mutex_init(&context_lock);
  
-@@ -377,6 +585,34 @@ static int tls_init(void)
+@@ -377,6 +584,34 @@ static int tls_init(void)
  	mbedtls_ssl_cache_init(&server_cache);
  #endif
  
@@ -836,7 +776,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	return 0;
  }
  
-@@ -437,8 +673,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
+@@ -437,8 +672,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
  	mbedtls_ssl_conf_max_frag_len(config, mfl_code);
  }
  #else
@@ -847,7 +787,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  /* Allocate TLS context. */
  static struct tls_context *tls_alloc(void)
-@@ -468,6 +706,15 @@ static struct tls_context *tls_alloc(void)
+@@ -468,6 +705,15 @@ static struct tls_context *tls_alloc(void)
  	if (tls) {
  		k_sem_init(&tls->tls_established, 0, 1);
  
@@ -863,7 +803,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		mbedtls_ssl_init(&tls->ssl);
  		mbedtls_ssl_config_init(&tls->config);
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-@@ -489,6 +736,7 @@ static struct tls_context *tls_alloc(void)
+@@ -489,6 +735,7 @@ static struct tls_context *tls_alloc(void)
  #if defined(CONFIG_MBEDTLS_DEBUG)
  		mbedtls_ssl_conf_dbg(&tls->config, zephyr_mbedtls_debug, NULL);
  #endif
@@ -871,7 +811,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	} else {
  		NET_WARN("Failed to allocate TLS context");
  	}
-@@ -512,12 +760,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
+@@ -512,12 +759,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
  	memcpy(&target_tls->options, &source_tls->options,
  	       sizeof(target_tls->options));
  
@@ -899,7 +839,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	return target_tls;
  }
-@@ -535,6 +796,39 @@ static int tls_release(struct tls_context *tls)
+@@ -535,6 +795,39 @@ static int tls_release(struct tls_context *tls)
  		return -EBADF;
  	}
  
@@ -939,7 +879,7 @@ index 0a0b360291d..4a4c225d03d 100644
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  	mbedtls_ssl_cookie_free(&tls->cookie);
  #endif
-@@ -545,12 +839,19 @@ static int tls_release(struct tls_context *tls)
+@@ -545,12 +838,19 @@ static int tls_release(struct tls_context *tls)
  	mbedtls_x509_crt_free(&tls->own_cert);
  	mbedtls_pk_free(&tls->priv_key);
  #endif
@@ -959,7 +899,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static bool peer_addr_cmp(const struct sockaddr *addr,
  			  const struct sockaddr *peer_addr)
  {
-@@ -574,7 +875,9 @@ static bool peer_addr_cmp(const struct sockaddr *addr,
+@@ -574,7 +874,9 @@ static bool peer_addr_cmp(const struct sockaddr *addr,
  
  	return false;
  }
@@ -969,7 +909,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int tls_session_save(const struct sockaddr *peer_addr,
  			    mbedtls_ssl_session *session)
  {
-@@ -743,6 +1046,226 @@ static void tls_session_purge(void)
+@@ -743,6 +1045,226 @@ static void tls_session_purge(void)
  	mbedtls_ssl_cache_init(&server_cache);
  #endif
  }
@@ -1196,7 +1136,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  static inline int time_left(uint32_t start, uint32_t timeout)
  {
-@@ -751,6 +1274,7 @@ static inline int time_left(uint32_t start, uint32_t timeout)
+@@ -751,6 +1273,7 @@ static inline int time_left(uint32_t start, uint32_t timeout)
  	return timeout - elapsed;
  }
  
@@ -1204,7 +1144,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int wait(int sock, int timeout, int event)
  {
  	struct zsock_pollfd fds = {
-@@ -789,11 +1313,11 @@ static int wait(int sock, int timeout, int event)
+@@ -789,11 +1312,11 @@ static int wait(int sock, int timeout, int event)
  
  static int wait_for_reason(int sock, int timeout, int reason)
  {
@@ -1218,7 +1158,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		return wait(sock, timeout, ZSOCK_POLLOUT);
  	}
  
-@@ -862,7 +1386,8 @@ static void dtls_peer_address_get(struct tls_context *context,
+@@ -862,7 +1385,8 @@ static void dtls_peer_address_get(struct tls_context *context,
  	*addrlen = len;
  }
  
@@ -1228,7 +1168,7 @@ index 0a0b360291d..4a4c225d03d 100644
  {
  	struct tls_context *tls_ctx = ctx;
  	ssize_t sent;
-@@ -870,67 +1395,80 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
+@@ -870,67 +1394,80 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
  	sent = zsock_sendto(tls_ctx->sock, buf, len, ZSOCK_MSG_DONTWAIT,
  			    &tls_ctx->dtls_peer_addr,
  			    tls_ctx->dtls_peer_addrlen);
@@ -1328,7 +1268,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	if (sent < 0) {
  		if (errno == EAGAIN) {
  			return MBEDTLS_ERR_SSL_WANT_WRITE;
-@@ -942,10 +1480,73 @@ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
+@@ -942,10 +1479,73 @@ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
  	return sent;
  }
  
@@ -1404,7 +1344,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	received = zsock_recvfrom(tls_ctx->sock, buf, len,
  				  ZSOCK_MSG_DONTWAIT, NULL, 0);
-@@ -959,6 +1560,85 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
+@@ -959,6 +1559,85 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
  
  	return received;
  }
@@ -1490,7 +1430,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
  static bool crt_is_pem(const unsigned char *buf, size_t buflen)
-@@ -971,7 +1651,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
+@@ -971,7 +1650,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
  static int tls_add_ca_certificate(struct tls_context *tls,
  				  struct tls_credential *ca_cert)
  {
@@ -1516,7 +1456,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	int err;
  
  	if (tls->options.cert_nocopy == TLS_CERT_NOCOPY_NONE ||
-@@ -995,6 +1692,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
+@@ -995,6 +1691,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
  	return -ENOTSUP;
  }
  
@@ -1524,7 +1464,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static void tls_set_ca_chain(struct tls_context *tls)
  {
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
-@@ -1003,11 +1701,27 @@ static void tls_set_ca_chain(struct tls_context *tls)
+@@ -1003,11 +1700,27 @@ static void tls_set_ca_chain(struct tls_context *tls)
  				      &mbedtls_x509_crt_profile_default);
  #endif /* MBEDTLS_X509_CRT_PARSE_C */
  }
@@ -1553,7 +1493,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	int err;
  
  	if (tls->options.cert_nocopy == TLS_CERT_NOCOPY_NONE ||
-@@ -1030,6 +1744,7 @@ static int tls_add_own_cert(struct tls_context *tls,
+@@ -1030,6 +1743,7 @@ static int tls_add_own_cert(struct tls_context *tls,
  	return -ENOTSUP;
  }
  
@@ -1561,7 +1501,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int tls_set_own_cert(struct tls_context *tls)
  {
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
-@@ -1044,11 +1759,27 @@ static int tls_set_own_cert(struct tls_context *tls)
+@@ -1044,11 +1758,27 @@ static int tls_set_own_cert(struct tls_context *tls)
  
  	return -ENOTSUP;
  }
@@ -1590,7 +1530,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	int err;
  
  	err = mbedtls_pk_parse_key(&tls->priv_key, priv_key->buf,
-@@ -1068,6 +1799,47 @@ static int tls_set_psk(struct tls_context *tls,
+@@ -1068,6 +1798,47 @@ static int tls_set_psk(struct tls_context *tls,
  		       struct tls_credential *psk,
  		       struct tls_credential *psk_id)
  {
@@ -1638,7 +1578,7 @@ index 0a0b360291d..4a4c225d03d 100644
  #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
  	int err = mbedtls_ssl_conf_psk(&tls->config,
  				       psk->buf, psk->len,
-@@ -1079,6 +1851,7 @@ static int tls_set_psk(struct tls_context *tls,
+@@ -1079,6 +1850,7 @@ static int tls_set_psk(struct tls_context *tls,
  
  	return 0;
  #endif
@@ -1646,7 +1586,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	return -ENOTSUP;
  }
-@@ -1121,6 +1894,7 @@ static int tls_set_credential(struct tls_context *tls,
+@@ -1121,6 +1893,7 @@ static int tls_set_credential(struct tls_context *tls,
  	return 0;
  }
  
@@ -1654,7 +1594,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int tls_mbedtls_set_credentials(struct tls_context *tls)
  {
  	struct tls_credential *cred;
-@@ -1471,10 +2245,57 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
+@@ -1471,10 +2244,57 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
  
  	return 0;
  }
@@ -1713,7 +1653,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	mbedtls_x509_crt cert_ctx;
  	int err;
  
-@@ -1509,7 +2330,31 @@ static int tls_check_cert(struct tls_credential *cert)
+@@ -1509,7 +2329,31 @@ static int tls_check_cert(struct tls_credential *cert)
  
  static int tls_check_priv_key(struct tls_credential *priv_key)
  {
@@ -1746,7 +1686,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	mbedtls_pk_context key_ctx;
  	int err;
  
-@@ -1537,7 +2382,22 @@ static int tls_check_priv_key(struct tls_credential *priv_key)
+@@ -1537,7 +2381,22 @@ static int tls_check_priv_key(struct tls_credential *priv_key)
  
  static int tls_check_psk(struct tls_credential *psk)
  {
@@ -1770,7 +1710,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	struct tls_credential *psk_id;
  
  	psk_id = credential_get(psk->tag, TLS_CREDENTIAL_PSK_ID);
-@@ -1557,7 +2417,7 @@ static int tls_check_psk(struct tls_credential *psk)
+@@ -1557,7 +2416,7 @@ static int tls_check_psk(struct tls_credential *psk)
  		"Reconfigure mbed TLS to support PSK based key exchange.");
  
  	return -ENOTSUP;
@@ -1779,7 +1719,7 @@ index 0a0b360291d..4a4c225d03d 100644
  }
  
  static int tls_check_credentials(const sec_tag_t *sec_tags, int sec_tag_count)
-@@ -1622,55 +2482,1167 @@ exit:
+@@ -1622,55 +2481,1167 @@ exit:
  	return err;
  }
  
@@ -2980,7 +2920,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	if (*optlen % sizeof(sec_tag_t) != 0 || *optlen == 0) {
  		return -EINVAL;
-@@ -1688,6 +3660,44 @@ static int tls_opt_sec_tag_list_get(struct tls_context *context,
+@@ -1688,6 +3659,44 @@ static int tls_opt_sec_tag_list_get(struct tls_context *context,
  static int tls_opt_hostname_set(struct tls_context *context,
  				const void *optval, socklen_t optlen)
  {
@@ -3025,7 +2965,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	ARG_UNUSED(optlen);
  
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
-@@ -1701,6 +3711,7 @@ static int tls_opt_hostname_set(struct tls_context *context,
+@@ -1701,6 +3710,7 @@ static int tls_opt_hostname_set(struct tls_context *context,
  	context->options.is_hostname_set = true;
  
  	return 0;
@@ -3033,7 +2973,7 @@ index 0a0b360291d..4a4c225d03d 100644
  }
  
  static int tls_opt_ciphersuite_list_set(struct tls_context *context,
-@@ -1723,12 +3734,23 @@ static int tls_opt_ciphersuite_list_set(struct tls_context *context,
+@@ -1723,12 +3733,23 @@ static int tls_opt_ciphersuite_list_set(struct tls_context *context,
  		return -EINVAL;
  	}
  
@@ -3057,7 +2997,7 @@ index 0a0b360291d..4a4c225d03d 100644
  }
  
  static int tls_opt_ciphersuite_list_get(struct tls_context *context,
-@@ -1742,6 +3764,49 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
+@@ -1742,6 +3763,49 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
  		return -EINVAL;
  	}
  
@@ -3107,7 +3047,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	if (context->options.ciphersuites[0] == 0) {
  		/* No specific ciphersuites configured, return all available. */
  		selected_ciphers = mbedtls_ssl_list_ciphersuites();
-@@ -1761,23 +3826,54 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
+@@ -1761,23 +3825,54 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
  	*optlen = i * sizeof(int);
  
  	return 0;
@@ -3168,7 +3108,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	return 0;
  }
-@@ -1808,6 +3904,12 @@ static int tls_opt_alpn_list_set(struct tls_context *context,
+@@ -1808,6 +3903,12 @@ static int tls_opt_alpn_list_set(struct tls_context *context,
  	memcpy(context->options.alpn_list, optval, optlen);
  	context->options.alpn_list[alpn_cnt] = NULL;
  
@@ -3181,7 +3121,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	return 0;
  }
  
-@@ -1854,12 +3956,18 @@ static int tls_opt_dtls_handshake_timeout_set(struct tls_context *context,
+@@ -1854,12 +3955,18 @@ static int tls_opt_dtls_handshake_timeout_set(struct tls_context *context,
  		context->options.dtls_handshake_timeout_min = *val;
  	}
  
@@ -3202,7 +3142,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	return 0;
  }
-@@ -2131,18 +4239,44 @@ static int tls_opt_cert_verify_result_get(struct tls_context *context,
+@@ -2131,18 +4238,44 @@ static int tls_opt_cert_verify_result_get(struct tls_context *context,
  		return -EINVAL;
  	}
  
@@ -3248,7 +3188,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	tls_session_purge();
  
  	return 0;
-@@ -2163,9 +4297,9 @@ static int tls_opt_peer_verify_set(struct tls_context *context,
+@@ -2163,9 +4296,9 @@ static int tls_opt_peer_verify_set(struct tls_context *context,
  
  	peer_verify = (int *)optval;
  
@@ -3261,7 +3201,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		return -EINVAL;
  	}
  
-@@ -2213,8 +4347,8 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
+@@ -2213,8 +4346,8 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
  	}
  
  	role = (int *)optval;
@@ -3272,7 +3212,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		return -EINVAL;
  	}
  
-@@ -2224,6 +4358,22 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
+@@ -2224,6 +4357,22 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
  }
  
  #if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
@@ -3295,7 +3235,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int tls_opt_cert_verify_callback_set(struct tls_context *context,
  					    const void *optval,
  					    socklen_t optlen)
-@@ -2247,18 +4397,68 @@ static int tls_opt_cert_verify_callback_set(struct tls_context *context,
+@@ -2247,18 +4396,68 @@ static int tls_opt_cert_verify_callback_set(struct tls_context *context,
  
  	return 0;
  }
@@ -3364,7 +3304,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static int protocol_check(int family, int type, int *proto)
  {
  	if (family != AF_INET && family != AF_INET6) {
-@@ -2342,7 +4542,11 @@ int ztls_close_ctx(struct tls_context *ctx, int sock)
+@@ -2342,7 +4541,11 @@ int ztls_close_ctx(struct tls_context *ctx, int sock)
  	/* Try to send close notification. */
  	ctx->flags = 0;
  
@@ -3376,7 +3316,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  	err = tls_release(ctx);
  	ret = zsock_close(ctx->sock);
-@@ -2401,6 +4605,32 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
+@@ -2401,6 +4604,32 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
  	    || (ctx->type == SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
  #endif
  	    ) {
@@ -3409,7 +3349,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		ret = tls_mbedtls_init(ctx, false);
  		if (ret < 0) {
  			goto error;
-@@ -2425,6 +4655,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
+@@ -2425,6 +4654,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
  		}
  
  		tls_session_store(ctx, addr, addrlen);
@@ -3417,7 +3357,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	}
  
  	return 0;
-@@ -2465,6 +4696,25 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
+@@ -2465,6 +4695,25 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
  
  	child->sock = sock;
  
@@ -3443,7 +3383,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	ret = tls_mbedtls_init(child, true);
  	if (ret < 0) {
  		goto error;
-@@ -2483,6 +4733,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
+@@ -2483,6 +4732,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
  	}
  
  	return fd;
@@ -3451,7 +3391,7 @@ index 0a0b360291d..4a4c225d03d 100644
  
  error:
  	if (child != NULL) {
-@@ -2501,6 +4752,7 @@ error:
+@@ -2501,6 +4751,7 @@ error:
  	return -1;
  }
  
@@ -3459,7 +3399,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static ssize_t send_tls(struct tls_context *ctx, const void *buf,
  			size_t len, int flags)
  {
-@@ -2579,8 +4831,85 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
+@@ -2579,8 +4830,85 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
  
  	return -1;
  }
@@ -3546,7 +3486,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static ssize_t sendto_dtls_client(struct tls_context *ctx, const void *buf,
  				  size_t len, int flags,
  				  const struct sockaddr *dest_addr,
-@@ -2672,6 +5001,24 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+@@ -2672,6 +5000,24 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  	ctx->flags = flags;
  
  	/* TLS */
@@ -3571,7 +3511,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	if (ctx->type == SOCK_STREAM) {
  		return send_tls(ctx, buf, len, flags);
  	}
-@@ -2688,6 +5035,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+@@ -2688,6 +5034,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  	errno = ENOTSUP;
  	return -1;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
@@ -3579,7 +3519,7 @@ index 0a0b360291d..4a4c225d03d 100644
  }
  
  static ssize_t dtls_sendmsg_merge_and_send(struct tls_context *ctx,
-@@ -2793,6 +5141,7 @@ send_loop:
+@@ -2793,6 +5140,7 @@ send_loop:
  	return tls_sendmsg_loop_and_send(ctx, msg, flags);
  }
  
@@ -3587,7 +3527,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  			size_t max_len, int flags)
  {
-@@ -2808,7 +5157,110 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+@@ -2808,7 +5156,110 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  		return -1;
  	}
  
@@ -3699,7 +3639,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		return 0;
  	}
  
-@@ -2821,79 +5273,235 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+@@ -2821,79 +5272,235 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  	end = sys_timepoint_calc(timeout);
  
  	do {
@@ -3978,7 +3918,7 @@ index 0a0b360291d..4a4c225d03d 100644
  static ssize_t recvfrom_dtls_common(struct tls_context *ctx, void *buf,
  				    size_t max_len, int flags,
  				    struct sockaddr *src_addr,
-@@ -3183,6 +5791,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+@@ -3183,6 +5790,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  
  	ctx->flags = flags;
  
@@ -4004,7 +3944,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	/* TLS */
  	if (ctx->type == SOCK_STREAM) {
  		return recv_tls(ctx, buf, max_len, flags);
-@@ -3201,18 +5828,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+@@ -3201,18 +5827,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  	errno = ENOTSUP;
  	return -1;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
@@ -4031,7 +3971,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	}
  
  	return 0;
-@@ -3233,7 +5867,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
+@@ -3233,7 +5866,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
  	 * it actually starts to poll for data.
  	 */
  	if ((pfd->events & ZSOCK_POLLIN) && (ctx->type == SOCK_DGRAM) &&
@@ -4040,7 +3980,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	    !is_handshake_complete(ctx)) {
  		(*pev)->obj = &ctx->tls_established;
  		(*pev)->type = K_POLL_TYPE_SEM_AVAILABLE;
-@@ -3281,6 +5915,79 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3281,6 +5914,79 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  {
  	int ret;
  
@@ -4120,7 +4060,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	if (ctx->type == SOCK_STREAM) {
  		if (!ctx->is_initialized) {
  			return -ENOTCONN;
-@@ -3325,11 +6032,6 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3325,11 +6031,6 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  	ret = mbedtls_ssl_read(&ctx->ssl, NULL, 0);
  	if (ret < 0) {
  		if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
@@ -4132,7 +4072,7 @@ index 0a0b360291d..4a4c225d03d 100644
  			if (ctx->type == SOCK_DGRAM) {
  				ret = tls_mbedtls_reset(ctx);
  				if (ret != 0) {
-@@ -3349,16 +6051,12 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3349,16 +6050,12 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  
  		NET_ERR("TLS data check error: -%x", -ret);
  
@@ -4149,7 +4089,7 @@ index 0a0b360291d..4a4c225d03d 100644
  			return -ENOTCONN;
  		}
  #endif
-@@ -3366,6 +6064,7 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3366,6 +6063,7 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  	}
  
  	return mbedtls_ssl_get_bytes_avail(&ctx->ssl);
@@ -4157,7 +4097,7 @@ index 0a0b360291d..4a4c225d03d 100644
  }
  
  static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
-@@ -3375,10 +6074,17 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
+@@ -3375,10 +6073,17 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
  
  	if (!ctx->is_listening) {
  		/* Already had TLS data to read on socket. */
@@ -4175,7 +4115,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	}
  
  	if (ctx->type == SOCK_STREAM) {
-@@ -3402,6 +6108,7 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
+@@ -3402,6 +6107,7 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
  	}
  #endif
  	ret = ztls_socket_data_check(ctx);
@@ -4183,7 +4123,7 @@ index 0a0b360291d..4a4c225d03d 100644
  	if (ret == -ENOTCONN || (pfd->revents & ZSOCK_POLLHUP)) {
  		/* Datagram does not return 0 on consecutive recv, but an error
  		 * code, hence clear POLLIN.
-@@ -3512,7 +6219,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+@@ -3512,7 +6218,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
  	 * reports that data is ready.
  	 */
  	if ((ctx->type != SOCK_DGRAM) ||
@@ -4192,7 +4132,7 @@ index 0a0b360291d..4a4c225d03d 100644
  		return false;
  	}
  
-@@ -3525,13 +6232,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+@@ -3525,13 +6231,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
  		pfd->revents &= ~ZSOCK_POLLIN;
  		return true;
  	} else if (!is_handshake_complete(ctx)) {
@@ -4208,7 +4148,7 @@ index 0a0b360291d..4a4c225d03d 100644
  				 ZSOCK_MSG_DONTWAIT);
  		if (ret < 0) {
  			pfd->revents |= ZSOCK_POLLERR;
-@@ -3850,6 +6557,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
+@@ -3850,6 +6556,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
  		err = tls_opt_cert_verify_callback_set(ctx, optval, optlen);
  		break;
  
@@ -4225,7 +4165,7 @@ index 0a0b360291d..4a4c225d03d 100644
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  	case TLS_DTLS_HANDSHAKE_TIMEOUT_MIN:
  		err = tls_opt_dtls_handshake_timeout_set(ctx, optval,
-@@ -3896,6 +6613,21 @@ out:
+@@ -3896,6 +6612,21 @@ out:
  }
  
  #if defined(CONFIG_NET_TEST)
@@ -4247,7 +4187,7 @@ index 0a0b360291d..4a4c225d03d 100644
  mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
  {
  	struct tls_context *ctx;
-@@ -3908,17 +6640,18 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
+@@ -3908,17 +6639,18 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
  
  	return &ctx->ssl;
  }
@@ -4270,7 +4210,7 @@ index 0a0b360291d..4a4c225d03d 100644
  }
  
  static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
-@@ -4004,8 +6737,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+@@ -4004,8 +6736,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
  static int tls_sock_shutdown_vmeth(void *obj, int how)
  {
  	struct tls_context *ctx = obj;
@@ -4417,1790 +4357,3 @@ index 25f563e3040..2e2f648d445 100644
  end:
  	k_mutex_unlock(&ctr_lock);
  
-diff --git a/tests/net/lib/coap_server/common/overlay-wolfssl.conf b/tests/net/lib/coap_server/common/overlay-wolfssl.conf
-new file mode 100644
-index 00000000000..ef9ade38ce3
---- /dev/null
-+++ b/tests/net/lib/coap_server/common/overlay-wolfssl.conf
-@@ -0,0 +1,14 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+#
-+# Switch the secure CoAP server test from the mbedTLS backend to wolfSSL,
-+# exercising DTLS server-side under the wolfSSL TLS sockets integration.
-+
-+CONFIG_MBEDTLS=n
-+CONFIG_POSIX_API=y
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+
-+CONFIG_WOLFSSL=y
-+CONFIG_WOLFSSL_DTLS=y
-+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-diff --git a/tests/net/lib/coap_server/common/testcase.yaml b/tests/net/lib/coap_server/common/testcase.yaml
-index 4bfa4556a61..c2b22fabfa3 100644
---- a/tests/net/lib/coap_server/common/testcase.yaml
-+++ b/tests/net/lib/coap_server/common/testcase.yaml
-@@ -17,3 +17,17 @@ tests:
-     extra_configs:
-       - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
-       - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
-+  net.coap.server.secure.wolfssl:
-+    tags:
-+      - tls
-+      - wolfssl
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    integration_platforms:
-+      - native_sim/native/64
-+    extra_configs:
-+      - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
-+      - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
-+    extra_args:
-+      - OVERLAY_CONFIG=overlay-wolfssl.conf
-diff --git a/tests/net/lib/http_server/tls/overlay-wolfssl.conf b/tests/net/lib/http_server/tls/overlay-wolfssl.conf
-new file mode 100644
-index 00000000000..9a24eb7a931
---- /dev/null
-+++ b/tests/net/lib/http_server/tls/overlay-wolfssl.conf
-@@ -0,0 +1,14 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+#
-+# Switch the http_server TLS test from the mbedTLS backend to wolfSSL.
-+
-+CONFIG_MBEDTLS=n
-+CONFIG_MBEDTLS_BUILTIN=n
-+CONFIG_MBEDTLS_ENABLE_HEAP=n
-+
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+
-+CONFIG_WOLFSSL=y
-+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-diff --git a/tests/net/lib/http_server/tls/src/main.c b/tests/net/lib/http_server/tls/src/main.c
-index 6d710eb350e..ec076b4e4c7 100644
---- a/tests/net/lib/http_server/tls/src/main.c
-+++ b/tests/net/lib/http_server/tls/src/main.c
-@@ -160,7 +160,12 @@ static void test_tls(void)
- 		const sec_tag_t *sec_tag_list;
- 		size_t sec_tag_list_size;
- 
--		sec_tag_list_size = sizeof(sec_tag_list);
-+		/* sizeof(sec_tag_list_verify_none), not sizeof(sec_tag_list)
-+		 * — the latter is sizeof(pointer), which on 64-bit hosts
-+		 * (e.g. native_sim/native/64) feeds an extra garbage sec_tag
-+		 * into setsockopt and breaks credential lookup.
-+		 */
-+		sec_tag_list_size = sizeof(sec_tag_list_verify_none);
- 		sec_tag_list = sec_tag_list_verify_none;
- 
- 		ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_SEC_TAG_LIST,
-diff --git a/tests/net/lib/http_server/tls/testcase.yaml b/tests/net/lib/http_server/tls/testcase.yaml
-index ef398a2f09d..78668f40e61 100644
---- a/tests/net/lib/http_server/tls/testcase.yaml
-+++ b/tests/net/lib/http_server/tls/testcase.yaml
-@@ -20,3 +20,12 @@ tests:
-     integration_toolchains:
-       - host
-       - llvm
-+  net.http.server.tls.wolfssl:
-+    tags: http net server socket wolfssl
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    integration_platforms:
-+      - native_sim/native/64
-+    extra_args:
-+      - OVERLAY_CONFIG=overlay-wolfssl.conf
-diff --git a/tests/net/lib/tls_credentials/testcase.yaml b/tests/net/lib/tls_credentials/testcase.yaml
-index 1e812e2164b..2b1440179f7 100644
---- a/tests/net/lib/tls_credentials/testcase.yaml
-+++ b/tests/net/lib/tls_credentials/testcase.yaml
-@@ -11,3 +11,24 @@ tests:
-       - net
-       - tls
-       - trusted-firmware-m
-+  net.tls_credentials.wolfssl:
-+    # Exercises the credentials API alongside a WOLFSSL=y build to catch
-+    # symbol/include collisions in a TLS-credentials-only configuration
-+    # (no NET_SOCKETS_SOCKOPT_TLS). The API itself is backend-agnostic.
-+    tags:
-+      - net
-+      - tls
-+      - wolfssl
-+    depends_on: netif
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    integration_platforms:
-+      - native_sim/native/64
-+    extra_configs:
-+      - CONFIG_MBEDTLS=n
-+      - CONFIG_POSIX_API=y
-+      - CONFIG_POSIX_TIMERS=y
-+      - CONFIG_POSIX_THREADS=y
-+      - CONFIG_WOLFSSL=y
-+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-diff --git a/tests/net/socket/register/testcase.yaml b/tests/net/socket/register/testcase.yaml
-index efbf8725023..ea6c154e3d5 100644
---- a/tests/net/socket/register/testcase.yaml
-+++ b/tests/net/socket/register/testcase.yaml
-@@ -22,3 +22,21 @@ tests:
-       - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
-       - CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
-       - CONFIG_MAIN_STACK_SIZE=2048
-+  net.socket.register.tls.wolfssl:
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    tags: net socket socket.register wolfssl
-+    extra_configs:
-+      - CONFIG_MBEDTLS=n
-+      - CONFIG_POSIX_API=y
-+      - CONFIG_POSIX_TIMERS=y
-+      - CONFIG_POSIX_THREADS=y
-+      - CONFIG_WOLFSSL=y
-+      - CONFIG_WOLFSSL_DTLS=y
-+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-+      - CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
-+      - CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=6
-+      - CONFIG_NET_SOCKETS_ENABLE_DTLS=y
-+      - CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
-+      - CONFIG_MAIN_STACK_SIZE=2048
-diff --git a/tests/net/socket/tls/overlay-wolfssl.conf b/tests/net/socket/tls/overlay-wolfssl.conf
-new file mode 100644
-index 00000000000..1e3851d3c9a
---- /dev/null
-+++ b/tests/net/socket/tls/overlay-wolfssl.conf
-@@ -0,0 +1,20 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+
-+CONFIG_MBEDTLS=n
-+CONFIG_POSIX_API=y
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+CONFIG_WOLFSSL=y
-+CONFIG_WOLFSSL_DTLS=y
-+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=100000
-+CONFIG_WOLFSSL_ALPN=y
-+CONFIG_WOLFSSL_PSK=y
-+CONFIG_MBEDTLS_ENABLE_HEAP=n
-+CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED=n
-+CONFIG_MBEDTLS_HASH_ALL_ENABLED=n
-+CONFIG_MBEDTLS_CMAC=n
-+CONFIG_MBEDTLS_SSL_ALPN=n
-+CONFIG_WOLFSSL_TLS_VERSION_1_3=y
-+CONFIG_WOLFSSL_SESSION_EXPORT=y
-+CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
-diff --git a/tests/net/socket/tls/prj.conf b/tests/net/socket/tls/prj.conf
-index 24058c31dd7..9e87ecf9e64 100644
---- a/tests/net/socket/tls/prj.conf
-+++ b/tests/net/socket/tls/prj.conf
-@@ -46,7 +46,15 @@ CONFIG_ZTEST=y
- CONFIG_ZTEST_STACK_SIZE=4096
- 
- CONFIG_MBEDTLS_ENABLE_HEAP=y
--CONFIG_MBEDTLS_HEAP_SIZE=18000
-+# Empirically determined: the suite hangs at test_v4_msg_trunc with
-+# CONFIG_MBEDTLS_HEAP_SIZE <= 18000 (upstream's value) once the fork's
-+# added ALPN/PSK/timeout tests + CONFIG_MBEDTLS_SSL_ALPN=y are in play.
-+# 19000 was the empirical floor; 22000 keeps ~3 KB headroom. If you add
-+# more mbedTLS-allocating tests and start seeing the same flake, bump
-+# this rather than chasing a phantom leak.
-+CONFIG_MBEDTLS_HEAP_SIZE=22000
- CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED=y
- CONFIG_MBEDTLS_HASH_ALL_ENABLED=y
- CONFIG_MBEDTLS_CMAC=y
-+CONFIG_MBEDTLS_SSL_ALPN=y
-+CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS=3
-diff --git a/tests/net/socket/tls/src/main.c b/tests/net/socket/tls/src/main.c
-index 8186ba7dbe9..4375fd04c5e 100644
---- a/tests/net/socket/tls/src/main.c
-+++ b/tests/net/socket/tls/src/main.c
-@@ -12,15 +12,54 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
- #include <zephyr/net/loopback.h>
- #include <zephyr/net/socket.h>
- #include <zephyr/net/tls_credentials.h>
-+/* IANA TLS ciphersuite IDs used by this file's set_ciphersuites tests.
-+ * Names match RFC 4279. Don't introduce a public Zephyr-wide header just
-+ * for these two — both backends accept IANA IDs verbatim via the byte-
-+ * list cipher API.
-+ */
-+#define TLS_PSK_WITH_AES_128_CBC_SHA  0x008C
-+#define TLS_PSK_WITH_AES_256_CBC_SHA  0x008D
-+
-+#if defined(CONFIG_WOLFSSL)
-+#ifndef WOLFSSL_USER_SETTINGS
-+#include <user_settings.h>
-+#endif
-+#include <wolfssl/ssl.h>
-+WOLFSSL *ztls_get_wolfssl_context(int fd);
-+int SendAlert(WOLFSSL *ssl, int severity, int type);
-+#endif
-+
-+#if defined(CONFIG_MBEDTLS)
- #include <mbedtls/ssl.h>
-+mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd);
-+#endif
- 
- #include "../../socket_helpers.h"
- 
-+static const int cipher_list_psk[] = {
-+	TLS_PSK_WITH_AES_128_CBC_SHA,
-+	TLS_PSK_WITH_AES_256_CBC_SHA
-+};
-+
-+/* Test test_set_ciphersuites() assumes [0] of this list is the
-+ * cipher that will be negotiated */
-+static const int cipher_list_psk2[] = {
-+	TLS_PSK_WITH_AES_128_CBC_SHA,
-+};
-+
-+static const int cipher_list_psk3[] = {
-+	TLS_PSK_WITH_AES_256_CBC_SHA,
-+};
-+
- #define TEST_STR_SMALL "test"
- 
- #define MY_IPV4_ADDR "127.0.0.1"
- #define MY_IPV6_ADDR "::1"
- 
-+#ifndef MY_DEFLT_HOSTNAME
-+#define MY_DEFLT_HOSTNAME "localhost"
-+#endif
-+
- #define ANY_PORT 0
- #define SERVER_PORT 4242
- 
-@@ -118,6 +157,20 @@ static void test_connect(int sock, struct sockaddr *addr, socklen_t addrlen)
- 	}
- }
- 
-+static void test_connect_err(int sock, struct sockaddr *addr, socklen_t addrlen)
-+{
-+	k_yield();
-+
-+	zassert_equal(zsock_connect(sock, addr, addrlen),
-+		      -1,
-+		      "connect expected to fail but succeeded");
-+
-+	if (IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)) {
-+		/* Let the connection proceed */
-+		k_yield();
-+	}
-+}
-+
- static void test_send(int sock, const void *buf, size_t len, int flags)
- {
- 	zassert_equal(zsock_send(sock, buf, len, flags),
-@@ -149,6 +202,15 @@ static void test_accept(int sock, int *new_sock, struct sockaddr *addr,
- 	zassert_true(*new_sock >= 0, "accept failed");
- }
- 
-+static void test_accept_err(int sock, int *new_sock, struct sockaddr *addr,
-+			    socklen_t *addrlen)
-+{
-+	zassert_not_null(new_sock, "null newsock");
-+
-+	*new_sock = zsock_accept(sock, addr, addrlen);
-+	zassert_true(*new_sock < 0, "accept expected to fail but succeeded");
-+}
-+
- static void test_shutdown(int sock, int how)
- {
- 	zassert_equal(zsock_shutdown(sock, how),
-@@ -290,6 +352,16 @@ static void client_connect_work_handler(struct k_work *work)
- 		     sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
- }
- 
-+static void client_connect_work_handler_err(struct k_work *work)
-+{
-+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-+	struct connect_data *data =
-+		CONTAINER_OF(dwork, struct connect_data, work);
-+
-+	test_connect_err(data->sock, data->addr, data->addr->sa_family == AF_INET ?
-+			 sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
-+}
-+
- static void dtls_client_connect_send_work_handler(struct k_work *work)
- {
- 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-@@ -407,6 +479,71 @@ static void test_prepare_dtls_connection(sa_family_t family)
- 	test_work_wait(&test_data.work);
- }
- 
-+/* Function pointer type for function to be called after socket creation but
-+ * before any bind/listen/connect operations */
-+typedef void (*tls_pre_cb)(void);
-+/* Function pointer type for function to be used to perform client work
-+ * instead of client_connect_work_handler() */
-+typedef void (*client_work_func)(struct k_work *work);
-+
-+static void test_prepare_tls_connection_ex(sa_family_t family, bool accept_err,
-+					   tls_pre_cb cb, client_work_func cw)
-+{
-+	struct sockaddr c_saddr;
-+	struct sockaddr s_saddr;
-+	socklen_t exp_addrlen = family == AF_INET6 ?
-+				sizeof(struct sockaddr_in6) :
-+				sizeof(struct sockaddr_in);
-+	struct sockaddr addr;
-+	socklen_t addrlen = sizeof(addr);
-+	struct connect_data test_data;
-+
-+	if (family == AF_INET6) {
-+		prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock,
-+				    (struct sockaddr_in6 *)&c_saddr,
-+				    IPPROTO_TLS_1_2);
-+		prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock,
-+				    (struct sockaddr_in6 *)&s_saddr,
-+				    IPPROTO_TLS_1_2);
-+	} else {
-+		prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock,
-+				    (struct sockaddr_in *)&c_saddr,
-+				    IPPROTO_TLS_1_2);
-+		prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &s_sock,
-+				    (struct sockaddr_in *)&s_saddr,
-+				    IPPROTO_TLS_1_2);
-+	}
-+
-+	if (NULL != cb) {
-+		cb();
-+	}
-+
-+	test_config_psk(s_sock, c_sock);
-+
-+	test_bind(s_sock, &s_saddr, exp_addrlen);
-+	test_listen(s_sock);
-+
-+	/* Helper work for the connect operation - need to handle client/server
-+	 * in parallel due to handshake.
-+	 */
-+	test_data.sock = c_sock;
-+	test_data.addr = &s_saddr;
-+	if (cw != NULL) {
-+		k_work_init_delayable(&test_data.work, cw);
-+	} else {
-+		k_work_init_delayable(&test_data.work, client_connect_work_handler);
-+	}
-+	test_work_reschedule(&test_data.work, K_NO_WAIT);
-+
-+	if (accept_err == true) {
-+		test_accept_err(s_sock, &new_sock, &addr, &addrlen);
-+	} else {
-+		test_accept(s_sock, &new_sock, &addr, &addrlen);
-+		zassert_equal(addrlen, exp_addrlen, "Wrong addrlen");
-+	}
-+	test_work_wait(&test_data.work);
-+}
-+
- ZTEST(net_socket_tls, test_v4_msg_waitall)
- {
- 	struct test_msg_waitall_data test_data = {
-@@ -537,6 +674,7 @@ static void send_work_handler(struct k_work *work)
- 
- void test_msg_trunc(sa_family_t family)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	int rv;
- 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
- 	struct send_data test_data = {
-@@ -571,6 +709,9 @@ void test_msg_trunc(sa_family_t family)
- 
- 	/* Small delay for the final alert exchange */
- 	k_msleep(10);
-+#else
-+	ztest_test_skip();
-+#endif
- }
- 
- ZTEST(net_socket_tls, test_v4_msg_trunc)
-@@ -665,18 +806,26 @@ static void test_dtls_sendmsg_no_buf(sa_family_t family)
- 
- ZTEST(net_socket_tls, test_v4_dtls_sendmsg_no_buf)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE > 0) {
- 		ztest_test_skip();
- 	}
-+#else
-+	ztest_test_skip();
-+#endif
- 
- 	test_dtls_sendmsg_no_buf(AF_INET);
- }
- 
- ZTEST(net_socket_tls, test_v6_dtls_sendmsg_no_buf)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE > 0) {
- 		ztest_test_skip();
- 	}
-+#else
-+	ztest_test_skip();
-+#endif
- 
- 	test_dtls_sendmsg_no_buf(AF_INET6);
- }
-@@ -785,18 +934,22 @@ static void test_dtls_sendmsg(sa_family_t family)
- 
- ZTEST(net_socket_tls, test_v4_dtls_sendmsg)
- {
--	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE == 0) {
--		ztest_test_skip();
--	}
-+#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-+	ztest_test_skip();
-+#elif CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE <= 0
-+	ztest_test_skip();
-+#endif
- 
- 	test_dtls_sendmsg(AF_INET);
- }
- 
- ZTEST(net_socket_tls, test_v6_dtls_sendmsg)
- {
--	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE == 0) {
--		ztest_test_skip();
--	}
-+#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-+	ztest_test_skip();
-+#elif CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE <= 0
-+	ztest_test_skip();
-+#endif
- 
- 	test_dtls_sendmsg(AF_INET6);
- }
-@@ -1165,7 +1318,21 @@ ZTEST(net_socket_tls, test_recv_eof_on_close)
- 	k_sleep(TCP_TEARDOWN_TIMEOUT);
- }
- 
-+/* Per-record framing overhead the test uses to right-size SO_RCVBUF for
-+ * exactly one TLS application record carrying TEST_STR_SMALL. Both numbers
-+ * are observed values for these suites' default ciphersuite (TLS 1.2 AES
-+ * GCM), measured by running the suite with an oversized buffer and printing
-+ * the inbound record length. Different values per backend reflect different
-+ * implementation choices for the record-layer framing (header layout, IV
-+ * placement, padding) — they are not part of any wire-format ABI. If a
-+ * test starts failing here after a backend or ciphersuite change, re-measure
-+ * with an oversized buffer and update.
-+ */
-+#if defined(CONFIG_WOLFSSL)
-+#define TLS_RECORD_OVERHEAD 29
-+#else
- #define TLS_RECORD_OVERHEAD 81
-+#endif
- 
- ZTEST(net_socket_tls, test_send_non_block)
- {
-@@ -1316,7 +1483,7 @@ ZTEST(net_socket_tls, test_send_on_close)
- 	new_sock = -1;
- 
- 	/* Small delay for packets to propagate. */
--	k_msleep(10);
-+	k_msleep(20);
- 
- 	/* Verify send() reports an error after connection is closed. */
- 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
-@@ -1338,7 +1505,7 @@ ZTEST(net_socket_tls, test_send_on_close)
- 	new_sock = -1;
- 
- 	/* Small delay for packets to propagate. */
--	k_msleep(10);
-+	k_msleep(20);
- 
- 	/* Graceful connection close should be reported first. */
- 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
-@@ -1489,10 +1656,13 @@ ZTEST(net_socket_tls, test_shutdown_rd_while_recv)
- 
- 	test_prepare_tls_connection(AF_INET6);
- 
--	/* Schedule reception shutdown from workqueue */
-+	/* Schedule reception shutdown from workqueue. 50ms margin guards
-+	 * against slow CI runners where recv() hasn't reached its blocking
-+	 * point at the 10ms mark.
-+	 */
- 	k_work_init_delayable(&test_data.work, shutdown_work);
- 	test_data.sock = c_sock;
--	test_work_reschedule(&test_data.work, K_MSEC(10));
-+	test_work_reschedule(&test_data.work, K_MSEC(50));
- 
- 	/* EOF should be notified by recv() */
- 	test_eof(c_sock);
-@@ -1502,6 +1672,78 @@ ZTEST(net_socket_tls, test_shutdown_rd_while_recv)
- 	k_sleep(TCP_TEARDOWN_TIMEOUT);
- }
- 
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
-+/* wolfSSL-only: exercises the recv_eof shortcut in
-+ * recvfrom_dtls_common_wolfssl that turns local SHUT_RD/SHUT_RDWR into
-+ * an EOF on the next recv(). The mbedTLS backend matches upstream
-+ * Zephyr behavior (no local-shutdown shortcut on DTLS), so this test
-+ * is gated to wolfSSL builds to preserve the upstream interface
-+ * contract for mbedTLS users.
-+ */
-+static void test_dtls_shutdown_synchronous_body(sa_family_t family, int how)
-+{
-+	test_prepare_dtls_connection(family);
-+
-+	test_shutdown(c_sock, how);
-+
-+	/* EOF should be notified by recv() */
-+	test_eof(c_sock);
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+#endif
-+
-+ZTEST(net_socket_tls, test_dtls_shutdown_rd_synchronous_v6)
-+{
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
-+	test_dtls_shutdown_synchronous_body(AF_INET6, ZSOCK_SHUT_RD);
-+#else
-+	ztest_test_skip();
-+#endif
-+}
-+
-+ZTEST(net_socket_tls, test_dtls_shutdown_rd_synchronous_v4)
-+{
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
-+	test_dtls_shutdown_synchronous_body(AF_INET, ZSOCK_SHUT_RD);
-+#else
-+	ztest_test_skip();
-+#endif
-+}
-+
-+ZTEST(net_socket_tls, test_dtls_shutdown_rd_while_recv)
-+{
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
-+	struct shutdown_data test_data = {
-+		.how = ZSOCK_SHUT_RD,
-+	};
-+
-+	test_prepare_dtls_connection(AF_INET6);
-+
-+	/* Schedule reception shutdown from workqueue while recv() is blocked
-+	 * — exercises the recv_eof check inside the wolfSSL DTLS recv loop
-+	 * (recvfrom_dtls_common_wolfssl). The TCP/TLS variant lives in
-+	 * test_shutdown_rd_while_recv. 50ms margin guards against slow CI
-+	 * runners where recv() hasn't reached its blocking point yet at the
-+	 * 10ms mark — short enough to keep the test fast.
-+	 */
-+	k_work_init_delayable(&test_data.work, shutdown_work);
-+	test_data.sock = c_sock;
-+	test_work_reschedule(&test_data.work, K_MSEC(50));
-+
-+	/* EOF should be notified by recv() */
-+	test_eof(c_sock);
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+#else
-+	ztest_test_skip();
-+#endif
-+}
-+
- ZTEST(net_socket_tls, test_send_while_recv)
- {
- 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
-@@ -1542,6 +1784,433 @@ ZTEST(net_socket_tls, test_send_while_recv)
- 	k_sleep(TCP_TEARDOWN_TIMEOUT);
- }
- 
-+void tls_set_cs_cb(void)
-+{
-+	int ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
-+				   (void *)cipher_list_psk, sizeof(cipher_list_psk));
-+	zassert_equal(ret, 0, "Unable to set ciphersuites on server");
-+	ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
-+			       (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
-+	zassert_equal(ret, 0, "Unable to set ciphersuites on client");
-+}
-+
-+void tls_set_cs_mismatch_cb(void)
-+{
-+	/* Set mismatched ciphersuites, should not connect */
-+	int ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
-+				   (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
-+	zassert_equal(ret, 0, "Unable to set ciphersuites on client");
-+	ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
-+			       (void *)cipher_list_psk3, sizeof(cipher_list_psk3));
-+	zassert_equal(ret, 0, "Unable to set ciphersuites on server");
-+}
-+
-+ZTEST(net_socket_tls, test_set_ciphersuites)
-+{
-+#define TLS_CS_TEST_MAX_CS_NUM 3
-+	int ret;
-+	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
-+	struct send_data test_data = {
-+		.data = TEST_STR_SMALL,
-+		.datalen = sizeof(TEST_STR_SMALL) - 1
-+	};
-+	int ciphersuites[TLS_CS_TEST_MAX_CS_NUM];
-+	int cs_len = sizeof(ciphersuites);
-+	int curr_cipher = 0;
-+	int cc_len = sizeof(int);
-+	int i;
-+
-+	for (i = 0; i < TLS_CS_TEST_MAX_CS_NUM; i++) {
-+		ciphersuites[i] = 0;
-+	}
-+
-+	test_prepare_tls_connection_ex(AF_INET, false, tls_set_cs_cb, NULL);
-+
-+	/* Verify the ciphersuite list is what we set for server */
-+	ret = zsock_getsockopt(s_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
-+			       (void *)ciphersuites, (socklen_t *)&cs_len);
-+	zassert_equal(ret, 0, "Unable to get ciphersuites for server");
-+	zassert_equal(cs_len, sizeof(cipher_list_psk), "Incorrect get ciphersuite len");
-+
-+	for (i = 0; i < cs_len / sizeof(int); i++) {
-+		zassert_equal(ciphersuites[i], cipher_list_psk[i],
-+			      "Retrieved ciphersuite list element does not match set value");
-+	}
-+
-+	/* Same for client */
-+	for (i = 0; i < TLS_CS_TEST_MAX_CS_NUM; i++) {
-+		ciphersuites[i] = 0;
-+	}
-+
-+	cs_len = sizeof(ciphersuites);
-+	ret = zsock_getsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_LIST,
-+			       (void *)ciphersuites, (socklen_t *)&cs_len);
-+	zassert_equal(ret, 0, "Unable to get ciphersuites for client");
-+	zassert_equal(cs_len, sizeof(cipher_list_psk2), "Incorrect get ciphersuite len");
-+
-+	for (i = 0; i < cs_len / sizeof(int); i++) {
-+		zassert_equal(ciphersuites[i], cipher_list_psk2[i],
-+			      "Retrieved ciphersuite list element does not match set value");
-+	}
-+
-+	/* Check that the actual negotiated cipher is correct for server */
-+	ret = zsock_getsockopt(new_sock, SOL_TLS, TLS_CIPHERSUITE_USED,
-+			       (void *)&curr_cipher, (socklen_t *)&cc_len);
-+	zassert_equal(ret, 0, "Unable to get current ciphersuite for server");
-+	zassert_equal(curr_cipher, cipher_list_psk2[0]);
-+
-+	/* Same for the client */
-+	curr_cipher = 0;
-+	ret = zsock_getsockopt(c_sock, SOL_TLS, TLS_CIPHERSUITE_USED,
-+			       (void *)&curr_cipher, (socklen_t *)&cc_len);
-+	zassert_equal(ret, 0, "Unable to get current ciphersuite for client");
-+	zassert_equal(curr_cipher, cipher_list_psk2[0]);
-+
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+
-+	/* recv() shall block until send work sends the data. */
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+
-+ZTEST(net_socket_tls, test_set_ciphersuites_err)
-+{
-+	/* Expect failure to connect and accept due to mismatched ciphersuites */
-+	test_prepare_tls_connection_ex(AF_INET, true,
-+		tls_set_cs_mismatch_cb, client_connect_work_handler_err);
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+
-+void tls_set_hostname_cb(void)
-+{
-+	int ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_HOSTNAME,
-+				   (void *)MY_DEFLT_HOSTNAME, strlen(MY_DEFLT_HOSTNAME));
-+	zassert_equal(ret, 0, "Unable to set hostname on client");
-+}
-+
-+ZTEST(net_socket_tls, test_set_hostname)
-+{
-+	int ret;
-+	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
-+	struct send_data test_data = {
-+		.data = TEST_STR_SMALL,
-+		.datalen = sizeof(TEST_STR_SMALL) - 1
-+	};
-+
-+	test_prepare_tls_connection_ex(AF_INET, false, tls_set_hostname_cb, NULL);
-+
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+
-+	/* recv() shall block until send work sends the data. */
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+
-+void tls_set_session_cache_cb(void)
-+{
-+	int t = TLS_SESSION_CACHE_ENABLED;
-+	int l = sizeof(int);
-+
-+	int ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_SESSION_CACHE,
-+				   (void *)&t, l);
-+	zassert_equal(ret, 0, "Unable to set session cache on server");
-+}
-+
-+ZTEST(net_socket_tls, test_session_cache)
-+{
-+	int ret;
-+	int enabled = 0;
-+	int len = sizeof(int);
-+	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
-+	struct send_data test_data = {
-+		.data = TEST_STR_SMALL,
-+		.datalen = sizeof(TEST_STR_SMALL) - 1
-+	};
-+
-+	test_prepare_tls_connection_ex(AF_INET, false, tls_set_session_cache_cb, NULL);
-+
-+	/* Check that the session cache is enabled */
-+	ret = zsock_getsockopt(s_sock, SOL_TLS, TLS_SESSION_CACHE,
-+			       (void *)&enabled, (socklen_t *)&len);
-+	zassert_equal(ret, 0, "Unable to get session cache enabled status");
-+	zassert_equal(enabled, TLS_SESSION_CACHE_ENABLED,
-+		      "Session cache value does not match what was set");
-+
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+
-+	/* recv() shall block until send work sends the data. */
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+
-+/* Helper enabling session cache on both client and server sockets. Used by
-+ * test_session_cache_client_resume to exercise the wolfSSL tls_session_store /
-+ * tls_session_restore marshalling code path.
-+ */
-+static void tls_set_session_cache_client_cb(void)
-+{
-+	int t = TLS_SESSION_CACHE_ENABLED;
-+	int l = sizeof(int);
-+	int ret;
-+
-+	ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_SESSION_CACHE,
-+			       (void *)&t, l);
-+	zassert_equal(ret, 0, "Unable to set session cache on server");
-+	ret = zsock_setsockopt(c_sock, SOL_TLS, TLS_SESSION_CACHE,
-+			       (void *)&t, l);
-+	zassert_equal(ret, 0, "Unable to set session cache on client");
-+}
-+
-+/* Sets up a TLS client/server connection on a FIXED server port so two
-+ * consecutive connections present the same peer address (which is the key
-+ * into client_cache). Used by test_session_cache_client_resume — the
-+ * main test_prepare_* helpers use ANY_PORT, which prevents resumption
-+ * lookup from matching across connections.
-+ */
-+static void prepare_tls_session_resume_connection(uint16_t server_port)
-+{
-+	struct sockaddr_in c_saddr;
-+	struct sockaddr_in s_saddr;
-+	struct sockaddr addr;
-+	socklen_t addrlen = sizeof(addr);
-+	struct connect_data test_data;
-+	int reuse = 1;
-+	int ret;
-+
-+	prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr,
-+			    IPPROTO_TLS_1_2);
-+	prepare_sock_tls_v4(MY_IPV4_ADDR, server_port, &s_sock, &s_saddr,
-+			    IPPROTO_TLS_1_2);
-+
-+	tls_set_session_cache_client_cb();
-+
-+	test_config_psk(s_sock, c_sock);
-+
-+	/* Fixed server port + back-to-back binds in the same suite: ask the
-+	 * stack to allow rebind so the test isn't fragile if a previous
-+	 * teardown's TIME_WAIT entry is still around.
-+	 */
-+	ret = zsock_setsockopt(s_sock, SOL_SOCKET, SO_REUSEADDR,
-+			       &reuse, sizeof(reuse));
-+	zassert_equal(ret, 0, "SO_REUSEADDR on server socket failed");
-+
-+	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
-+	test_listen(s_sock);
-+
-+	test_data.sock = c_sock;
-+	test_data.addr = (struct sockaddr *)&s_saddr;
-+	k_work_init_delayable(&test_data.work, client_connect_work_handler);
-+	test_work_reschedule(&test_data.work, K_NO_WAIT);
-+
-+	test_accept(s_sock, &new_sock, &addr, &addrlen);
-+	test_work_wait(&test_data.work);
-+}
-+
-+/* Verifies that the second connect to the same peer actually resumes via the
-+ * client-side session marshalling (mbedTLS: tls_session_save/get; wolfSSL:
-+ * wolfSSL_i2d_SSL_SESSION / wolfSSL_d2i_SSL_SESSION in tls_session_store /
-+ * tls_session_restore). Purges first so state is isolated.
-+ */
-+ZTEST(net_socket_tls, test_session_cache_client_resume)
-+{
-+	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
-+	struct send_data test_data = {
-+		.data = TEST_STR_SMALL,
-+		.datalen = sizeof(TEST_STR_SMALL) - 1,
-+	};
-+	int ret;
-+
-+	/* Purge any sessions left by earlier tests so we can observe the
-+	 * transition from "no cached session" to "cached session".
-+	 */
-+	{
-+		int dummy = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
-+
-+		zassert_true(dummy >= 0, "purge socket open failed");
-+		ret = zsock_setsockopt(dummy, SOL_TLS, TLS_SESSION_CACHE_PURGE,
-+				       NULL, 0);
-+		zassert_equal(ret, 0, "purge setsockopt failed");
-+		zsock_close(dummy);
-+	}
-+
-+	/* First connection — should perform full handshake, then store. */
-+	prepare_tls_session_resume_connection(SERVER_PORT);
-+
-+#if defined(CONFIG_WOLFSSL)
-+	{
-+		WOLFSSL *ssl = ztls_get_wolfssl_context(c_sock);
-+		int reused;
-+
-+		zassert_not_null(ssl, "Failed to get wolfSSL context");
-+		reused = wolfSSL_session_reused(ssl);
-+		zassert_equal(reused, 0,
-+			      "First connect should not be a resumption (got %d)",
-+			      reused);
-+	}
-+#endif
-+
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+
-+	test_sockets_close();
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+
-+	/* Second connection to the SAME server port — should restore the
-+	 * stored session and resume.
-+	 */
-+	prepare_tls_session_resume_connection(SERVER_PORT);
-+
-+#if defined(CONFIG_WOLFSSL)
-+	{
-+		WOLFSSL *ssl = ztls_get_wolfssl_context(c_sock);
-+		int reused;
-+
-+		zassert_not_null(ssl, "Failed to get wolfSSL context");
-+		reused = wolfSSL_session_reused(ssl);
-+		zassert_not_equal(reused, 0,
-+				  "Second connect did not reuse session");
-+	}
-+#endif
-+
-+	memset(rx_buf, 0, sizeof(rx_buf));
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
-+
-+	test_sockets_close();
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+
-+/* Smoke test for M01: verify that a TLS handshake completes when wolfSSL
-+ * secure renegotiation is enabled. With HAVE_SECURE_RENEGOTIATION the TLS
-+ * init path calls wolfSSL_UseSecureRenegotiation() on each new SSL object;
-+ * a failure there fails ztls_connect_ctx/ztls_accept_ctx. A successful
-+ * handshake proves the call is reachable and the API is wired up. A full
-+ * renegotiation round-trip would require additional hooks into the Zephyr
-+ * TLS socket API which are out of scope here.
-+ */
-+ZTEST(net_socket_tls, test_tls_renegotiation_smoke)
-+{
-+#if defined(CONFIG_WOLFSSL)
-+#if !defined(HAVE_SECURE_RENEGOTIATION)
-+	ztest_test_skip();
-+	return;
-+#endif
-+#elif !defined(CONFIG_MBEDTLS_SSL_RENEGOTIATION)
-+	ztest_test_skip();
-+	return;
-+#endif
-+	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
-+	struct send_data test_data = {
-+		.data = TEST_STR_SMALL,
-+		.datalen = sizeof(TEST_STR_SMALL) - 1,
-+	};
-+	int ret;
-+
-+	test_prepare_tls_connection(AF_INET);
-+
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
-+
-+	test_sockets_close();
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+}
-+
-+const char *alpn_list[] = {
-+	"http/1.0",
-+	"http/1.1"
-+};
-+
-+void tls_set_alpn_cb(void)
-+{
-+	socklen_t len = sizeof(alpn_list);
-+	int ret = zsock_setsockopt(s_sock, SOL_TLS, TLS_ALPN_LIST,
-+				   (void *)alpn_list, len);
-+	zassert_equal(ret, 0, "Unable to set alpn on server");
-+}
-+
-+ZTEST(net_socket_tls, test_alpn)
-+{
-+#if CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS > 0
-+	int ret;
-+	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
-+	struct send_data test_data = {
-+		.data = TEST_STR_SMALL,
-+		.datalen = sizeof(TEST_STR_SMALL) - 1
-+	};
-+	const char *alpn_buf[2];
-+	int alpn_len = sizeof(alpn_buf);
-+
-+	alpn_buf[0] = NULL;
-+	alpn_buf[1] = NULL;
-+
-+	test_prepare_tls_connection_ex(AF_INET, false, tls_set_alpn_cb, NULL);
-+
-+	/* Check that the ALPN list is the one we set */
-+	ret = zsock_getsockopt(s_sock, SOL_TLS, TLS_ALPN_LIST,
-+			       (void *)alpn_buf, (socklen_t *)&alpn_len);
-+	zassert_equal(ret, 0, "Unable to get alpn list");
-+	zassert_equal(alpn_len, sizeof(alpn_list), "Retrieved ALPN list length incorrect");
-+	zassert_equal(strlen(alpn_buf[0]), strlen(alpn_list[0]),
-+		      "Retrieved ALPN list element length incorrect");
-+	zassert_mem_equal(alpn_buf[0], alpn_list[0], strlen(alpn_list[0]),
-+			  "Retrieved ALPN element does not match what was set");
-+	zassert_equal(strlen(alpn_buf[1]), strlen(alpn_list[1]),
-+		      "Retrieved ALPN list element length incorrect");
-+	zassert_mem_equal(alpn_buf[1], alpn_list[1], strlen(alpn_list[1]),
-+			  "Retrieved ALPN element does not match what was set");
-+
-+	test_data.sock = c_sock;
-+	k_work_init_delayable(&test_data.tx_work, send_work_handler);
-+	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
-+
-+	/* recv() shall block until send work sends the data. */
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
-+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+#else
-+	ztest_test_skip();
-+#endif
-+}
-+
- ZTEST(net_socket_tls, test_poll_tls_pollin)
- {
- 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
-@@ -1575,6 +2244,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollin)
- 
- ZTEST(net_socket_tls, test_poll_dtls_pollin)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
- 	struct send_data test_data = {
- 		.data = TEST_STR_SMALL,
-@@ -1608,6 +2278,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollin)
- 
- 	/* Small delay for the final alert exchange */
- 	k_msleep(10);
-+#else
-+	ztest_test_skip();
-+#endif
- }
- 
- ZTEST(net_socket_tls, test_poll_tls_pollout)
-@@ -1660,6 +2333,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollout)
- 
- ZTEST(net_socket_tls, test_poll_dtls_pollout)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	struct zsock_pollfd fds[1];
- 	int ret;
- 
-@@ -1677,6 +2351,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollout)
- 
- 	/* Small delay for the final alert exchange */
- 	k_msleep(10);
-+#else
-+	ztest_test_skip();
-+#endif
- }
- 
- ZTEST(net_socket_tls, test_poll_tls_pollhup)
-@@ -1709,6 +2386,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollhup)
- 
- ZTEST(net_socket_tls, test_poll_dtls_pollhup)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	struct zsock_pollfd fds[1];
- 	uint8_t rx_buf;
- 	int ret;
-@@ -1734,10 +2412,11 @@ ZTEST(net_socket_tls, test_poll_dtls_pollhup)
- 
- 	/* Small delay for the final alert exchange */
- 	k_msleep(10);
-+#else
-+	ztest_test_skip();
-+#endif
- }
- 
--mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd);
--
- ZTEST(net_socket_tls, test_poll_tls_pollerr)
- {
- 	uint8_t rx_buf;
-@@ -1745,7 +2424,11 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
- 	struct zsock_pollfd fds[1];
- 	int optval;
- 	socklen_t optlen = sizeof(optval);
-+#if defined(CONFIG_WOLFSSL)
-+	WOLFSSL *ssl_ctx;
-+#else
- 	mbedtls_ssl_context *ssl_ctx;
-+#endif
- 
- 	test_prepare_tls_connection(AF_INET6);
- 
-@@ -1753,9 +2436,14 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
- 	fds[0].events = ZSOCK_POLLIN;
- 
- 	/* Get access to the underlying ssl context, and send alert. */
-+#if defined(CONFIG_WOLFSSL)
-+	ssl_ctx = ztls_get_wolfssl_context(c_sock);
-+	SendAlert(ssl_ctx, alert_fatal, wolfssl_alert_protocol_version);
-+#else
- 	ssl_ctx = ztls_get_mbedtls_ssl_context(c_sock);
- 	mbedtls_ssl_send_alert_message(ssl_ctx, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
- 				       MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
-+#endif
- 
- 	ret = zsock_poll(fds, 1, 100);
- 	zassert_equal(ret, 1, "poll() should've report event");
-@@ -1777,12 +2465,17 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
- 
- ZTEST(net_socket_tls, test_poll_dtls_pollerr)
- {
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
- 	uint8_t rx_buf;
- 	int ret;
- 	struct zsock_pollfd fds[1];
- 	int optval;
- 	socklen_t optlen = sizeof(optval);
-+#if defined(CONFIG_WOLFSSL)
-+	WOLFSSL *ssl_ctx;
-+#else
- 	mbedtls_ssl_context *ssl_ctx;
-+#endif
- 
- 	test_prepare_dtls_connection(AF_INET6);
- 
-@@ -1790,9 +2483,14 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
- 	fds[0].events = ZSOCK_POLLIN;
- 
- 	/* Get access to the underlying ssl context, and send alert. */
-+#if defined(CONFIG_WOLFSSL)
-+	ssl_ctx = ztls_get_wolfssl_context(c_sock);
-+	SendAlert(ssl_ctx, alert_fatal, wolfssl_alert_protocol_version);
-+#else
- 	ssl_ctx = ztls_get_mbedtls_ssl_context(c_sock);
- 	mbedtls_ssl_send_alert_message(ssl_ctx, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
- 				       MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
-+#endif
- 
- 	ret = zsock_poll(fds, 1, 100);
- 	zassert_equal(ret, 1, "poll() should've report event");
-@@ -1812,6 +2510,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
- 
- 	/* Small delay for the final alert exchange */
- 	k_msleep(10);
-+#else
-+	ztest_test_skip();
-+#endif
- }
- 
- #define BAD_CA_CERT_TAG 11
-@@ -1896,6 +2597,71 @@ ZTEST(net_socket_tls, test_dtls_bad_cred)
- 	test_bad_cred_common(true);
- }
- 
-+ZTEST(net_socket_tls, test_tls13_psk_handshake)
-+{
-+#if !defined(WOLFSSL_TLS13) || !defined(CONFIG_WOLFSSL)
-+	ztest_test_skip();
-+	return;
-+#else
-+	struct sockaddr_in6 c_saddr, s_saddr;
-+	struct sockaddr addr;
-+	socklen_t addrlen = sizeof(addr);
-+	struct connect_data test_data;
-+	uint8_t tx_buf[] = TEST_STR_SMALL;
-+	uint8_t rx_buf[sizeof(tx_buf)];
-+	int ret;
-+	int optval;
-+	socklen_t optlen = sizeof(optval);
-+
-+	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock,
-+			    &c_saddr, IPPROTO_TLS_1_3);
-+	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock,
-+			    &s_saddr, IPPROTO_TLS_1_3);
-+
-+	test_config_psk(s_sock, c_sock);
-+
-+	test_bind(s_sock, (struct sockaddr *)&s_saddr,
-+		  sizeof(struct sockaddr_in6));
-+	test_listen(s_sock);
-+
-+	test_data.sock = c_sock;
-+	test_data.addr = (struct sockaddr *)&s_saddr;
-+	k_work_init_delayable(&test_data.work,
-+			      client_connect_work_handler);
-+	test_work_reschedule(&test_data.work, K_NO_WAIT);
-+
-+	test_accept(s_sock, &new_sock, &addr, &addrlen);
-+	test_work_wait(&test_data.work);
-+
-+	/* Verify protocol is TLS 1.3 via socket option */
-+	ret = zsock_getsockopt(new_sock, SOL_SOCKET, SO_PROTOCOL,
-+			       &optval, &optlen);
-+	zassert_equal(ret, 0, "getsockopt failed (%d)", errno);
-+	zassert_equal(optval, IPPROTO_TLS_1_3,
-+		      "Expected TLS 1.3 protocol");
-+
-+	/* Verify TLS 1.3 was actually negotiated, not just requested */
-+	{
-+		WOLFSSL *ssl = ztls_get_wolfssl_context(new_sock);
-+
-+		zassert_not_null(ssl, "Failed to get wolfSSL context");
-+		zassert_equal(wolfSSL_GetVersion(ssl), WOLFSSL_TLSV1_3,
-+			      "Negotiated version is not TLS 1.3");
-+	}
-+
-+	/* Send and receive */
-+	test_send(c_sock, tx_buf, sizeof(tx_buf), 0);
-+	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
-+	zassert_equal(ret, sizeof(tx_buf), "recv() failed");
-+	zassert_mem_equal(rx_buf, tx_buf, sizeof(tx_buf),
-+			  "Data mismatch");
-+
-+	test_sockets_close();
-+
-+	k_sleep(TCP_TEARDOWN_TIMEOUT);
-+#endif
-+}
-+
- static void *tls_tests_setup(void)
- {
- 	k_work_queue_init(&tls_test_work_queue);
-diff --git a/tests/net/socket/tls/testcase.yaml b/tests/net/socket/tls/testcase.yaml
-index f652305f20b..ae875ccd726 100644
---- a/tests/net/socket/tls/testcase.yaml
-+++ b/tests/net/socket/tls/testcase.yaml
-@@ -21,3 +21,12 @@ tests:
-   net.socket.tls.sendmsg_no_buf:
-     extra_configs:
-       - CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE=0
-+  net.socket.tls.wolfssl:
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    integration_platforms:
-+      - native_sim
-+    tags: net socket tls wolfssl
-+    extra_args:
-+      - OVERLAY_CONFIG=overlay-wolfssl.conf
-diff --git a/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf b/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf
-new file mode 100644
-index 00000000000..64b08d40f32
---- /dev/null
-+++ b/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf
-@@ -0,0 +1,13 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+
-+CONFIG_MBEDTLS=n
-+CONFIG_POSIX_API=y
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+CONFIG_WOLFSSL=y
-+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-+CONFIG_WOLFSSL_SESSION_EXPORT=y
-+CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
-+CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK=n
-+CONFIG_WOLFSSL_VERIFY_CALLBACK=y
-diff --git a/tests/net/socket/tls_ext/overlay-wolfssl.conf b/tests/net/socket/tls_ext/overlay-wolfssl.conf
-new file mode 100644
-index 00000000000..ca2568bb15d
---- /dev/null
-+++ b/tests/net/socket/tls_ext/overlay-wolfssl.conf
-@@ -0,0 +1,11 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+
-+CONFIG_MBEDTLS=n
-+CONFIG_POSIX_API=y
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+CONFIG_WOLFSSL=y
-+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-+CONFIG_WOLFSSL_SESSION_EXPORT=y
-+CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
-diff --git a/tests/net/socket/tls_ext/src/main.c b/tests/net/socket/tls_ext/src/main.c
-index ffc4c5630fd..e2f5d8a780d 100644
---- a/tests/net/socket/tls_ext/src/main.c
-+++ b/tests/net/socket/tls_ext/src/main.c
-@@ -10,11 +10,17 @@
- #include <zephyr/net/socket.h>
- #include <zephyr/net/tls_credentials.h>
- #include <zephyr/posix/unistd.h>
-+#include <time.h>
- #include <zephyr/sys/util.h>
- #include <zephyr/ztest.h>
- 
-+#if defined(CONFIG_WOLFSSL)
-+#include <wolfssl/ssl.h>
-+#include <zephyr/net/tls_verify.h>
-+#else
- #include <mbedtls/x509.h>
- #include <mbedtls/x509_crt.h>
-+#endif
- 
- LOG_MODULE_REGISTER(tls_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
- 
-@@ -434,9 +440,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
- 
- ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_required)
- {
-+#if defined(CONFIG_WOLFSSL)
-+	/* wolfSSL rejects v1 peer certificates (test uses v1 server.der as
-+	 * client cert). This is a wolfSSL policy, not a bug. */
-+	ztest_test_skip();
-+#else
- 	test_common(TLS_PEER_VERIFY_REQUIRED);
-+#endif
- }
- 
-+/* --- Unified cert verify result tests (both backends) --- */
-+
- static void test_tls_cert_verify_result_opt_common(uint32_t expect)
- {
- 	int server_fd, client_fd, ret;
-@@ -481,13 +495,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
- 	test_tls_cert_verify_result_opt_common(MBEDTLS_X509_BADCERT_CN_MISMATCH);
- }
- 
-+/* --- Unified cert verify callback tests (mbedTLS backend only) --- */
-+
-+#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK) && !defined(CONFIG_WOLFSSL)
-+
- struct test_cert_verify_ctx {
- 	bool cb_called;
- 	int result;
- };
- 
- static int cert_verify_cb(void *ctx, mbedtls_x509_crt *crt, int depth,
--			  uint32_t *flags)
-+			   uint32_t *flags)
- {
- 	struct test_cert_verify_ctx *test_ctx = (struct test_cert_verify_ctx *)ctx;
- 
-@@ -507,6 +525,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
- 	int server_fd, client_fd, ret;
- 	k_tid_t server_thread_id;
- 	struct sockaddr_in sa;
-+
- 	struct test_cert_verify_ctx ctx = {
- 		.cb_called = false,
- 		.result = result,
-@@ -546,10 +565,49 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
- 	test_tls_cert_verify_cb_opt_common(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED);
- }
- 
-+#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
-+
-+#if defined(CONFIG_WOLFSSL) && defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
-+/* Contract test: TLS_CERT_VERIFY_CALLBACK (opt 20) is the mbedTLS-style
-+ * cert-verify callback. Under CONFIG_WOLFSSL the option is documented to
-+ * return -ENOTSUP; users must use TLS_CERT_VERIFY_CALLBACK_WOLFSSL
-+ * instead. This test pins that contract so a future setsockopt
-+ * dispatcher change can't silently start accepting opt 20 under wolfSSL.
-+ */
-+ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt20_enotsup_on_wolfssl)
-+{
-+	int client_fd;
-+	int ret;
-+	struct tls_cert_verify_cb dummy = { .cb = NULL, .ctx = NULL };
-+
-+	client_fd = zsock_socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
-+	zassert_true(client_fd >= 0, "socket() failed: %d", errno);
-+
-+	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK,
-+			       &dummy, sizeof(dummy));
-+	zassert_equal(ret, -1, "setsockopt() should fail under wolfSSL");
-+	zassert_equal(errno, ENOTSUP,
-+		      "expected -ENOTSUP, got errno=%d", errno);
-+
-+	(void)zsock_close(client_fd);
-+}
-+#endif /* CONFIG_WOLFSSL && CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
-+
- static void *setup(void)
- {
- 	int r;
- 
-+	/* native_sim starts with CLOCK_REALTIME at epoch 0 (1970).
-+	 * wolfSSL validates certificate dates, so set the clock to a
-+	 * date within the test certificates' validity period.
-+	 */
-+	const struct timespec ts = {
-+		.tv_sec = 1704067200, /* 2024-01-01T00:00:00Z */
-+		.tv_nsec = 0,
-+	};
-+
-+	(void)clock_settime(CLOCK_REALTIME, &ts);
-+
- 	/*
- 	 * Load both client & server credentials
- 	 *
-@@ -599,4 +657,328 @@ static void *setup(void)
- 	return NULL;
- }
- 
-+/* --- wolfSSL-style verify callback tests --- */
-+
-+#if defined(CONFIG_WOLFSSL_VERIFY_CALLBACK)
-+
-+struct wolfssl_verify_ctx {
-+	bool cb_called;
-+	int depth_seen;
-+	int error_seen;
-+	int decision;  /* 1 = accept, 0 = reject */
-+};
-+
-+static int wolfssl_verify_cb(int preverify_ok, void *store_ctx)
-+{
-+	WOLFSSL_X509_STORE_CTX *store = store_ctx;
-+	struct wolfssl_verify_ctx *ctx;
-+
-+	if (store == NULL || store->userCtx == NULL) {
-+		return preverify_ok;
-+	}
-+
-+	ctx = (struct wolfssl_verify_ctx *)store->userCtx;
-+	ctx->cb_called = true;
-+	ctx->depth_seen = store->error_depth;
-+	ctx->error_seen = store->error;
-+
-+	return ctx->decision;
-+}
-+
-+struct wolfssl_verify_inspect_ctx {
-+	bool cb_called;
-+	int error_depth;
-+	int total_certs;
-+	bool has_certs_buffer;
-+	bool domain_is_localhost;
-+};
-+
-+static int wolfssl_verify_inspect_cb(int preverify_ok, void *store_ctx)
-+{
-+	WOLFSSL_X509_STORE_CTX *store = store_ctx;
-+	struct wolfssl_verify_inspect_ctx *ctx;
-+
-+	if (store == NULL || store->userCtx == NULL) {
-+		return preverify_ok;
-+	}
-+
-+	ctx = (struct wolfssl_verify_inspect_ctx *)store->userCtx;
-+	ctx->cb_called = true;
-+	ctx->error_depth = store->error_depth;
-+	ctx->total_certs = store->totalCerts;
-+	ctx->has_certs_buffer = (store->certs != NULL &&
-+				 store->certs[store->error_depth].length > 0);
-+
-+	if (store->domain != NULL &&
-+	    strcmp(store->domain, "localhost") == 0) {
-+		ctx->domain_is_localhost = true;
-+	}
-+
-+	return 1; /* accept */
-+}
-+
-+ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_accept)
-+{
-+	int server_fd, client_fd, ret;
-+	k_tid_t server_thread_id;
-+	struct sockaddr_in sa;
-+
-+	struct wolfssl_verify_ctx ctx = {
-+		.cb_called = false,
-+		.decision = 1, /* accept */
-+	};
-+	struct tls_cert_verify_cb_wolfssl cb = {
-+		.cb = wolfssl_verify_cb,
-+		.ctx = &ctx,
-+	};
-+
-+	server_fd = test_configure_server(&server_thread_id,
-+					  TLS_PEER_VERIFY_NONE, false, false);
-+	client_fd = test_configure_client(&sa, false, "localhost");
-+
-+	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
-+			       &cb, sizeof(cb));
-+	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
-+
-+	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
-+	zassert_equal(ret, 0, "failed to connect (%d)", errno);
-+	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
-+
-+	test_shutdown(client_fd, server_fd, server_thread_id);
-+}
-+
-+ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_reject)
-+{
-+	int server_fd, client_fd, ret;
-+	k_tid_t server_thread_id;
-+	struct sockaddr_in sa;
-+
-+	struct wolfssl_verify_ctx ctx = {
-+		.cb_called = false,
-+		.decision = 0, /* reject */
-+	};
-+	struct tls_cert_verify_cb_wolfssl cb = {
-+		.cb = wolfssl_verify_cb,
-+		.ctx = &ctx,
-+	};
-+
-+	server_fd = test_configure_server(&server_thread_id,
-+					  TLS_PEER_VERIFY_NONE, false, true);
-+	client_fd = test_configure_client(&sa, false, "localhost");
-+
-+	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
-+			       &cb, sizeof(cb));
-+	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
-+
-+	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
-+	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
-+	zassert_equal(ret, -1, "connect() should fail");
-+	zassert_equal(errno, ECONNABORTED, "invalid errno");
-+
-+	test_shutdown(client_fd, server_fd, server_thread_id);
-+}
-+
-+ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_inspect_fields)
-+{
-+	int server_fd, client_fd, ret;
-+	k_tid_t server_thread_id;
-+	struct sockaddr_in sa;
-+
-+	struct wolfssl_verify_inspect_ctx ctx = {0};
-+	struct tls_cert_verify_cb_wolfssl cb = {
-+		.cb = wolfssl_verify_inspect_cb,
-+		.ctx = &ctx,
-+	};
-+
-+	server_fd = test_configure_server(&server_thread_id,
-+					  TLS_PEER_VERIFY_NONE, false, false);
-+	client_fd = test_configure_client(&sa, false, "localhost");
-+
-+	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
-+			       &cb, sizeof(cb));
-+	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
-+
-+	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
-+	zassert_equal(ret, 0, "failed to connect (%d)", errno);
-+
-+	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
-+	zassert_true(ctx.total_certs > 0, "totalCerts should be > 0");
-+	zassert_true(ctx.has_certs_buffer,
-+		     "certs buffer should contain DER data");
-+	zassert_true(ctx.domain_is_localhost,
-+		     "domain should be 'localhost'");
-+
-+	test_shutdown(client_fd, server_fd, server_thread_id);
-+}
-+
-+static int wolfssl_verify_null_ctx_cb(int preverify_ok, void *store_ctx)
-+{
-+	WOLFSSL_X509_STORE_CTX *store = store_ctx;
-+
-+	/* When ctx is NULL, wolfSSL's default userCtx resolution applies.
-+	 * store->userCtx should be NULL (ssl->verifyCbCtx is NULL by default).
-+	 */
-+	if (store != NULL && store->userCtx == NULL) {
-+		/* This is the expected path -- userCtx is NULL because we
-+		 * did not call wolfSSL_SetCertCbCtx. Accept the cert.
-+		 */
-+		return 1;
-+	}
-+
-+	/* Unexpected: userCtx is non-NULL. Reject to signal test failure. */
-+	return 0;
-+}
-+
-+ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_null_ctx)
-+{
-+	int server_fd, client_fd, ret;
-+	k_tid_t server_thread_id;
-+	struct sockaddr_in sa;
-+
-+	/* Register wolfSSL-style callback with ctx set to NULL.
-+	 * wolfSSL should NOT call wolfSSL_SetCertCbCtx, so
-+	 * store->userCtx in the callback should be NULL.
-+	 */
-+	struct tls_cert_verify_cb_wolfssl cb = {
-+		.cb = wolfssl_verify_null_ctx_cb,
-+		.ctx = NULL,
-+	};
-+
-+	server_fd = test_configure_server(&server_thread_id,
-+					  TLS_PEER_VERIFY_NONE, false, false);
-+	client_fd = test_configure_client(&sa, false, "localhost");
-+
-+	ret = zsock_setsockopt(client_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
-+			       &cb, sizeof(cb));
-+	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
-+
-+	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
-+	zassert_equal(ret, 0,
-+		      "connect failed -- userCtx may not be NULL (%d)", errno);
-+
-+	test_shutdown(client_fd, server_fd, server_thread_id);
-+}
-+
-+/* --- Server-side wolfSSL-style verify callback test --- */
-+
-+static struct wolfssl_verify_ctx server_wolfssl_verify_ctx;
-+
-+static void server_thread_wolfssl_verify_fn(void *arg0, void *arg1, void *arg2)
-+{
-+	const int server_fd = POINTER_TO_INT(arg0);
-+	int r;
-+	int client_fd;
-+	socklen_t addrlen;
-+	struct sockaddr_in sa;
-+
-+	k_thread_name_set(k_current_get(), "server");
-+
-+	memset(&sa, 0, sizeof(sa));
-+	addrlen = sizeof(sa);
-+
-+	k_sem_give(&server_sem);
-+	r = accept(server_fd, (struct sockaddr *)&sa, &addrlen);
-+	zassert_not_equal(r, -1, "accept() failed (%d)", errno);
-+	client_fd = r;
-+
-+	r = close(client_fd);
-+	zassert_not_equal(r, -1, "close() failed on the server fd (%d)", errno);
-+}
-+
-+ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_server_accept)
-+{
-+	static const sec_tag_t server_tag_list[] = {
-+		CA_CERTIFICATE_TAG,
-+		SERVER_CERTIFICATE_TAG,
-+	};
-+	int server_fd, client_fd, ret;
-+	k_tid_t tid;
-+	struct sockaddr_in sa;
-+	/* Use REQUIRED, not OPTIONAL. On the server side OPTIONAL maps to
-+	 * plain WOLFSSL_VERIFY_PEER (request a cert, but accept the handshake
-+	 * if the client doesn't present one), so a misbehaving client that
-+	 * skips its certificate never triggers the verify callback. REQUIRED
-+	 * adds WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, forcing the server to
-+	 * actually demand a client certificate and exercise the callback.
-+	 */
-+	int peer_verify = TLS_PEER_VERIFY_REQUIRED;
-+
-+	memset(&server_wolfssl_verify_ctx, 0, sizeof(server_wolfssl_verify_ctx));
-+	server_wolfssl_verify_ctx.decision = 1; /* accept */
-+
-+	struct tls_cert_verify_cb_wolfssl cb = {
-+		.cb = wolfssl_verify_cb,
-+		.ctx = &server_wolfssl_verify_ctx,
-+	};
-+
-+	k_sem_init(&server_sem, 0, 1);
-+
-+	/* Create server socket */
-+	ret = socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
-+	zassert_not_equal(ret, -1, "failed to create server socket (%d)", errno);
-+	server_fd = ret;
-+
-+	int yes = true;
-+
-+	ret = setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
-+	zassert_not_equal(ret, -1, "failed to set SO_REUSEADDR (%d)", errno);
-+
-+	ret = setsockopt(server_fd, SOL_TLS, TLS_SEC_TAG_LIST,
-+			 server_tag_list, sizeof(server_tag_list));
-+	zassert_not_equal(ret, -1, "failed to set TLS_SEC_TAG_LIST (%d)", errno);
-+
-+	ret = setsockopt(server_fd, SOL_TLS, TLS_HOSTNAME, "localhost",
-+			 sizeof("localhost"));
-+	zassert_not_equal(ret, -1, "failed to set TLS_HOSTNAME (%d)", errno);
-+
-+	ret = setsockopt(server_fd, SOL_TLS, TLS_PEER_VERIFY,
-+			 &peer_verify, sizeof(peer_verify));
-+	zassert_not_equal(ret, -1, "failed to set TLS_PEER_VERIFY (%d)", errno);
-+
-+	ret = setsockopt(server_fd, SOL_TLS, TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
-+			 &cb, sizeof(cb));
-+	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
-+
-+	memset(&sa, 0, sizeof(sa));
-+	sa.sin_addr.s_addr = INADDR_ANY;
-+	sa.sin_family = AF_INET;
-+	sa.sin_port = htons(PORT);
-+
-+	ret = bind(server_fd, (struct sockaddr *)&sa, sizeof(sa));
-+	zassert_not_equal(ret, -1, "failed to bind (%d)", errno);
-+
-+	ret = listen(server_fd, 1);
-+	zassert_not_equal(ret, -1, "failed to listen (%d)", errno);
-+
-+	tid = k_thread_create(&server_thread, server_stack, STACK_SIZE,
-+			      server_thread_wolfssl_verify_fn,
-+			      INT_TO_POINTER(server_fd), NULL, NULL,
-+			      K_PRIO_PREEMPT(8), 0, K_NO_WAIT);
-+
-+	ret = k_sem_take(&server_sem, K_MSEC(TIMEOUT));
-+	zassert_equal(0, ret, "failed to synchronize with server thread (%d)", ret);
-+
-+	/* Client presents its cert */
-+	client_fd = test_configure_client(&sa, true, "localhost");
-+
-+	ret = zsock_connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
-+	zassert_equal(ret, 0, "failed to connect (%d)", errno);
-+
-+	/* The server's wolfSSL-style verify callback should have been invoked
-+	 * during accept() on the cloned child context.
-+	 */
-+	zassert_true(server_wolfssl_verify_ctx.cb_called,
-+		     "server wolfSSL-style verify callback was not called");
-+
-+	ret = close(client_fd);
-+	zassert_not_equal(-1, ret, "close() failed on client fd (%d)", errno);
-+	ret = close(server_fd);
-+	zassert_not_equal(-1, ret, "close() failed on server fd (%d)", errno);
-+	ret = k_thread_join(&server_thread, K_FOREVER);
-+	zassert_equal(0, ret, "k_thread_join() failed (%d)", ret);
-+	k_yield();
-+}
-+
-+#endif /* CONFIG_WOLFSSL_VERIFY_CALLBACK */
-+
- ZTEST_SUITE(net_socket_tls_api_extension, NULL, setup, NULL, NULL, NULL);
-diff --git a/tests/net/socket/tls_ext/testcase.yaml b/tests/net/socket/tls_ext/testcase.yaml
-index 497e5f8c65e..2da1d40d794 100644
---- a/tests/net/socket/tls_ext/testcase.yaml
-+++ b/tests/net/socket/tls_ext/testcase.yaml
-@@ -8,3 +8,19 @@ tests:
-     platform_allow: qemu_x86
-     integration_platforms:
-       - qemu_x86
-+
-+  net.socket.tls.ext.wolfssl:
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    tags: net socket tls wolfssl
-+    extra_args:
-+      - OVERLAY_CONFIG=overlay-wolfssl.conf
-+
-+  net.socket.tls.ext.wolfssl.verify_cb:
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    tags: net socket tls wolfssl
-+    extra_args:
-+      - OVERLAY_CONFIG=overlay-wolfssl-verify-cb.conf
-diff --git a/tests/subsys/random/rng/overlay-wolfssl.conf b/tests/subsys/random/rng/overlay-wolfssl.conf
-new file mode 100644
-index 00000000000..dd5f99c20d1
---- /dev/null
-+++ b/tests/subsys/random/rng/overlay-wolfssl.conf
-@@ -0,0 +1,8 @@
-+# Copyright (c) 2026 wolfSSL Inc.
-+# SPDX-License-Identifier: Apache-2.0
-+
-+CONFIG_POSIX_API=y
-+CONFIG_POSIX_TIMERS=y
-+CONFIG_POSIX_THREADS=y
-+CONFIG_WOLFSSL=y
-+CONFIG_CTR_DRBG_CSPRNG_GENERATOR=y
-diff --git a/tests/subsys/random/rng/testcase.yaml b/tests/subsys/random/rng/testcase.yaml
-index 7534548a3dc..1b7f3339618 100644
---- a/tests/subsys/random/rng/testcase.yaml
-+++ b/tests/subsys/random/rng/testcase.yaml
-@@ -24,6 +24,18 @@ tests:
-     min_ram: 16
-     integration_platforms:
-       - native_sim
-+  crypto.rng.random_ctr_drbg.wolfssl:
-+    extra_args:
-+      - CONF_FILE=prj_ctr_drbg.conf
-+      - OVERLAY_CONFIG=overlay-wolfssl.conf
-+    filter: CONFIG_ENTROPY_HAS_DRIVER
-+    min_ram: 16
-+    platform_allow:
-+      - native_sim
-+      - native_sim/native/64
-+    integration_platforms:
-+      - native_sim
-+    tags: crypto random security wolfssl
-   drivers.rng.random_psa_crypto:
-     filter: CONFIG_BUILD_WITH_TFM
-     arch_exclude: posix

--- a/zephyr/4.4/README.md
+++ b/zephyr/4.4/README.md
@@ -1,0 +1,140 @@
+## How to setup wolfSSL support for standard Zephyr TLS Sockets and RNG (Zephyr 4.4)
+
+wolfSSL can also be used as the underlying implementation for the default Zephyr TLS socket interface.
+With this enabled, all existing applications using the Zephyr TLS sockets will now use wolfSSL inside
+for all TLS operations. This will also enable wolfSSL as an alternative RNG implementation. To enable
+this feature, first ensure wolfSSL has been added to the west manifest using the instructions from the
+README.md here: https://github.com/wolfSSL/wolfssl/tree/master/zephyr
+
+This integration depends on Kconfig options and a few small fixes in the wolfSSL Zephyr module:
+Zephyr default TLS support (`WOLFSSL_SESSION_EXPORT`, `WOLFSSL_KEEP_PEER_CERT`,
+`WOLFSSL_ALWAYS_VERIFY_CB`, and the `native_sim` timer gate extension) plus three Zephyr 4.4 fixes
+(a `wolfio.h` include guard for the retyped 4.4 zsock prototypes, an `arpa/inet.h` include in
+`test.h`, and a malloc-arena bump in the `wolfssl_tls_sock` sample). These are all in wolfSSL
+upstream (master), so a recent wolfSSL revision needs no extra module patching.
+
+Then patch the Zephyr tree (run inside the `zephyr` directory). The integration ships as two
+patches, both generated against the Zephyr **4.4.1** release:
+
+- **`zephyr-tls-4.4.1.patch`** — the core wolfSSL backend (the BSD-sockets TLS layer and the
+  RNG/CSPRNG). This is all that is required to use wolfSSL for TLS sockets.
+- **`zephyr-tls-4.4.1-tests.patch`** — the wolfSSL twister test scenarios and the echo_server
+  sample overlay. Apply it only if you want to run the test suite yourself; it is not needed to
+  use the integration. It depends on the core patch, so apply the core patch first.
+
+```
+# required:
+patch -p1 < /path/to/your/osp/zephyr/4.4/zephyr-tls-4.4.1.patch
+# optional, only to run the tests:
+patch -p1 < /path/to/your/osp/zephyr/4.4/zephyr-tls-4.4.1-tests.patch
+```
+
+The tests patch also includes one small, wolfSSL-independent test fix —
+`sizeof(sec_tag_list_verify_none)` in `tests/net/lib/http_server/tls/src/main.c`, which the
+`net.http.server.tls` scenario needs on 64-bit builds. That fix is being submitted upstream
+separately and is expected to land in Zephyr 4.4.2; if you apply the tests patch to a tree that
+already contains it, drop the corresponding one-line hunk.
+
+The 4.4 mbedTLS module also requires the `tf-psa-crypto` west project — make sure it is in
+your manifest's allowlist before `west update`.
+
+### Minimum prj.conf
+
+Use `tests/net/socket/tls/prj_wolfssl.conf` as a template. At minimum the application needs
+`CONFIG_MBEDTLS=n`, `CONFIG_WOLFSSL=y`, and Zephyr POSIX support (`CONFIG_POSIX_API=y`,
+`CONFIG_POSIX_TIMERS=y`, `CONFIG_POSIX_THREADS=y`; without `CONFIG_POSIX_API` also set
+`CONFIG_POSIX_SYSTEM_INTERFACES=y` — Zephyr 4.4 gates the POSIX option groups on it).
+Size `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` to the application footprint.
+
+### What changed compared to the Zephyr 4.3 integration
+
+Zephyr 4.4 restructured the TLS socket layer and the random subsystem; the integration follows:
+
+- **Per-session TLS contexts / DTLS multi-client servers.** Upstream 4.4 moved the TLS session
+  state into per-session contexts (`struct tls_session_context`), allowing a DTLS server socket
+  to serve multiple clients concurrently (bounded by
+  `CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS`). The wolfSSL backend implements full parity:
+  one `WOLFSSL` object per session sharing the per-socket `WOLFSSL_CTX`, with incoming datagrams
+  matched to sessions by peer address. Session matching by DTLS Connection ID is **not**
+  supported on the wolfSSL backend (the `TLS_DTLS_CID*` socket options return `-ENOPROTOOPT`,
+  as in 4.3); the upstream CID-based address-migration test reports as skipped under the
+  wolfssl scenarios.
+- **Socket option naming.** Upstream renamed the TLS socket options to `ZSOCK_TLS_*` (with
+  legacy `TLS_*` aliases in `<zephyr/net/net_compat.h>`). The integration adds
+  `ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL` (21) plus a `TLS_CERT_VERIFY_CALLBACK_WOLFSSL`
+  compat alias, and the option struct is `struct zsock_tls_cert_verify_cb_wolfssl`
+  (compat alias `tls_cert_verify_cb_wolfssl`).
+- **TLS handshake timeout.** Handshakes during `connect()`/`accept()` are now bounded by the
+  upstream `CONFIG_NET_SOCKETS_TLS_CONNECT_TIMEOUT` (default 10 s) on both backends.
+- **RNG.** Zephyr 4.4 removed `random_ctr_drbg.c` (the CSPRNG is PSA-based now). The wolfSSL
+  RNG integration is therefore a new CSPRNG choice option `CONFIG_WOLFSSL_CSPRNG_GENERATOR`
+  (file `subsys/random/random_wolfssl.c`, wolfSSL Hash-DRBG seeded from the entropy driver,
+  personalization string via `CONFIG_WOLFSSL_CSPRNG_PERSONALIZATION`). Select it inside
+  `choice CSPRNG_GENERATOR_CHOICE` instead of the deprecated `CTR_DRBG_CSPRNG_GENERATOR`.
+- **Minimum TLS version.** Upstream 4.4 enforces a minimum TLS version derived from the socket
+  protocol. The wolfSSL backend keeps the 4.3 exact-version method selection
+  (`wolfTLSv1_2/1_3_*_method`), which is stricter: an `IPPROTO_TLS_1_2` socket negotiates
+  exactly TLS 1.2 and will not upgrade to 1.3.
+- **Kconfig rename (action required when migrating from 4.3).** The option gating the
+  wolfSSL-style verify callback was renamed from `CONFIG_WOLFSSL_VERIFY_CALLBACK` to
+  `CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK` (the old name risked colliding with the
+  wolfSSL module's own Kconfig namespace). A 4.3-era `prj.conf` still setting the old name
+  fails the build with `error: Aborting due to Kconfig warnings` /
+  `attempt to assign the value 'y' to the undefined symbol WOLFSSL_VERIFY_CALLBACK` —
+  rename the option in your application config.
+
+### Configuration options
+
+Kconfig help text is authoritative:
+- wolfSSL module: https://github.com/wolfSSL/wolfssl/blob/master/zephyr/Kconfig
+- Zephyr TLS socket layer: `subsys/net/lib/sockets/Kconfig` (after applying the patch)
+
+Options added by this integration:
+
+| Kconfig | Purpose |
+|---|---|
+| `WOLFSSL_SESSION_EXPORT` | External session cache (serialize sessions across connections) |
+| `WOLFSSL_KEEP_PEER_CERT` | Retain peer certificate after handshake |
+| `WOLFSSL_ALWAYS_VERIFY_CB` | Invoke verify callback on success in addition to failure |
+| `NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK` | Enable wolfSSL-native per-cert verify callback via the `TLS_CERT_VERIFY_CALLBACK_WOLFSSL` socket option (named `WOLFSSL_VERIFY_CALLBACK` in the 4.3 integration) |
+| `WOLFSSL_CSPRNG_GENERATOR` | Use the wolfSSL DRBG as the system CSPRNG (`sys_csrand_get`) |
+| `WOLFSSL_CSPRNG_PERSONALIZATION` | Personalization string for the wolfSSL DRBG |
+
+Existing wolfSSL module options (`WOLFSSL_DTLS`, `WOLFSSL_ALPN`, `WOLFSSL_PSK`,
+`WOLFSSL_TLS_VERSION_1_3`, `WOLFSSL_MAX_FRAGMENT_LEN`) are opt-in as usual.
+
+### Limitations
+
+- TLS 1.0 and 1.1 disabled (`NO_OLD_TLS`).
+- The mbedTLS-style `TLS_CERT_VERIFY_CALLBACK` socket option is not supported on the wolfSSL backend.
+- `TLS_CERT_NOCOPY` has no effect — certificates are always copied.
+- TLS 1.3 0-RTT not wired on the wolfSSL path.
+- DTLS Connection ID (`TLS_DTLS_CID*`) is not supported; DTLS server sessions are matched by
+  peer address only.
+- OCSP and CRL handling is library-internal on both backends; there is no Zephyr socket-option API for it.
+- The test suites use the wolfSSL-internal `SendAlert()` API (via `<wolfssl/internal.h>`) to
+  inject fatal alerts; that is a test-only dependency that may need attention on wolfSSL uprevs.
+
+### Run Zephyr TLS samples
+
+```
+west build -b <your_board> samples/net/sockets/echo_server -DEXTRA_CONF_FILE=overlay-wolfssl.conf
+```
+
+### Run Zephyr TLS tests
+
+```
+west twister -p native_sim -s tests/net/socket/tls/net.socket.tls.wolfssl
+west twister -p native_sim -s tests/net/socket/tls_ext/net.socket.tls.ext.wolfssl
+west twister -p native_sim -s tests/net/socket/tls_ext/net.socket.tls.ext.wolfssl.verify_cb
+west twister -p native_sim -s tests/subsys/random/rng/crypto.rng.random_wolfssl
+```
+
+(Additional wolfssl-tagged scenarios exist for `tests/net/socket/register`,
+`tests/net/lib/tls_credentials`, `tests/net/lib/http_server/tls` and
+`tests/net/lib/coap_server`: `west twister -p native_sim --tag wolfssl`.)
+
+### References
+
+- Zephyr TLS sockets: https://docs.zephyrproject.org/latest/connectivity/networking/api/sockets.html
+- wolfSSL Zephyr module: https://github.com/wolfSSL/wolfssl/tree/master/zephyr

--- a/zephyr/4.4/zephyr-tls-4.4.1-tests.patch
+++ b/zephyr/4.4/zephyr-tls-4.4.1-tests.patch
@@ -1,0 +1,2499 @@
+diff --git a/samples/net/sockets/echo_server/overlay-wolfssl.conf b/samples/net/sockets/echo_server/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..b3a539a5e0a
+--- /dev/null
++++ b/samples/net/sockets/echo_server/overlay-wolfssl.conf
+@@ -0,0 +1,26 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MAIN_STACK_SIZE=3072
++CONFIG_NET_BUF_RX_COUNT=80
++CONFIG_NET_BUF_TX_COUNT=80
++
++# TLS configuration
++CONFIG_MBEDTLS=n
++CONFIG_NET_SAMPLE_CERTS_WITH_SC=y
++
++CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
++CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=6
++CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
++CONFIG_NET_SOCKETS_DTLS_MAX_FRAGMENT_LENGTH=2048
++CONFIG_ZVFS_OPEN_MAX=20
++
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++
++
+diff --git a/samples/net/sockets/echo_server/sample.yaml b/samples/net/sockets/echo_server/sample.yaml
+index c67d92b6334..5f7ce98b3e3 100644
+--- a/samples/net/sockets/echo_server/sample.yaml
++++ b/samples/net/sockets/echo_server/sample.yaml
+@@ -134,6 +134,22 @@ tests:
+       - qemu_x86_64
+     integration_platforms:
+       - qemu_x86
++  sample.net.sockets.echo_server.wolfssl:
++    tags: net socket tls wolfssl
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_args:
++      - EXTRA_CONF_FILE="overlay-wolfssl.conf"
++    harness: console
++    harness_config:
++      type: multi_line
++      ordered: false
++      regex:
++        - "Waiting for TCP.*IPv4"
++        - "Waiting for UDP.*IPv4"
+   sample.net.sockets.echo_server.nsos:
+     harness: console
+     platform_allow:
+diff --git a/tests/net/lib/coap_server/common/overlay-wolfssl.conf b/tests/net/lib/coap_server/common/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..ef9ade38ce3
+--- /dev/null
++++ b/tests/net/lib/coap_server/common/overlay-wolfssl.conf
+@@ -0,0 +1,14 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++#
++# Switch the secure CoAP server test from the mbedTLS backend to wolfSSL,
++# exercising DTLS server-side under the wolfSSL TLS sockets integration.
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+diff --git a/tests/net/lib/coap_server/common/testcase.yaml b/tests/net/lib/coap_server/common/testcase.yaml
+index 514e17d4264..b8963c8da82 100644
+--- a/tests/net/lib/coap_server/common/testcase.yaml
++++ b/tests/net/lib/coap_server/common/testcase.yaml
+@@ -12,3 +12,13 @@ common:
+ 
+ tests:
+   net.coap.server.secure: {}
++  net.coap.server.secure.wolfssl:
++    tags:
++      - wolfssl
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
+diff --git a/tests/net/lib/http_server/tls/overlay-wolfssl.conf b/tests/net/lib/http_server/tls/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..73f459c0974
+--- /dev/null
++++ b/tests/net/lib/http_server/tls/overlay-wolfssl.conf
+@@ -0,0 +1,15 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++#
++# Switch the http_server TLS test from the mbedTLS backend to wolfSSL.
++
++CONFIG_MBEDTLS=n
++CONFIG_MBEDTLS_BUILTIN=n
++CONFIG_MBEDTLS_ENABLE_HEAP=n
++
++CONFIG_POSIX_SYSTEM_INTERFACES=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++
++CONFIG_WOLFSSL=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+diff --git a/tests/net/lib/http_server/tls/src/main.c b/tests/net/lib/http_server/tls/src/main.c
+index 2a26ff77377..35e2f61d22a 100644
+--- a/tests/net/lib/http_server/tls/src/main.c
++++ b/tests/net/lib/http_server/tls/src/main.c
+@@ -14,6 +14,9 @@
+ #include <zephyr/net/tls_credentials.h>
+ #include <zephyr/sys/util.h>
+ #include <zephyr/ztest.h>
++#if defined(CONFIG_WOLFSSL)
++#include <time.h>
++#endif
+ 
+ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ 
+@@ -161,7 +164,12 @@ static void test_tls(void)
+ 		const sec_tag_t *sec_tag_list;
+ 		size_t sec_tag_list_size;
+ 
+-		sec_tag_list_size = sizeof(sec_tag_list);
++		/* sizeof(sec_tag_list_verify_none), not sizeof(sec_tag_list)
++		 * — the latter is sizeof(pointer), which on 64-bit hosts
++		 * (e.g. native_sim/native/64) feeds an extra garbage sec_tag
++		 * into setsockopt and breaks credential lookup.
++		 */
++		sec_tag_list_size = sizeof(sec_tag_list_verify_none);
+ 		sec_tag_list = sec_tag_list_verify_none;
+ 
+ 		ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
+@@ -263,4 +271,37 @@ static void *setup(void)
+ 	return NULL;
+ }
+ 
+-ZTEST_SUITE(framework_tests_tls, NULL, setup, NULL, NULL, NULL);
++#if defined(CONFIG_WOLFSSL)
++/* Realtime clock (seconds since the Unix epoch) used to satisfy wolfSSL's
++ * X.509 date validation. It MUST lie within every test certificate's validity
++ * window: the http_server certs used here are valid Nov-2024..2124, so this is
++ * 2025-06-01T00:00:00Z. Update it if the test certificates are regenerated
++ * with a later notBefore.
++ */
++#define WOLFSSL_CERT_VALID_TIME 1748736000
++
++static void set_cert_validity_clock(void *fixture)
++{
++	const struct timespec ts = {
++		.tv_sec = WOLFSSL_CERT_VALID_TIME,
++		.tv_nsec = 0,
++	};
++	int ret;
++
++	ARG_UNUSED(fixture);
++
++	/* wolfSSL validates X.509 certificate dates. On native_sim z_time()
++	 * reads the host clock, but on real targets it reads the Zephyr realtime
++	 * clock, whose offset ztest's clock_offset_reset_rule resets to epoch 0
++	 * (1970) after every test -- so this must run before each test, not once
++	 * in suite setup, or the CA certificate is rejected as "not yet valid".
++	 */
++	ret = clock_settime(CLOCK_REALTIME, &ts);
++	zassert_ok(ret, "failed to set CLOCK_REALTIME (%d)", ret);
++}
++#define HTTP_TLS_BEFORE set_cert_validity_clock
++#else
++#define HTTP_TLS_BEFORE NULL
++#endif /* CONFIG_WOLFSSL */
++
++ZTEST_SUITE(framework_tests_tls, NULL, setup, HTTP_TLS_BEFORE, NULL, NULL);
+diff --git a/tests/net/lib/http_server/tls/testcase.yaml b/tests/net/lib/http_server/tls/testcase.yaml
+index ef398a2f09d..09b50bf1602 100644
+--- a/tests/net/lib/http_server/tls/testcase.yaml
++++ b/tests/net/lib/http_server/tls/testcase.yaml
+@@ -20,3 +20,12 @@ tests:
+     integration_toolchains:
+       - host
+       - llvm
++  net.http.server.tls.wolfssl:
++    tags: wolfssl
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
+diff --git a/tests/net/lib/tls_credentials/testcase.yaml b/tests/net/lib/tls_credentials/testcase.yaml
+index 1e812e2164b..2b1440179f7 100644
+--- a/tests/net/lib/tls_credentials/testcase.yaml
++++ b/tests/net/lib/tls_credentials/testcase.yaml
+@@ -11,3 +11,24 @@ tests:
+       - net
+       - tls
+       - trusted-firmware-m
++  net.tls_credentials.wolfssl:
++    # Exercises the credentials API alongside a WOLFSSL=y build to catch
++    # symbol/include collisions in a TLS-credentials-only configuration
++    # (no NET_SOCKETS_SOCKOPT_TLS). The API itself is backend-agnostic.
++    tags:
++      - net
++      - tls
++      - wolfssl
++    depends_on: netif
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim/native/64
++    extra_configs:
++      - CONFIG_MBEDTLS=n
++      - CONFIG_POSIX_API=y
++      - CONFIG_POSIX_TIMERS=y
++      - CONFIG_POSIX_THREADS=y
++      - CONFIG_WOLFSSL=y
++      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+diff --git a/tests/net/socket/register/overlay-wolfssl.conf b/tests/net/socket/register/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..0ded287a070
+--- /dev/null
++++ b/tests/net/socket/register/overlay-wolfssl.conf
+@@ -0,0 +1,15 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
++CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=6
++CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++CONFIG_NET_SOCKETS_DTLS_TIMEOUT=30000
++CONFIG_MAIN_STACK_SIZE=2048
+diff --git a/tests/net/socket/register/testcase.yaml b/tests/net/socket/register/testcase.yaml
+index e6c22b7886d..bcdae95cf25 100644
+--- a/tests/net/socket/register/testcase.yaml
++++ b/tests/net/socket/register/testcase.yaml
+@@ -11,3 +11,10 @@ tests:
+   net.socket.register.tls:
+     extra_args:
+       - EXTRA_CONF_FILE=overlay-tls.conf
++  net.socket.register.tls.wolfssl:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    tags: wolfssl
++    extra_args:
++      - EXTRA_CONF_FILE=overlay-wolfssl.conf
+diff --git a/tests/net/socket/tls/check_conf_sync.py b/tests/net/socket/tls/check_conf_sync.py
+new file mode 100644
+index 00000000000..d30cd1b3768
+--- /dev/null
++++ b/tests/net/socket/tls/check_conf_sync.py
+@@ -0,0 +1,81 @@
++#!/usr/bin/env python3
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++"""Check that prj_wolfssl.conf stays in sync with prj.conf.
++
++prj_wolfssl.conf is a standalone CONF_FILE for the net.socket.tls.wolfssl
++scenario (not an overlay), so the backend-neutral options it duplicates
++from prj.conf can silently drift when prj.conf changes upstream. This
++script fails when:
++
++ - a backend-neutral option from prj.conf is missing from, or has a
++   different value in, prj_wolfssl.conf, or
++ - prj_wolfssl.conf contains an option that is neither backend-neutral
++   (matching prj.conf) nor an expected wolfSSL/POSIX addition.
++
++Run it from anywhere:  python3 tests/net/socket/tls/check_conf_sync.py
++"""
++
++import re
++import sys
++from pathlib import Path
++
++HERE = Path(__file__).parent
++
++# Options that only exist in prj.conf (mbedTLS backend specifics).
++PRJ_ONLY = re.compile(r"^CONFIG_MBEDTLS")
++
++# Options that only exist in prj_wolfssl.conf (wolfSSL backend specifics).
++WOLFSSL_ONLY = re.compile(
++    r"^CONFIG_(WOLFSSL|POSIX_)"
++    r"|^CONFIG_MBEDTLS=n$"
++    r"|^CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE="
++)
++
++
++def read_options(path):
++    opts = {}
++    for line in path.read_text().splitlines():
++        line = line.strip()
++        if not line or line.startswith("#"):
++            continue
++        key, _, value = line.partition("=")
++        opts[key] = value
++    return opts
++
++
++def main():
++    prj = read_options(HERE / "prj.conf")
++    wolf = read_options(HERE / "prj_wolfssl.conf")
++    errors = []
++
++    for key, value in prj.items():
++        if PRJ_ONLY.match(f"{key}={value}"):
++            continue
++        if key not in wolf:
++            errors.append(f"missing from prj_wolfssl.conf: {key}={value}")
++        elif wolf[key] != value and not WOLFSSL_ONLY.match(f"{key}={wolf[key]}"):
++            errors.append(
++                f"value drift for {key}: prj.conf={value} "
++                f"prj_wolfssl.conf={wolf[key]}"
++            )
++
++    for key, value in wolf.items():
++        entry = f"{key}={value}"
++        if WOLFSSL_ONLY.match(entry):
++            continue
++        if key not in prj:
++            errors.append(f"unexpected in prj_wolfssl.conf: {entry}")
++
++    if errors:
++        print("prj.conf / prj_wolfssl.conf are out of sync:")
++        for err in errors:
++            print(f"  - {err}")
++        return 1
++
++    print("prj.conf and prj_wolfssl.conf are in sync")
++    return 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+diff --git a/tests/net/socket/tls/prj.conf b/tests/net/socket/tls/prj.conf
+index 4b5a4a8d1a8..81d618309c3 100644
+--- a/tests/net/socket/tls/prj.conf
++++ b/tests/net/socket/tls/prj.conf
+@@ -53,3 +53,6 @@ CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID=y
+ CONFIG_MBEDTLS_PSA_KEY_SLOT_COUNT=32
+ CONFIG_MBEDTLS_CIPHERSUITE_TLS_PSK_WITH_AES_256_CBC_SHA384=y
+ CONFIG_MBEDTLS_CIPHERSUITE_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256=y
++CONFIG_MBEDTLS_SSL_ALPN=y
++CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS=3
++CONFIG_NET_CONTEXT_REUSEPORT=y
+diff --git a/tests/net/socket/tls/prj_wolfssl.conf b/tests/net/socket/tls/prj_wolfssl.conf
+new file mode 100644
+index 00000000000..c433e70a967
+--- /dev/null
++++ b/tests/net/socket/tls/prj_wolfssl.conf
+@@ -0,0 +1,76 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++#
++# Standalone configuration for the wolfSSL-backend scenario
++# (net.socket.tls.wolfssl). This is a full CONF_FILE rather than an
++# overlay on top of prj.conf on purpose: prj.conf carries mbedTLS
++# options that would have to be neutralized symbol-by-symbol here, and
++# every upstream addition to prj.conf would break this scenario with a
++# Kconfig warning. Keep the backend-neutral part below in sync with
++# prj.conf when it changes — check_conf_sync.py in this directory
++# verifies the two files and fails on drift.
++
++# Setup for self-contained net testing without requiring a SLIP driver
++CONFIG_SMP=n
++CONFIG_NET_TEST=y
++
++# General config
++CONFIG_REQUIRES_FULL_LIBC=y
++
++# Networking config
++CONFIG_NETWORKING=y
++CONFIG_NET_IPV4=y
++CONFIG_NET_IPV6=y
++CONFIG_NET_TCP=y
++CONFIG_NET_UDP=y
++CONFIG_NET_SOCKETS=y
++CONFIG_NET_SOCKETS_SOCKOPT_TLS=y
++CONFIG_NET_SOCKETS_ENABLE_DTLS=y
++CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE=128
++CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS=4
++CONFIG_TLS_MAX_CREDENTIALS_NUMBER=10
++CONFIG_NET_CONTEXT_RCVTIMEO=y
++CONFIG_NET_CONTEXT_SNDTIMEO=y
++CONFIG_NET_CONTEXT_RCVBUF=y
++CONFIG_ZVFS_OPEN_ADD_SIZE_NET=10
++
++# Keep timings short for the test
++CONFIG_NET_TCP_TIME_WAIT_DELAY=10
++CONFIG_NET_SOCKETS_CONNECT_TIMEOUT=200
++CONFIG_NET_SOCKETS_TLS_CONNECT_TIMEOUT=200
++CONFIG_NET_SOCKETS_DTLS_TIMEOUT=1000
++
++# Network driver config
++CONFIG_NET_DRIVERS=y
++CONFIG_NET_LOOPBACK=y
++CONFIG_NET_LOOPBACK_SIMULATE_PACKET_DROP=y
++CONFIG_TEST_RANDOM_GENERATOR=y
++
++CONFIG_MAIN_STACK_SIZE=4096
++CONFIG_TEST_USERSPACE=y
++
++# The test requires lot of bufs
++CONFIG_NET_MAX_CONTEXTS=20
++CONFIG_NET_PKT_TX_COUNT=24
++CONFIG_NET_PKT_RX_COUNT=24
++CONFIG_NET_BUF_TX_COUNT=32
++CONFIG_NET_BUF_RX_COUNT=32
++
++CONFIG_ZTEST=y
++CONFIG_ZTEST_STACK_SIZE=4096
++
++# wolfSSL backend
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_DTLS=y
++CONFIG_WOLFSSL_ALPN=y
++CONFIG_WOLFSSL_PSK=y
++CONFIG_WOLFSSL_TLS_VERSION_1_3=y
++CONFIG_WOLFSSL_SESSION_EXPORT=y
++CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=100000
++CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS=3
++CONFIG_NET_CONTEXT_REUSEPORT=y
+diff --git a/tests/net/socket/tls/src/main.c b/tests/net/socket/tls/src/main.c
+index 5db92a18ff3..c1531aa1d1a 100644
+--- a/tests/net/socket/tls/src/main.c
++++ b/tests/net/socket/tls/src/main.c
+@@ -11,23 +11,80 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ #include <zephyr/net/loopback.h>
+ #include <zephyr/net/socket.h>
+ #include <zephyr/net/tls_credentials.h>
++/* IANA TLS ciphersuite IDs used by this file's set_ciphersuites tests.
++ * Names match RFC 5487. Don't introduce a public Zephyr-wide header just
++ * for these two — both backends accept IANA IDs verbatim via the byte-
++ * list cipher API. (The RFC 4279 SHA-1 CBC suites used previously are no
++ * longer selectable in the Zephyr 4.4 mbedTLS ciphersuite Kconfig.)
++ */
++#define TEST_TLS_PSK_WITH_AES_128_GCM_SHA256  0x00A8
++#define TEST_TLS_PSK_WITH_AES_256_CBC_SHA384  0x00AF
++
++#if defined(CONFIG_WOLFSSL)
++#ifndef WOLFSSL_USER_SETTINGS
++#include <user_settings.h>
++#endif
++#include <wolfssl/ssl.h>
++WOLFSSL *ztls_get_wolfssl_context(int fd);
++/* Fatal-alert injection for the pollerr tests; implemented in
++ * wolfssl_alert.c, which confines <wolfssl/internal.h> (and its huge
++ * unprefixed identifier surface) to a single translation unit.
++ */
++void test_wolfssl_send_fatal_alert(WOLFSSL *ssl);
++#endif
++
++#if defined(CONFIG_MBEDTLS)
+ #include <mbedtls/ssl.h>
++mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd);
++#endif
+ 
+ #include "../../socket_helpers.h"
+ 
+-struct mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd);
+ uint32_t ztls_get_session_count(void);
+ 
++/* Server-side allow-list. Only TLS_PSK_WITH_AES_256_CBC_SHA384 is enabled
++ * in prj.conf for the mbedTLS scenarios — the GCM suite entry is never
++ * negotiated, it only exercises list handling and the mismatch case. Keep
++ * it that way: enabling extra suites globally in prj.conf would change the
++ * default cipher negotiated by the other tests in this file, which size
++ * SO_RCVBUF based on the default suite's record overhead.
++ */
++static const int cipher_list_psk[] = {
++	TEST_TLS_PSK_WITH_AES_256_CBC_SHA384,
++	TEST_TLS_PSK_WITH_AES_128_GCM_SHA256
++};
++
++/* Test test_set_ciphersuites() assumes [0] of this list is the
++ * cipher that will be negotiated */
++static const int cipher_list_psk2[] = {
++	TEST_TLS_PSK_WITH_AES_256_CBC_SHA384,
++};
++
++static const int cipher_list_psk3[] = {
++	TEST_TLS_PSK_WITH_AES_128_GCM_SHA256,
++};
++
+ #define TEST_STR_SMALL "test"
+ 
+ #define MY_IPV4_ADDR "127.0.0.1"
+ #define MY_IPV6_ADDR "::1"
+ 
++#ifndef MY_DEFLT_HOSTNAME
++#define MY_DEFLT_HOSTNAME "localhost"
++#endif
++
+ #define ANY_PORT 0
+ #define SERVER_PORT 4242
+ #define CLIENT_1_PORT 4243
+ #define CLIENT_2_PORT 4244
+ #define CLIENT_3_PORT 4245
++/* Dedicated port for test_session_cache_client_resume: the client-side
++ * session cache is keyed by peer address, so the test needs a fixed
++ * port — but it must not collide with SERVER_PORT used by the DTLS
++ * multi-client tests, to stay independent of suite ordering and
++ * TIME_WAIT teardown.
++ */
++#define RESUME_SERVER_PORT 4246
+ 
+ #define PSK_TAG 1
+ 
+@@ -121,6 +178,20 @@ static void test_connect(int sock, struct net_sockaddr *addr, net_socklen_t addr
+ 	}
+ }
+ 
++static void test_connect_err(int sock, struct net_sockaddr *addr, net_socklen_t addrlen)
++{
++	k_yield();
++
++	zassert_equal(zsock_connect(sock, addr, addrlen),
++		      -1,
++		      "connect expected to fail but succeeded");
++
++	if (IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)) {
++		/* Let the connection proceed */
++		k_yield();
++	}
++}
++
+ static void test_send(int sock, const void *buf, size_t len, int flags)
+ {
+ 	zassert_equal(zsock_send(sock, buf, len, flags),
+@@ -158,6 +229,15 @@ static void test_accept(int sock, int *new_sock, struct net_sockaddr *addr,
+ 	zassert_true(*new_sock >= 0, "zsock_accept() failed");
+ }
+ 
++static void test_accept_err(int sock, int *new_sock, struct net_sockaddr *addr,
++			    net_socklen_t *addrlen)
++{
++	zassert_not_null(new_sock, "null newsock");
++
++	*new_sock = zsock_accept(sock, addr, addrlen);
++	zassert_true(*new_sock < 0, "accept expected to fail but succeeded");
++}
++
+ static void test_shutdown(int sock, int how)
+ {
+ 	zassert_equal(zsock_shutdown(sock, how),
+@@ -302,6 +382,16 @@ static void client_connect_work_handler(struct k_work *work)
+ 		     sizeof(struct net_sockaddr_in) : sizeof(struct net_sockaddr_in6));
+ }
+ 
++static void client_connect_work_handler_err(struct k_work *work)
++{
++	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
++	struct connect_data *data =
++		CONTAINER_OF(dwork, struct connect_data, work);
++
++	test_connect_err(data->sock, data->addr, data->addr->sa_family == NET_AF_INET ?
++			 sizeof(struct net_sockaddr_in) : sizeof(struct net_sockaddr_in6));
++}
++
+ static void dtls_client_connect_send_work_handler(struct k_work *work)
+ {
+ 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+@@ -419,6 +509,71 @@ static void test_prepare_dtls_connection(net_sa_family_t family)
+ 	test_work_wait(&test_data.work);
+ }
+ 
++/* Function pointer type for function to be called after socket creation but
++ * before any bind/listen/connect operations */
++typedef void (*tls_pre_cb)(void);
++/* Function pointer type for function to be used to perform client work
++ * instead of client_connect_work_handler() */
++typedef void (*client_work_func)(struct k_work *work);
++
++static void test_prepare_tls_connection_ex(net_sa_family_t family, bool accept_err,
++					   tls_pre_cb cb, client_work_func cw)
++{
++	struct net_sockaddr c_saddr;
++	struct net_sockaddr s_saddr;
++	net_socklen_t exp_addrlen = family == NET_AF_INET6 ?
++				sizeof(struct net_sockaddr_in6) :
++				sizeof(struct net_sockaddr_in);
++	struct net_sockaddr addr;
++	net_socklen_t addrlen = sizeof(addr);
++	struct connect_data test_data;
++
++	if (family == NET_AF_INET6) {
++		prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock,
++				    (struct net_sockaddr_in6 *)&c_saddr,
++				    NET_IPPROTO_TLS_1_2);
++		prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock,
++				    (struct net_sockaddr_in6 *)&s_saddr,
++				    NET_IPPROTO_TLS_1_2);
++	} else {
++		prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock,
++				    (struct net_sockaddr_in *)&c_saddr,
++				    NET_IPPROTO_TLS_1_2);
++		prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &s_sock,
++				    (struct net_sockaddr_in *)&s_saddr,
++				    NET_IPPROTO_TLS_1_2);
++	}
++
++	if (NULL != cb) {
++		cb();
++	}
++
++	test_config_psk(s_sock, c_sock);
++
++	test_bind(s_sock, &s_saddr, exp_addrlen);
++	test_listen(s_sock);
++
++	/* Helper work for the connect operation - need to handle client/server
++	 * in parallel due to handshake.
++	 */
++	test_data.sock = c_sock;
++	test_data.addr = &s_saddr;
++	if (cw != NULL) {
++		k_work_init_delayable(&test_data.work, cw);
++	} else {
++		k_work_init_delayable(&test_data.work, client_connect_work_handler);
++	}
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	if (accept_err == true) {
++		test_accept_err(s_sock, &new_sock, &addr, &addrlen);
++	} else {
++		test_accept(s_sock, &new_sock, &addr, &addrlen);
++		zassert_equal(addrlen, exp_addrlen, "Wrong addrlen");
++	}
++	test_work_wait(&test_data.work);
++}
++
+ ZTEST(net_socket_tls, test_v4_msg_waitall)
+ {
+ 	struct test_msg_waitall_data test_data = {
+@@ -549,6 +704,7 @@ static void send_work_handler(struct k_work *work)
+ 
+ void test_msg_trunc(net_sa_family_t family)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	int rv;
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+ 	struct send_data test_data = {
+@@ -583,6 +739,9 @@ void test_msg_trunc(net_sa_family_t family)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_v4_msg_trunc)
+@@ -677,18 +836,26 @@ static void test_dtls_sendmsg_no_buf(net_sa_family_t family)
+ 
+ ZTEST(net_socket_tls, test_v4_dtls_sendmsg_no_buf)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE > 0) {
+ 		ztest_test_skip();
+ 	}
++#else
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg_no_buf(NET_AF_INET);
+ }
+ 
+ ZTEST(net_socket_tls, test_v6_dtls_sendmsg_no_buf)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE > 0) {
+ 		ztest_test_skip();
+ 	}
++#else
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg_no_buf(NET_AF_INET6);
+ }
+@@ -828,18 +995,22 @@ static void test_dtls_sendmsg_overflow(net_sa_family_t family)
+ 
+ ZTEST(net_socket_tls, test_v4_dtls_sendmsg)
+ {
+-	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE == 0) {
+-		ztest_test_skip();
+-	}
++#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	ztest_test_skip();
++#elif CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE <= 0
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg(NET_AF_INET);
+ }
+ 
+ ZTEST(net_socket_tls, test_v6_dtls_sendmsg)
+ {
+-	if (CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE == 0) {
+-		ztest_test_skip();
+-	}
++#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	ztest_test_skip();
++#elif CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE <= 0
++	ztest_test_skip();
++#endif
+ 
+ 	test_dtls_sendmsg(NET_AF_INET6);
+ }
+@@ -1220,7 +1391,21 @@ ZTEST(net_socket_tls, test_recv_eof_on_close)
+ 	k_sleep(TCP_TEARDOWN_TIMEOUT);
+ }
+ 
++/* Per-record framing overhead the test uses to right-size SO_RCVBUF for
++ * exactly one TLS application record carrying TEST_STR_SMALL. Both numbers
++ * are observed values for these suites' default ciphersuite (TLS 1.2 AES
++ * GCM), measured by running the suite with an oversized buffer and printing
++ * the inbound record length. Different values per backend reflect different
++ * implementation choices for the record-layer framing (header layout, IV
++ * placement, padding) — they are not part of any wire-format ABI. If a
++ * test starts failing here after a backend or ciphersuite change, re-measure
++ * with an oversized buffer and update.
++ */
++#if defined(CONFIG_WOLFSSL)
++#define TLS_RECORD_OVERHEAD 29
++#else
+ #define TLS_RECORD_OVERHEAD 81
++#endif
+ 
+ ZTEST(net_socket_tls, test_send_non_block)
+ {
+@@ -1371,7 +1556,7 @@ ZTEST(net_socket_tls, test_send_on_close)
+ 	new_sock = -1;
+ 
+ 	/* Small delay for packets to propagate. */
+-	k_msleep(10);
++	k_msleep(20);
+ 
+ 	/* Verify send() reports an error after connection is closed. */
+ 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
+@@ -1393,7 +1578,7 @@ ZTEST(net_socket_tls, test_send_on_close)
+ 	new_sock = -1;
+ 
+ 	/* Small delay for packets to propagate. */
+-	k_msleep(10);
++	k_msleep(20);
+ 
+ 	/* Graceful connection close should be reported first. */
+ 	ret = zsock_recv(c_sock, rx_buf, sizeof(rx_buf), 0);
+@@ -1544,10 +1729,82 @@ ZTEST(net_socket_tls, test_shutdown_rd_while_recv)
+ 
+ 	test_prepare_tls_connection(NET_AF_INET6);
+ 
+-	/* Schedule reception shutdown from workqueue */
++	/* Schedule reception shutdown from workqueue. 50ms margin guards
++	 * against slow CI runners where recv() hasn't reached its blocking
++	 * point at the 10ms mark.
++	 */
+ 	k_work_init_delayable(&test_data.work, shutdown_work);
+ 	test_data.sock = c_sock;
+-	test_work_reschedule(&test_data.work, K_MSEC(10));
++	test_work_reschedule(&test_data.work, K_MSEC(50));
++
++	/* EOF should be notified by recv() */
++	test_eof(c_sock);
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++/* wolfSSL-only: exercises the recv_eof shortcut in
++ * recvfrom_dtls_common_wolfssl that turns local SHUT_RD/SHUT_RDWR into
++ * an EOF on the next recv(). The mbedTLS backend matches upstream
++ * Zephyr behavior (no local-shutdown shortcut on DTLS), so this test
++ * is gated to wolfSSL builds to preserve the upstream interface
++ * contract for mbedTLS users.
++ */
++static void test_dtls_shutdown_synchronous_body(net_sa_family_t family, int how)
++{
++	test_prepare_dtls_connection(family);
++
++	test_shutdown(c_sock, how);
++
++	/* EOF should be notified by recv() */
++	test_eof(c_sock);
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++#endif
++
++ZTEST(net_socket_tls, test_dtls_shutdown_rd_synchronous_v6)
++{
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++	test_dtls_shutdown_synchronous_body(NET_AF_INET6, ZSOCK_SHUT_RD);
++#else
++	ztest_test_skip();
++#endif
++}
++
++ZTEST(net_socket_tls, test_dtls_shutdown_rd_synchronous_v4)
++{
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++	test_dtls_shutdown_synchronous_body(NET_AF_INET, ZSOCK_SHUT_RD);
++#else
++	ztest_test_skip();
++#endif
++}
++
++ZTEST(net_socket_tls, test_dtls_shutdown_rd_while_recv)
++{
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++	struct shutdown_data test_data = {
++		.how = ZSOCK_SHUT_RD,
++	};
++
++	test_prepare_dtls_connection(NET_AF_INET6);
++
++	/* Schedule reception shutdown from workqueue while recv() is blocked
++	 * — exercises the recv_eof check inside the wolfSSL DTLS recv loop
++	 * (recvfrom_dtls_common_wolfssl). The TCP/TLS variant lives in
++	 * test_shutdown_rd_while_recv. 50ms margin guards against slow CI
++	 * runners where recv() hasn't reached its blocking point yet at the
++	 * 10ms mark — short enough to keep the test fast.
++	 */
++	k_work_init_delayable(&test_data.work, shutdown_work);
++	test_data.sock = c_sock;
++	test_work_reschedule(&test_data.work, K_MSEC(50));
+ 
+ 	/* EOF should be notified by recv() */
+ 	test_eof(c_sock);
+@@ -1555,6 +1812,9 @@ ZTEST(net_socket_tls, test_shutdown_rd_while_recv)
+ 	test_sockets_close();
+ 
+ 	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_send_while_recv)
+@@ -1597,6 +1857,591 @@ ZTEST(net_socket_tls, test_send_while_recv)
+ 	k_sleep(TCP_TEARDOWN_TIMEOUT);
+ }
+ 
++void tls_set_cs_cb(void)
++{
++	int ret = zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++				   (void *)cipher_list_psk, sizeof(cipher_list_psk));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on server");
++	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++			       (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on client");
++}
++
++void tls_set_cs_mismatch_cb(void)
++{
++	/* Set mismatched ciphersuites, should not connect */
++	int ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++				   (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on client");
++	ret = zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++			       (void *)cipher_list_psk3, sizeof(cipher_list_psk3));
++	zassert_equal(ret, 0, "Unable to set ciphersuites on server");
++}
++
++ZTEST(net_socket_tls, test_set_ciphersuites)
++{
++#define TLS_CS_TEST_MAX_CS_NUM 3
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++	int ciphersuites[TLS_CS_TEST_MAX_CS_NUM];
++	int cs_len = sizeof(ciphersuites);
++	int curr_cipher = 0;
++	int cc_len = sizeof(int);
++	int i;
++
++	for (i = 0; i < TLS_CS_TEST_MAX_CS_NUM; i++) {
++		ciphersuites[i] = 0;
++	}
++
++	test_prepare_tls_connection_ex(NET_AF_INET, false, tls_set_cs_cb, NULL);
++
++	/* Verify the ciphersuite list is what we set for server */
++	ret = zsock_getsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++			       (void *)ciphersuites, (net_socklen_t *)&cs_len);
++	zassert_equal(ret, 0, "Unable to get ciphersuites for server");
++	zassert_equal(cs_len, sizeof(cipher_list_psk), "Incorrect get ciphersuite len");
++
++	for (i = 0; i < cs_len / sizeof(int); i++) {
++		zassert_equal(ciphersuites[i], cipher_list_psk[i],
++			      "Retrieved ciphersuite list element does not match set value");
++	}
++
++	/* Same for client */
++	for (i = 0; i < TLS_CS_TEST_MAX_CS_NUM; i++) {
++		ciphersuites[i] = 0;
++	}
++
++	cs_len = sizeof(ciphersuites);
++	ret = zsock_getsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++			       (void *)ciphersuites, (net_socklen_t *)&cs_len);
++	zassert_equal(ret, 0, "Unable to get ciphersuites for client");
++	zassert_equal(cs_len, sizeof(cipher_list_psk2), "Incorrect get ciphersuite len");
++
++	for (i = 0; i < cs_len / sizeof(int); i++) {
++		zassert_equal(ciphersuites[i], cipher_list_psk2[i],
++			      "Retrieved ciphersuite list element does not match set value");
++	}
++
++	/* Check that the actual negotiated cipher is correct for server */
++	ret = zsock_getsockopt(new_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_USED,
++			       (void *)&curr_cipher, (net_socklen_t *)&cc_len);
++	zassert_equal(ret, 0, "Unable to get current ciphersuite for server");
++	zassert_equal(curr_cipher, cipher_list_psk2[0]);
++
++	/* Same for the client */
++	curr_cipher = 0;
++	ret = zsock_getsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_USED,
++			       (void *)&curr_cipher, (net_socklen_t *)&cc_len);
++	zassert_equal(ret, 0, "Unable to get current ciphersuite for client");
++	zassert_equal(curr_cipher, cipher_list_psk2[0]);
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++ZTEST(net_socket_tls, test_set_ciphersuites_err)
++{
++	/* Expect failure to connect and accept due to mismatched ciphersuites */
++	test_prepare_tls_connection_ex(NET_AF_INET, true,
++		tls_set_cs_mismatch_cb, client_connect_work_handler_err);
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++void tls_set_hostname_cb(void)
++{
++	int ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME,
++				   (void *)MY_DEFLT_HOSTNAME, strlen(MY_DEFLT_HOSTNAME));
++	zassert_equal(ret, 0, "Unable to set hostname on client");
++}
++
++ZTEST(net_socket_tls, test_set_hostname)
++{
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++
++	test_prepare_tls_connection_ex(NET_AF_INET, false, tls_set_hostname_cb, NULL);
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++/* Verify that TLS options can still be set on an already-established
++ * connection without failing the setsockopt call. On the wolfSSL backend
++ * live changes are propagated to existing sessions best-effort (and apply
++ * fully to future sessions); on mbedTLS they update the shared config.
++ * Either way the call must succeed and the connection must stay usable.
++ */
++ZTEST(net_socket_tls, test_opt_set_after_connect)
++{
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++#if defined(CONFIG_WOLFSSL)
++	static const int bad_cipher_list[] = { 0x1FFFF };
++#endif
++
++	test_prepare_tls_connection(NET_AF_INET);
++
++	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME,
++			       (void *)MY_DEFLT_HOSTNAME,
++			       strlen(MY_DEFLT_HOSTNAME));
++	zassert_equal(ret, 0, "setting hostname after connect failed (%d)",
++		      errno);
++
++	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++			       (void *)cipher_list_psk2, sizeof(cipher_list_psk2));
++	zassert_equal(ret, 0, "setting ciphersuites after connect failed (%d)",
++		      errno);
++
++#if defined(CONFIG_WOLFSSL)
++	/* Argument validation must happen before the option is stored,
++	 * independent of the (best-effort) live application.
++	 */
++	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_CIPHERSUITE_LIST,
++			       (void *)bad_cipher_list, sizeof(bad_cipher_list));
++	zassert_equal(ret, -1, "invalid ciphersuite ID not rejected");
++	zassert_equal(errno, EINVAL, "wrong errno value: %d", errno);
++#endif
++
++	/* Connection must still be usable. */
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_WOLFSSL)
++/* Defined further below with the DTLS multi-client tests. */
++static void dtls_verify_address(struct net_sockaddr *addr, net_socklen_t addrlen,
++				struct net_sockaddr *expected);
++#endif
++
++/* wolfSSL-only: an empty UDP datagram spoofed from the peer's address must
++ * not tear down an established DTLS server session (it carries no TLS
++ * record and source addresses are trivially forgeable). The mbedTLS
++ * backend inherits upstream behavior here (a 0-byte BIO read is treated
++ * as EOF), so the test is gated to the wolfSSL backend.
++ */
++ZTEST(net_socket_tls, test_dtls_server_empty_datagram)
++{
++#if !defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) || !defined(CONFIG_WOLFSSL)
++	ztest_test_skip();
++#else
++	struct net_sockaddr c_saddr;
++	struct net_sockaddr s_saddr;
++	struct net_sockaddr recv_addr;
++	net_socklen_t recv_addrlen = sizeof(recv_addr);
++	struct connect_data test_data;
++	struct timeval timeo_optval = {
++		.tv_sec = 1,
++		.tv_usec = 0,
++	};
++	int role = ZSOCK_TLS_DTLS_ROLE_SERVER;
++	int yes = 1;
++	uint8_t rx_buf;
++	uint8_t tx_buf = 0;
++	int helper_sock;
++	int ret;
++
++	prepare_sock_dtls_v4(MY_IPV4_ADDR, CLIENT_1_PORT, &c_sock,
++			     (struct net_sockaddr_in *)&c_saddr,
++			     NET_IPPROTO_DTLS_1_2);
++	prepare_sock_dtls_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock,
++			     (struct net_sockaddr_in *)&s_saddr,
++			     NET_IPPROTO_DTLS_1_2);
++
++	test_config_psk(s_sock, c_sock);
++
++	zassert_ok(zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_DTLS_ROLE,
++				    &role, sizeof(role)),
++		   "setsockopt failed (%d)", errno);
++	zassert_ok(zsock_setsockopt(s_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_RCVTIMEO,
++				    &timeo_optval, sizeof(timeo_optval)),
++		   "setsockopt failed (%d)", errno);
++	/* Allow the helper socket below to bind to the client's port. */
++	zassert_ok(zsock_setsockopt(c_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_REUSEPORT,
++				    &yes, sizeof(yes)),
++		   "setsockopt failed (%d)", errno);
++
++	test_bind(c_sock, &c_saddr, sizeof(struct net_sockaddr_in));
++	test_bind(s_sock, &s_saddr, sizeof(struct net_sockaddr_in));
++
++	/* Client handshake + initial data. */
++	test_data.sock = c_sock;
++	test_data.addr = &s_saddr;
++	k_work_init_delayable(&test_data.work, dtls_client_connect_send_work_handler);
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	ret = zsock_recvfrom(s_sock, &rx_buf, sizeof(rx_buf), 0,
++			     &recv_addr, &recv_addrlen);
++	zassert_equal(ret, sizeof(rx_buf), "recv() failed");
++	test_work_wait(&test_data.work);
++
++	/* Inject a 0-byte datagram with the client's exact source address. */
++	helper_sock = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
++	zassert_true(helper_sock >= 0, "helper socket failed (%d)", errno);
++	zassert_ok(zsock_setsockopt(helper_sock, ZSOCK_SOL_SOCKET,
++				    ZSOCK_SO_REUSEPORT, &yes, sizeof(yes)),
++		   "setsockopt failed (%d)", errno);
++	zassert_ok(zsock_bind(helper_sock, &c_saddr,
++			      sizeof(struct net_sockaddr_in)),
++		   "helper bind failed (%d)", errno);
++	ret = zsock_sendto(helper_sock, &tx_buf, 0, 0, &s_saddr,
++			   sizeof(struct net_sockaddr_in));
++	zassert_equal(ret, 0, "empty sendto() failed (%d)", errno);
++
++	k_msleep(10);
++
++	/* The empty datagram must be dropped: no EOF, no session teardown. */
++	ret = zsock_recv(s_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
++	zassert_equal(ret, -1, "recv() should not have returned data/EOF");
++	zassert_equal(errno, EAGAIN, "wrong errno value: %d", errno);
++
++	/* The established session must still carry data. */
++	test_send(c_sock, &tx_buf, sizeof(tx_buf), 0);
++
++	recv_addrlen = sizeof(recv_addr);
++	ret = zsock_recvfrom(s_sock, &rx_buf, sizeof(rx_buf), 0,
++			     &recv_addr, &recv_addrlen);
++	zassert_equal(ret, sizeof(rx_buf), "recv() after empty datagram failed");
++	dtls_verify_address(&recv_addr, recv_addrlen, &c_saddr);
++
++	(void)zsock_close(helper_sock);
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#endif
++}
++
++void tls_set_session_cache_cb(void)
++{
++	int t = ZSOCK_TLS_SESSION_CACHE_ENABLED;
++	int l = sizeof(int);
++
++	int ret = zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_SESSION_CACHE,
++				   (void *)&t, l);
++	zassert_equal(ret, 0, "Unable to set session cache on server");
++}
++
++ZTEST(net_socket_tls, test_session_cache)
++{
++	int ret;
++	int enabled = 0;
++	int len = sizeof(int);
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++
++	test_prepare_tls_connection_ex(NET_AF_INET, false, tls_set_session_cache_cb, NULL);
++
++	/* Check that the session cache is enabled */
++	ret = zsock_getsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_SESSION_CACHE,
++			       (void *)&enabled, (net_socklen_t *)&len);
++	zassert_equal(ret, 0, "Unable to get session cache enabled status");
++	zassert_equal(enabled, ZSOCK_TLS_SESSION_CACHE_ENABLED,
++		      "Session cache value does not match what was set");
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++/* Helper enabling session cache on both client and server sockets. Used by
++ * test_session_cache_client_resume to exercise the wolfSSL tls_session_store /
++ * tls_session_restore marshalling code path.
++ */
++static void tls_set_session_cache_client_cb(void)
++{
++	int t = ZSOCK_TLS_SESSION_CACHE_ENABLED;
++	int l = sizeof(int);
++	int ret;
++
++	ret = zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_SESSION_CACHE,
++			       (void *)&t, l);
++	zassert_equal(ret, 0, "Unable to set session cache on server");
++	ret = zsock_setsockopt(c_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_SESSION_CACHE,
++			       (void *)&t, l);
++	zassert_equal(ret, 0, "Unable to set session cache on client");
++}
++
++/* Sets up a TLS client/server connection on a FIXED server port so two
++ * consecutive connections present the same peer address (which is the key
++ * into client_cache). Used by test_session_cache_client_resume — the
++ * main test_prepare_* helpers use ANY_PORT, which prevents resumption
++ * lookup from matching across connections.
++ */
++static void prepare_tls_session_resume_connection(uint16_t server_port)
++{
++	struct net_sockaddr_in c_saddr;
++	struct net_sockaddr_in s_saddr;
++	struct net_sockaddr addr;
++	net_socklen_t addrlen = sizeof(addr);
++	struct connect_data test_data;
++	int reuse = 1;
++	int ret;
++
++	prepare_sock_tls_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr,
++			    NET_IPPROTO_TLS_1_2);
++	prepare_sock_tls_v4(MY_IPV4_ADDR, server_port, &s_sock, &s_saddr,
++			    NET_IPPROTO_TLS_1_2);
++
++	tls_set_session_cache_client_cb();
++
++	test_config_psk(s_sock, c_sock);
++
++	/* Fixed server port + back-to-back binds in the same suite: ask the
++	 * stack to allow rebind so the test isn't fragile if a previous
++	 * teardown's TIME_WAIT entry is still around.
++	 */
++	ret = zsock_setsockopt(s_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_REUSEADDR,
++			       &reuse, sizeof(reuse));
++	zassert_equal(ret, 0, "ZSOCK_SO_REUSEADDR on server socket failed");
++
++	test_bind(s_sock, (struct net_sockaddr *)&s_saddr, sizeof(s_saddr));
++	test_listen(s_sock);
++
++	test_data.sock = c_sock;
++	test_data.addr = (struct net_sockaddr *)&s_saddr;
++	k_work_init_delayable(&test_data.work, client_connect_work_handler);
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	test_accept(s_sock, &new_sock, &addr, &addrlen);
++	test_work_wait(&test_data.work);
++}
++
++/* Verifies that the second connect to the same peer actually resumes via the
++ * client-side session marshalling (mbedTLS: tls_session_save/get; wolfSSL:
++ * wolfSSL_i2d_SSL_SESSION / wolfSSL_d2i_SSL_SESSION in tls_session_store /
++ * tls_session_restore). Purges first so state is isolated.
++ */
++ZTEST(net_socket_tls, test_session_cache_client_resume)
++{
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1,
++	};
++	int ret;
++
++	/* Purge any sessions left by earlier tests so we can observe the
++	 * transition from "no cached session" to "cached session".
++	 */
++	{
++		int dummy = zsock_socket(NET_AF_INET, NET_SOCK_STREAM, NET_IPPROTO_TLS_1_2);
++
++		zassert_true(dummy >= 0, "purge socket open failed");
++		ret = zsock_setsockopt(dummy, ZSOCK_SOL_TLS, ZSOCK_TLS_SESSION_CACHE_PURGE,
++				       NULL, 0);
++		zassert_equal(ret, 0, "purge setsockopt failed");
++		zsock_close(dummy);
++	}
++
++	/* First connection — should perform full handshake, then store. */
++	prepare_tls_session_resume_connection(RESUME_SERVER_PORT);
++
++#if defined(CONFIG_WOLFSSL)
++	{
++		WOLFSSL *ssl = ztls_get_wolfssl_context(c_sock);
++		int reused;
++
++		zassert_not_null(ssl, "Failed to get wolfSSL context");
++		reused = wolfSSL_session_reused(ssl);
++		zassert_equal(reused, 0,
++			      "First connect should not be a resumption (got %d)",
++			      reused);
++	}
++#endif
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++
++	test_sockets_close();
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++
++	/* Second connection to the SAME server port — should restore the
++	 * stored session and resume.
++	 */
++	prepare_tls_session_resume_connection(RESUME_SERVER_PORT);
++
++#if defined(CONFIG_WOLFSSL)
++	{
++		WOLFSSL *ssl = ztls_get_wolfssl_context(c_sock);
++		int reused;
++
++		zassert_not_null(ssl, "Failed to get wolfSSL context");
++		reused = wolfSSL_session_reused(ssl);
++		zassert_not_equal(reused, 0,
++				  "Second connect did not reuse session");
++	}
++#endif
++
++	memset(rx_buf, 0, sizeof(rx_buf));
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++/* Smoke test for M01: verify that a TLS handshake completes when wolfSSL
++ * secure renegotiation is enabled. With HAVE_SECURE_RENEGOTIATION the TLS
++ * init path calls wolfSSL_UseSecureRenegotiation() on each new SSL object;
++ * a failure there fails ztls_connect_ctx/ztls_accept_ctx. A successful
++ * handshake proves the call is reachable and the API is wired up. A full
++ * renegotiation round-trip would require additional hooks into the Zephyr
++ * TLS socket API which are out of scope here.
++ */
++ZTEST(net_socket_tls, test_tls_renegotiation_smoke)
++{
++#if defined(CONFIG_WOLFSSL)
++#if !defined(HAVE_SECURE_RENEGOTIATION)
++	ztest_test_skip();
++	return;
++#endif
++#elif !defined(CONFIG_MBEDTLS_SSL_RENEGOTIATION)
++	ztest_test_skip();
++	return;
++#endif
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1,
++	};
++	int ret;
++
++	test_prepare_tls_connection(NET_AF_INET);
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++}
++
++const char *alpn_list[] = {
++	"http/1.0",
++	"http/1.1"
++};
++
++void tls_set_alpn_cb(void)
++{
++	net_socklen_t len = sizeof(alpn_list);
++	int ret = zsock_setsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_ALPN_LIST,
++				   (void *)alpn_list, len);
++	zassert_equal(ret, 0, "Unable to set alpn on server");
++}
++
++ZTEST(net_socket_tls, test_alpn)
++{
++#if CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS > 0
++	int ret;
++	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1] = { 0 };
++	struct send_data test_data = {
++		.data = TEST_STR_SMALL,
++		.datalen = sizeof(TEST_STR_SMALL) - 1
++	};
++	const char *alpn_buf[2];
++	int alpn_len = sizeof(alpn_buf);
++
++	alpn_buf[0] = NULL;
++	alpn_buf[1] = NULL;
++
++	test_prepare_tls_connection_ex(NET_AF_INET, false, tls_set_alpn_cb, NULL);
++
++	/* Check that the ALPN list is the one we set */
++	ret = zsock_getsockopt(s_sock, ZSOCK_SOL_TLS, ZSOCK_TLS_ALPN_LIST,
++			       (void *)alpn_buf, (net_socklen_t *)&alpn_len);
++	zassert_equal(ret, 0, "Unable to get alpn list");
++	zassert_equal(alpn_len, sizeof(alpn_list), "Retrieved ALPN list length incorrect");
++	zassert_equal(strlen(alpn_buf[0]), strlen(alpn_list[0]),
++		      "Retrieved ALPN list element length incorrect");
++	zassert_mem_equal(alpn_buf[0], alpn_list[0], strlen(alpn_list[0]),
++			  "Retrieved ALPN element does not match what was set");
++	zassert_equal(strlen(alpn_buf[1]), strlen(alpn_list[1]),
++		      "Retrieved ALPN list element length incorrect");
++	zassert_mem_equal(alpn_buf[1], alpn_list[1], strlen(alpn_list[1]),
++			  "Retrieved ALPN element does not match what was set");
++
++	test_data.sock = c_sock;
++	k_work_init_delayable(&test_data.tx_work, send_work_handler);
++	test_work_reschedule(&test_data.tx_work, K_MSEC(10));
++
++	/* recv() shall block until send work sends the data. */
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(TEST_STR_SMALL) - 1, "recv() failed");
++	zassert_mem_equal(rx_buf, TEST_STR_SMALL, ret, "Invalid data received");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#else
++	ztest_test_skip();
++#endif
++}
++
+ ZTEST(net_socket_tls, test_poll_tls_pollin)
+ {
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+@@ -1630,6 +2475,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollin)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollin)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+ 	struct send_data test_data = {
+ 		.data = TEST_STR_SMALL,
+@@ -1663,6 +2509,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollin)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_poll_tls_pollout)
+@@ -1715,6 +2564,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollout)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollout)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	struct zsock_pollfd fds[1];
+ 	int ret;
+ 
+@@ -1732,6 +2582,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollout)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_poll_tls_pollhup)
+@@ -1764,6 +2617,7 @@ ZTEST(net_socket_tls, test_poll_tls_pollhup)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollhup)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	struct zsock_pollfd fds[1];
+ 	uint8_t rx_buf;
+ 	int ret;
+@@ -1789,6 +2643,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollhup)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+@@ -1798,7 +2655,11 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ 	struct zsock_pollfd fds[1];
+ 	int optval;
+ 	net_socklen_t optlen = sizeof(optval);
++#if defined(CONFIG_WOLFSSL)
++	WOLFSSL *ssl_ctx;
++#else
+ 	mbedtls_ssl_context *ssl_ctx;
++#endif
+ 
+ 	test_prepare_tls_connection(NET_AF_INET6);
+ 
+@@ -1806,9 +2667,14 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ 	fds[0].events = ZSOCK_POLLIN;
+ 
+ 	/* Get access to the underlying ssl context, and send alert. */
++#if defined(CONFIG_WOLFSSL)
++	ssl_ctx = ztls_get_wolfssl_context(c_sock);
++	test_wolfssl_send_fatal_alert(ssl_ctx);
++#else
+ 	ssl_ctx = ztls_get_mbedtls_ssl_context(c_sock);
+ 	mbedtls_ssl_send_alert_message(ssl_ctx, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+ 				       MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
++#endif
+ 
+ 	ret = zsock_poll(fds, 1, 100);
+ 	zassert_equal(ret, 1, "poll() should've report event");
+@@ -1829,12 +2695,17 @@ ZTEST(net_socket_tls, test_poll_tls_pollerr)
+ 
+ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
+ {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	uint8_t rx_buf;
+ 	int ret;
+ 	struct zsock_pollfd fds[1];
+ 	int optval;
+ 	net_socklen_t optlen = sizeof(optval);
++#if defined(CONFIG_WOLFSSL)
++	WOLFSSL *ssl_ctx;
++#else
+ 	mbedtls_ssl_context *ssl_ctx;
++#endif
+ 
+ 	test_prepare_dtls_connection(NET_AF_INET6);
+ 
+@@ -1842,9 +2713,14 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
+ 	fds[0].events = ZSOCK_POLLIN;
+ 
+ 	/* Get access to the underlying ssl context, and send alert. */
++#if defined(CONFIG_WOLFSSL)
++	ssl_ctx = ztls_get_wolfssl_context(c_sock);
++	test_wolfssl_send_fatal_alert(ssl_ctx);
++#else
+ 	ssl_ctx = ztls_get_mbedtls_ssl_context(c_sock);
+ 	mbedtls_ssl_send_alert_message(ssl_ctx, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
+ 				       MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
++#endif
+ 
+ 	ret = zsock_poll(fds, 1, 100);
+ 	zassert_equal(ret, 1, "poll() should've report event");
+@@ -1863,6 +2739,9 @@ ZTEST(net_socket_tls, test_poll_dtls_pollerr)
+ 
+ 	/* Small delay for the final alert exchange */
+ 	k_msleep(10);
++#else
++	ztest_test_skip();
++#endif
+ }
+ 
+ #define BAD_CA_CERT_TAG 11
+@@ -2602,6 +3481,30 @@ ZTEST(net_socket_tls, test_v6_dtls_server_cid_matching_on_addr_change)
+ 	test_dtls_server_cid_matching_on_addr_change(NET_AF_INET6);
+ }
+ 
++/* Poll a non-blocking recv until the DTLS peer's close-notify has been
++ * processed and the socket reports ENOTCONN, or a short bound elapses. On
++ * native_sim loopback delivery is synchronous and the first recv already sees
++ * the alert; on targets with asynchronous delivery (e.g. real hardware) this
++ * waits for the in-flight alert instead of racing a fixed guess delay. A
++ * genuinely missing close-notify is NOT masked: errno stays EAGAIN, the bound
++ * expires, and the caller's ENOTCONN assertion fails.
++ */
++static int recv_await_peer_closed(int sock)
++{
++	uint8_t rx_buf;
++	int ret = -1;
++
++	for (int i = 0; i < 20; i++) {
++		ret = zsock_recv(sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
++		if (ret == -1 && errno == ENOTCONN) {
++			break;
++		}
++		k_msleep(5);
++	}
++
++	return ret;
++}
++
+ static void test_dtls_server_session_timeout_poll(net_sa_family_t family)
+ {
+ 	struct net_sockaddr c_saddr_1;
+@@ -2624,11 +3527,11 @@ static void test_dtls_server_session_timeout_poll(net_sa_family_t family)
+ 	zassert_equal(fds[0].revents, ZSOCK_POLLHUP, "expected ZSOCK_POLLHUP");
+ 	zassert_equal(ztls_get_session_count(), 3, "Expected session count mismatch");
+ 
+-	/* Small delay for the alerts exchange */
+-	k_msleep(10);
+-
+-	/* Verify client socket reports error (server closed the session) */
+-	ret = zsock_recv(c_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
++	/* Verify client socket reports error (server closed the session). The
++	 * close-notify may still be in flight on targets with asynchronous
++	 * loopback delivery, so poll for it instead of racing a fixed delay.
++	 */
++	ret = recv_await_peer_closed(c_sock);
+ 	zassert_equal(ret, -1, "recv() should've failed");
+ 	zassert_equal(errno, ENOTCONN, "Wrong errno, expected ENOTCONN");
+ 
+@@ -2646,11 +3549,8 @@ static void test_dtls_server_session_timeout_poll(net_sa_family_t family)
+ 	zassert_equal(fds[0].revents, ZSOCK_POLLHUP, "expected ZSOCK_POLLHUP");
+ 	zassert_equal(ztls_get_session_count(), 3, "Expected session count mismatch");
+ 
+-	/* Small delay for the alerts exchange */
+-	k_msleep(10);
+-
+-	/* Verify second client socket reports error (server closed the session) */
+-	ret = zsock_recv(c_sock_2, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
++	/* Verify second client socket reports error (server closed the session). */
++	ret = recv_await_peer_closed(c_sock_2);
+ 	zassert_equal(ret, -1, "recv() should've failed");
+ 	zassert_equal(errno, ENOTCONN, "Wrong errno, expected ENOTCONN");
+ }
+@@ -2694,11 +3594,11 @@ static void test_dtls_server_session_timeout_recvfrom(net_sa_family_t family)
+ 	zassert_equal(errno, EAGAIN, "Wrong errno, expected EAGAIN");
+ 	zassert_equal(ztls_get_session_count(), 3, "Expected session count mismatch");
+ 
+-	/* Small delay for the alerts exchange */
+-	k_msleep(10);
+-
+-	/* Verify client socket reports error (server closed the session) */
+-	ret = zsock_recv(c_sock, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
++	/* Verify client socket reports error (server closed the session). The
++	 * close-notify may still be in flight on targets with asynchronous
++	 * loopback delivery, so poll for it instead of racing a fixed delay.
++	 */
++	ret = recv_await_peer_closed(c_sock);
+ 	zassert_equal(ret, -1, "recv() should've failed");
+ 	zassert_equal(errno, ENOTCONN, "Wrong errno, expected ENOTCONN");
+ 
+@@ -2714,8 +3614,8 @@ static void test_dtls_server_session_timeout_recvfrom(net_sa_family_t family)
+ 	zassert_equal(errno, EAGAIN, "Wrong errno, expected EAGAIN");
+ 	zassert_equal(ztls_get_session_count(), 3, "Expected session count mismatch");
+ 
+-	/* Verify second client socket reports error (server closed the session) */
+-	ret = zsock_recv(c_sock_2, &rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
++	/* Verify second client socket reports error (server closed the session). */
++	ret = recv_await_peer_closed(c_sock_2);
+ 	zassert_equal(ret, -1, "recv() should've failed");
+ 	zassert_equal(errno, ENOTCONN, "Wrong errno, expected ENOTCONN");
+ }
+@@ -2730,6 +3630,71 @@ ZTEST(net_socket_tls, test_v6_dtls_server_session_timeout_recvfrom)
+ 	test_dtls_server_session_timeout_recvfrom(NET_AF_INET6);
+ }
+ 
++ZTEST(net_socket_tls, test_tls13_psk_handshake)
++{
++#if !defined(WOLFSSL_TLS13) || !defined(CONFIG_WOLFSSL)
++	ztest_test_skip();
++	return;
++#else
++	struct net_sockaddr_in6 c_saddr, s_saddr;
++	struct net_sockaddr addr;
++	net_socklen_t addrlen = sizeof(addr);
++	struct connect_data test_data;
++	uint8_t tx_buf[] = TEST_STR_SMALL;
++	uint8_t rx_buf[sizeof(tx_buf)];
++	int ret;
++	int optval;
++	net_socklen_t optlen = sizeof(optval);
++
++	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock,
++			    &c_saddr, NET_IPPROTO_TLS_1_3);
++	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock,
++			    &s_saddr, NET_IPPROTO_TLS_1_3);
++
++	test_config_psk(s_sock, c_sock);
++
++	test_bind(s_sock, (struct net_sockaddr *)&s_saddr,
++		  sizeof(struct net_sockaddr_in6));
++	test_listen(s_sock);
++
++	test_data.sock = c_sock;
++	test_data.addr = (struct net_sockaddr *)&s_saddr;
++	k_work_init_delayable(&test_data.work,
++			      client_connect_work_handler);
++	test_work_reschedule(&test_data.work, K_NO_WAIT);
++
++	test_accept(s_sock, &new_sock, &addr, &addrlen);
++	test_work_wait(&test_data.work);
++
++	/* Verify protocol is TLS 1.3 via socket option */
++	ret = zsock_getsockopt(new_sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_PROTOCOL,
++			       &optval, &optlen);
++	zassert_equal(ret, 0, "getsockopt failed (%d)", errno);
++	zassert_equal(optval, NET_IPPROTO_TLS_1_3,
++		      "Expected TLS 1.3 protocol");
++
++	/* Verify TLS 1.3 was actually negotiated, not just requested */
++	{
++		WOLFSSL *ssl = ztls_get_wolfssl_context(new_sock);
++
++		zassert_not_null(ssl, "Failed to get wolfSSL context");
++		zassert_equal(wolfSSL_GetVersion(ssl), WOLFSSL_TLSV1_3,
++			      "Negotiated version is not TLS 1.3");
++	}
++
++	/* Send and receive */
++	test_send(c_sock, tx_buf, sizeof(tx_buf), 0);
++	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
++	zassert_equal(ret, sizeof(tx_buf), "recv() failed");
++	zassert_mem_equal(rx_buf, tx_buf, sizeof(tx_buf),
++			  "Data mismatch");
++
++	test_sockets_close();
++
++	k_sleep(TCP_TEARDOWN_TIMEOUT);
++#endif
++}
++
+ static void *tls_tests_setup(void)
+ {
+ 	k_work_queue_init(&tls_test_work_queue);
+diff --git a/tests/net/socket/tls/src/wolfssl_alert.c b/tests/net/socket/tls/src/wolfssl_alert.c
+new file mode 100644
+index 00000000000..b8efb6ef6b2
+--- /dev/null
++++ b/tests/net/socket/tls/src/wolfssl_alert.c
+@@ -0,0 +1,29 @@
++/*
++ * Copyright (c) 2026 wolfSSL Inc.
++ *
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++/* Isolated translation unit for the wolfSSL-internal SendAlert() API used
++ * by the pollerr tests. <wolfssl/internal.h> exposes a large number of
++ * unprefixed identifiers (e.g. the TLS_* ciphersuite enums) that easily
++ * collide with test-local names, so it is confined to this small file:
++ * main.c only sees the test_wolfssl_send_fatal_alert() wrapper. Taking
++ * the SendAlert() prototype from internal.h (instead of a hand-written
++ * declaration) makes a wolfSSL signature change a build error rather
++ * than a silent mismatch.
++ */
++
++#if defined(CONFIG_WOLFSSL)
++
++#ifndef WOLFSSL_USER_SETTINGS
++#include <user_settings.h>
++#endif
++#include <wolfssl/internal.h>
++
++void test_wolfssl_send_fatal_alert(WOLFSSL *ssl)
++{
++	(void)SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
++}
++
++#endif /* CONFIG_WOLFSSL */
+diff --git a/tests/net/socket/tls/testcase.yaml b/tests/net/socket/tls/testcase.yaml
+index b4acc1c1806..d8e36173c38 100644
+--- a/tests/net/socket/tls/testcase.yaml
++++ b/tests/net/socket/tls/testcase.yaml
+@@ -7,20 +7,40 @@ common:
+     - socket
+     - tls
+   filter: CONFIG_FULL_LIBC_SUPPORTED
+-  integration_platforms:
+-    - qemu_x86
+   platform_exclude: vmu_rt1170/mimxrt1176/cm7 # See #61129
++  # NOTE: integration_platforms is set per-scenario rather than here.
++  # Twister merges common list keys into every scenario, so a common
++  # qemu_x86 entry would become an (invalid) integration platform of
++  # the wolfssl scenario, whose platform_allow is native_sim only.
++  # Remember to add integration_platforms to new scenarios.
+ tests:
+   net.socket.tls:
+     extra_configs:
+       - CONFIG_NET_TC_THREAD_COOPERATIVE=y
++    integration_platforms:
++      - qemu_x86
+   net.socket.tls.preempt:
+     extra_configs:
+       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
+     platform_exclude: mps2/an385
++    integration_platforms:
++      - qemu_x86
+   net.socket.tls.sendmsg_no_buf:
+     extra_configs:
+       - CONFIG_NET_SOCKETS_DTLS_SENDMSG_BUF_SIZE=0
++    integration_platforms:
++      - qemu_x86
+   net.socket.tls.no_dtls_cid:
+     extra_configs:
+       - CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID=n
++    integration_platforms:
++      - qemu_x86
++  net.socket.tls.wolfssl:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim
++    tags: wolfssl
++    extra_args:
++      - CONF_FILE=prj_wolfssl.conf
+diff --git a/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf b/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf
+new file mode 100644
+index 00000000000..c704feb71c6
+--- /dev/null
++++ b/tests/net/socket/tls_ext/overlay-wolfssl-verify-cb.conf
+@@ -0,0 +1,13 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++CONFIG_WOLFSSL_SESSION_EXPORT=y
++CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
++CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK=n
++CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK=y
+diff --git a/tests/net/socket/tls_ext/overlay-wolfssl.conf b/tests/net/socket/tls_ext/overlay-wolfssl.conf
+new file mode 100644
+index 00000000000..ca2568bb15d
+--- /dev/null
++++ b/tests/net/socket/tls_ext/overlay-wolfssl.conf
+@@ -0,0 +1,11 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_MBEDTLS=n
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
++CONFIG_WOLFSSL_SESSION_EXPORT=y
++CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
+diff --git a/tests/net/socket/tls_ext/src/main.c b/tests/net/socket/tls_ext/src/main.c
+index 865a44993d7..cc79217a081 100644
+--- a/tests/net/socket/tls_ext/src/main.c
++++ b/tests/net/socket/tls_ext/src/main.c
+@@ -13,8 +13,14 @@
+ #include <zephyr/sys/util.h>
+ #include <zephyr/ztest.h>
+ 
++#if defined(CONFIG_WOLFSSL)
++#include <time.h>
++#include <wolfssl/ssl.h>
++#include <zephyr/net/tls_verify.h>
++#else
+ #include <mbedtls/x509.h>
+ #include <mbedtls/x509_crt.h>
++#endif
+ 
+ LOG_MODULE_REGISTER(tls_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ 
+@@ -84,7 +90,7 @@ static struct k_thread server_thread;
+  * sockets are always required to verify the server public key.
+  *
+  * Additionally, when the peer verification mode is
+- * @ref TLS_PEER_VERIFY_OPTIONAL or @ref TLS_PEER_VERIFY_REQUIRED, then
++ * @ref ZSOCK_TLS_PEER_VERIFY_OPTIONAL or @ref ZSOCK_TLS_PEER_VERIFY_REQUIRED, then
+  * the server also needs the CA cert in order to verify the client. This
+  * type of configuration is often referred to as *mutual authentication*.
+  */
+@@ -233,7 +239,7 @@ static int test_configure_server(k_tid_t *server_thread_id, int peer_verify,
+ 	server_fd = r;
+ 
+ 	r = zsock_setsockopt(server_fd, ZSOCK_SOL_SOCKET, ZSOCK_SO_REUSEADDR, &yes, sizeof(yes));
+-	zassert_not_equal(r, -1, "failed to set SO_REUSEADDR (%d)", errno);
++	zassert_not_equal(r, -1, "failed to set ZSOCK_SO_REUSEADDR (%d)", errno);
+ 
+ 	switch (peer_verify) {
+ 	case ZSOCK_TLS_PEER_VERIFY_NONE:
+@@ -247,7 +253,7 @@ static int test_configure_server(k_tid_t *server_thread_id, int peer_verify,
+ 
+ 		r = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
+ 				     &peer_verify, sizeof(peer_verify));
+-		zassert_not_equal(r, -1, "failed to set TLS_PEER_VERIFY (%d)",
++		zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_PEER_VERIFY (%d)",
+ 				  errno);
+ 		break;
+ 	default:
+@@ -258,11 +264,11 @@ static int test_configure_server(k_tid_t *server_thread_id, int peer_verify,
+ 
+ 	r = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
+ 			     sec_tag_list, sec_tag_list_size);
+-	zassert_not_equal(r, -1, "failed to set TLS_SEC_TAG_LIST (%d)", errno);
++	zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_SEC_TAG_LIST (%d)", errno);
+ 
+ 	r = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, "localhost",
+ 			     sizeof("localhost"));
+-	zassert_not_equal(r, -1, "failed to set TLS_HOSTNAME (%d)", errno);
++	zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_HOSTNAME (%d)", errno);
+ 
+ 	memset(&sa, 0, sizeof(sa));
+ 	/* The server listens on all network interfaces */
+@@ -334,11 +340,11 @@ static int test_configure_client(struct net_sockaddr_in *sa, bool own_cert,
+ 
+ 	r = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
+ 			     sec_tag_list, sec_tag_list_size);
+-	zassert_not_equal(r, -1, "failed to set TLS_SEC_TAG_LIST (%d)", errno);
++	zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_SEC_TAG_LIST (%d)", errno);
+ 
+ 	r = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, hostname,
+ 			     strlen(hostname) + 1);
+-	zassert_not_equal(r, -1, "failed to set TLS_HOSTNAME (%d)", errno);
++	zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_HOSTNAME (%d)", errno);
+ 
+ 	sa->sin_family = NET_PF_INET;
+ 	sa->sin_port = net_htons(PORT);
+@@ -434,9 +440,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
+ 
+ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_required)
+ {
++#if defined(CONFIG_WOLFSSL)
++	/* wolfSSL rejects v1 peer certificates (test uses v1 server.der as
++	 * client cert). This is a wolfSSL policy, not a bug. */
++	ztest_test_skip();
++#else
+ 	test_common(ZSOCK_TLS_PEER_VERIFY_REQUIRED);
++#endif
+ }
+ 
++/* --- Unified cert verify result tests (both backends) --- */
++
+ static void test_tls_cert_verify_result_opt_common(uint32_t expect)
+ {
+ 	int server_fd, client_fd, ret;
+@@ -457,7 +471,7 @@ static void test_tls_cert_verify_result_opt_common(uint32_t expect)
+ 
+ 	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
+ 			       &peer_verify, sizeof(peer_verify));
+-	zassert_ok(ret, "failed to set TLS_PEER_VERIFY (%d)", errno);
++	zassert_ok(ret, "failed to set ZSOCK_TLS_PEER_VERIFY (%d)", errno);
+ 
+ 	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
+ 	zassert_not_equal(ret, -1, "failed to connect (%d)", errno);
+@@ -481,13 +495,60 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
+ 	test_tls_cert_verify_result_opt_common(MBEDTLS_X509_BADCERT_CN_MISMATCH);
+ }
+ 
++/* Applications commonly pass strlen(host) + 1 (or sizeof a literal) as
++ * optlen for TLS_HOSTNAME. The mbedTLS backend ignores optlen and reads a
++ * C string; the wolfSSL backend uses optlen as the hostname length and
++ * strips a trailing NUL. Both must accept the NUL-terminated form and
++ * still match the certificate CN — pin that here.
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_hostname_trailing_nul)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++	uint32_t optval;
++	net_socklen_t optlen = sizeof(optval);
++	int peer_verify = ZSOCK_TLS_PEER_VERIFY_OPTIONAL;
++
++	server_fd = test_configure_server(&server_thread_id,
++					  ZSOCK_TLS_PEER_VERIFY_NONE,
++					  false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	/* Override the hostname with optlen including the terminating NUL. */
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME,
++			       "localhost", sizeof("localhost"));
++	zassert_ok(ret, "failed to set TLS_HOSTNAME (%d)", errno);
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
++			       &peer_verify, sizeof(peer_verify));
++	zassert_ok(ret, "failed to set TLS_PEER_VERIFY (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_not_equal(ret, -1, "failed to connect (%d)", errno);
++
++	/* The CN must have matched despite the NUL-terminated optval. */
++	ret = zsock_getsockopt(client_fd, ZSOCK_SOL_TLS,
++			       ZSOCK_TLS_CERT_VERIFY_RESULT, &optval, &optlen);
++	zassert_equal(ret, 0, "getsockopt failed (%d)", errno);
++	zassert_equal(optval, 0,
++		      "unexpected verify result 0x%x (hostname mismatch?)",
++		      optval);
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++/* --- Unified cert verify callback tests (mbedTLS backend only) --- */
++
++#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK) && !defined(CONFIG_WOLFSSL)
++
+ struct test_cert_verify_ctx {
+ 	bool cb_called;
+ 	int result;
+ };
+ 
+ static int cert_verify_cb(void *ctx, mbedtls_x509_crt *crt, int depth,
+-			  uint32_t *flags)
++			   uint32_t *flags)
+ {
+ 	struct test_cert_verify_ctx *test_ctx = (struct test_cert_verify_ctx *)ctx;
+ 
+@@ -522,7 +583,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
+ 
+ 	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK,
+ 			       &cb, sizeof(cb));
+-	zassert_ok(ret, "failed to set TLS_CERT_VERIFY_CALLBACK (%d)", errno);
++	zassert_ok(ret, "failed to set ZSOCK_TLS_CERT_VERIFY_CALLBACK (%d)", errno);
+ 
+ 	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
+ 	zassert_true(ctx.cb_called, "callback not called");
+@@ -546,6 +607,37 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
+ 	test_tls_cert_verify_cb_opt_common(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED);
+ }
+ 
++#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
++
++#if defined(CONFIG_WOLFSSL)
++/* Contract test: ZSOCK_TLS_CERT_VERIFY_CALLBACK (opt 20) is the mbedTLS-style
++ * cert-verify callback. Under CONFIG_WOLFSSL the option is documented to
++ * return -ENOTSUP regardless of CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK;
++ * users must use ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL instead. This test
++ * pins that contract so a future setsockopt dispatcher change can't
++ * silently start accepting opt 20 under wolfSSL. Gated only on
++ * CONFIG_WOLFSSL so it runs in both wolfssl scenarios (with the
++ * mbedTLS-style callback option enabled or disabled).
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt20_enotsup_on_wolfssl)
++{
++	int client_fd;
++	int ret;
++	struct zsock_tls_cert_verify_cb dummy = { .cb = NULL, .ctx = NULL };
++
++	client_fd = zsock_socket(NET_AF_INET, NET_SOCK_STREAM, NET_IPPROTO_TLS_1_2);
++	zassert_true(client_fd >= 0, "socket() failed: %d", errno);
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK,
++			       &dummy, sizeof(dummy));
++	zassert_equal(ret, -1, "setsockopt() should fail under wolfSSL");
++	zassert_equal(errno, ENOTSUP,
++		      "expected -ENOTSUP, got errno=%d", errno);
++
++	(void)zsock_close(client_fd);
++}
++#endif /* CONFIG_WOLFSSL */
++
+ static void *setup(void)
+ {
+ 	int r;
+@@ -599,4 +691,361 @@ static void *setup(void)
+ 	return NULL;
+ }
+ 
+-ZTEST_SUITE(net_socket_tls_api_extension, NULL, setup, NULL, NULL, NULL);
++/* --- wolfSSL-style verify callback tests --- */
++
++#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
++
++struct wolfssl_verify_ctx {
++	bool cb_called;
++	int depth_seen;
++	int error_seen;
++	int decision;  /* 1 = accept, 0 = reject */
++};
++
++static int wolfssl_verify_cb(int preverify_ok, void *store_ctx)
++{
++	WOLFSSL_X509_STORE_CTX *store = store_ctx;
++	struct wolfssl_verify_ctx *ctx;
++
++	if (store == NULL || store->userCtx == NULL) {
++		return preverify_ok;
++	}
++
++	ctx = (struct wolfssl_verify_ctx *)store->userCtx;
++	ctx->cb_called = true;
++	ctx->depth_seen = store->error_depth;
++	ctx->error_seen = store->error;
++
++	return ctx->decision;
++}
++
++struct wolfssl_verify_inspect_ctx {
++	bool cb_called;
++	int error_depth;
++	int total_certs;
++	bool has_certs_buffer;
++	bool domain_is_localhost;
++};
++
++static int wolfssl_verify_inspect_cb(int preverify_ok, void *store_ctx)
++{
++	WOLFSSL_X509_STORE_CTX *store = store_ctx;
++	struct wolfssl_verify_inspect_ctx *ctx;
++
++	if (store == NULL || store->userCtx == NULL) {
++		return preverify_ok;
++	}
++
++	ctx = (struct wolfssl_verify_inspect_ctx *)store->userCtx;
++	ctx->cb_called = true;
++	ctx->error_depth = store->error_depth;
++	ctx->total_certs = store->totalCerts;
++	ctx->has_certs_buffer = (store->certs != NULL &&
++				 store->certs[store->error_depth].length > 0);
++
++	if (store->domain != NULL &&
++	    strcmp(store->domain, "localhost") == 0) {
++		ctx->domain_is_localhost = true;
++	}
++
++	return 1; /* accept */
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_accept)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++
++	struct wolfssl_verify_ctx ctx = {
++		.cb_called = false,
++		.decision = 1, /* accept */
++	};
++	struct zsock_tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_cb,
++		.ctx = &ctx,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  ZSOCK_TLS_PEER_VERIFY_NONE, false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0, "failed to connect (%d)", errno);
++	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_reject)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++
++	struct wolfssl_verify_ctx ctx = {
++		.cb_called = false,
++		.decision = 0, /* reject */
++	};
++	struct zsock_tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_cb,
++		.ctx = &ctx,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  ZSOCK_TLS_PEER_VERIFY_NONE, false, true);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
++	zassert_equal(ret, -1, "connect() should fail");
++	zassert_equal(errno, ECONNABORTED, "invalid errno");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_inspect_fields)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++
++	struct wolfssl_verify_inspect_ctx ctx = {0};
++	struct zsock_tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_inspect_cb,
++		.ctx = &ctx,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  ZSOCK_TLS_PEER_VERIFY_NONE, false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0, "failed to connect (%d)", errno);
++
++	zassert_true(ctx.cb_called, "wolfSSL-style verify callback was not called");
++	zassert_true(ctx.total_certs > 0, "totalCerts should be > 0");
++	zassert_true(ctx.has_certs_buffer,
++		     "certs buffer should contain DER data");
++	zassert_true(ctx.domain_is_localhost,
++		     "domain should be 'localhost'");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++static int wolfssl_verify_null_ctx_cb(int preverify_ok, void *store_ctx)
++{
++	WOLFSSL_X509_STORE_CTX *store = store_ctx;
++
++	/* When ctx is NULL, wolfSSL's default userCtx resolution applies.
++	 * store->userCtx should be NULL (ssl->verifyCbCtx is NULL by default).
++	 */
++	if (store != NULL && store->userCtx == NULL) {
++		/* This is the expected path -- userCtx is NULL because we
++		 * did not call wolfSSL_SetCertCbCtx. Accept the cert.
++		 */
++		return 1;
++	}
++
++	/* Unexpected: userCtx is non-NULL. Reject to signal test failure. */
++	return 0;
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_null_ctx)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++
++	/* Register wolfSSL-style callback with ctx set to NULL.
++	 * wolfSSL should NOT call wolfSSL_SetCertCbCtx, so
++	 * store->userCtx in the callback should be NULL.
++	 */
++	struct zsock_tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_null_ctx_cb,
++		.ctx = NULL,
++	};
++
++	server_fd = test_configure_server(&server_thread_id,
++					  ZSOCK_TLS_PEER_VERIFY_NONE, false, false);
++	client_fd = test_configure_client(&sa, false, "localhost");
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			       &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0,
++		      "connect failed -- userCtx may not be NULL (%d)", errno);
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++/* --- Server-side wolfSSL-style verify callback test --- */
++
++static struct wolfssl_verify_ctx server_wolfssl_verify_ctx;
++
++static void server_thread_wolfssl_verify_fn(void *arg0, void *arg1, void *arg2)
++{
++	const int server_fd = POINTER_TO_INT(arg0);
++	int r;
++	int client_fd;
++	net_socklen_t addrlen;
++	struct net_sockaddr_in sa;
++
++	k_thread_name_set(k_current_get(), "server");
++
++	memset(&sa, 0, sizeof(sa));
++	addrlen = sizeof(sa);
++
++	k_sem_give(&server_sem);
++	r = zsock_accept(server_fd, (struct net_sockaddr *)&sa, &addrlen);
++	zassert_not_equal(r, -1, "zsock_accept() failed (%d)", errno);
++	client_fd = r;
++
++	r = zsock_close(client_fd);
++	zassert_not_equal(r, -1, "zsock_close() failed on the server fd (%d)", errno);
++}
++
++ZTEST(net_socket_tls_api_extension, test_wolfssl_verify_cb_server_accept)
++{
++	static const sec_tag_t server_tag_list[] = {
++		CA_CERTIFICATE_TAG,
++		SERVER_CERTIFICATE_TAG,
++	};
++	int server_fd, client_fd, ret;
++	k_tid_t tid;
++	struct net_sockaddr_in sa;
++	/* Use REQUIRED, not OPTIONAL. On the server side OPTIONAL maps to
++	 * plain WOLFSSL_VERIFY_PEER (request a cert, but accept the handshake
++	 * if the client doesn't present one), so a misbehaving client that
++	 * skips its certificate never triggers the verify callback. REQUIRED
++	 * adds WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, forcing the server to
++	 * actually demand a client certificate and exercise the callback.
++	 */
++	int peer_verify = ZSOCK_TLS_PEER_VERIFY_REQUIRED;
++
++	memset(&server_wolfssl_verify_ctx, 0, sizeof(server_wolfssl_verify_ctx));
++	server_wolfssl_verify_ctx.decision = 1; /* accept */
++
++	struct zsock_tls_cert_verify_cb_wolfssl cb = {
++		.cb = wolfssl_verify_cb,
++		.ctx = &server_wolfssl_verify_ctx,
++	};
++
++	k_sem_init(&server_sem, 0, 1);
++
++	/* Create server socket */
++	ret = zsock_socket(NET_AF_INET, NET_SOCK_STREAM, NET_IPPROTO_TLS_1_2);
++	zassert_not_equal(ret, -1, "failed to create server socket (%d)", errno);
++	server_fd = ret;
++
++	int yes = true;
++
++	ret = zsock_setsockopt(server_fd, ZSOCK_SOL_SOCKET, ZSOCK_SO_REUSEADDR, &yes, sizeof(yes));
++	zassert_not_equal(ret, -1, "failed to set ZSOCK_SO_REUSEADDR (%d)", errno);
++
++	ret = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
++			 server_tag_list, sizeof(server_tag_list));
++	zassert_not_equal(ret, -1, "failed to set ZSOCK_TLS_SEC_TAG_LIST (%d)", errno);
++
++	ret = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, "localhost",
++			 sizeof("localhost"));
++	zassert_not_equal(ret, -1, "failed to set ZSOCK_TLS_HOSTNAME (%d)", errno);
++
++	ret = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
++			 &peer_verify, sizeof(peer_verify));
++	zassert_not_equal(ret, -1, "failed to set ZSOCK_TLS_PEER_VERIFY (%d)", errno);
++
++	ret = zsock_setsockopt(server_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL,
++			 &cb, sizeof(cb));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL (%d)", errno);
++
++	memset(&sa, 0, sizeof(sa));
++	sa.sin_addr.s_addr = NET_INADDR_ANY;
++	sa.sin_family = NET_AF_INET;
++	sa.sin_port = net_htons(PORT);
++
++	ret = zsock_bind(server_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_not_equal(ret, -1, "failed to bind (%d)", errno);
++
++	ret = zsock_listen(server_fd, 1);
++	zassert_not_equal(ret, -1, "failed to listen (%d)", errno);
++
++	tid = k_thread_create(&server_thread, server_stack, STACK_SIZE,
++			      server_thread_wolfssl_verify_fn,
++			      INT_TO_POINTER(server_fd), NULL, NULL,
++			      K_PRIO_PREEMPT(8), 0, K_NO_WAIT);
++
++	ret = k_sem_take(&server_sem, K_MSEC(TIMEOUT));
++	zassert_equal(0, ret, "failed to synchronize with server thread (%d)", ret);
++
++	/* Client presents its cert */
++	client_fd = test_configure_client(&sa, true, "localhost");
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, 0, "failed to connect (%d)", errno);
++
++	/* The server's wolfSSL-style verify callback should have been invoked
++	 * during zsock_accept() on the cloned child context.
++	 */
++	zassert_true(server_wolfssl_verify_ctx.cb_called,
++		     "server wolfSSL-style verify callback was not called");
++
++	ret = zsock_close(client_fd);
++	zassert_not_equal(-1, ret, "zsock_close() failed on client fd (%d)", errno);
++	ret = zsock_close(server_fd);
++	zassert_not_equal(-1, ret, "zsock_close() failed on server fd (%d)", errno);
++	ret = k_thread_join(&server_thread, K_FOREVER);
++	zassert_equal(0, ret, "k_thread_join() failed (%d)", ret);
++	k_yield();
++}
++
++#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
++
++#if defined(CONFIG_WOLFSSL)
++/* Realtime clock (seconds since the Unix epoch) used to satisfy wolfSSL's
++ * X.509 date validation. It MUST lie within every test certificate's validity
++ * window: the echo_server certs used here are valid 2020..2119, so this is
++ * 2025-06-01T00:00:00Z. Update it if the test certificates are regenerated
++ * with a later notBefore.
++ */
++#define WOLFSSL_CERT_VALID_TIME 1748736000
++
++static void set_cert_validity_clock(void *fixture)
++{
++	const struct timespec ts = {
++		.tv_sec = WOLFSSL_CERT_VALID_TIME,
++		.tv_nsec = 0,
++	};
++	int ret;
++
++	ARG_UNUSED(fixture);
++
++	/* wolfSSL validates X.509 certificate dates. On native_sim z_time()
++	 * reads the host clock, but on real targets it reads the Zephyr realtime
++	 * clock, whose offset ztest's clock_offset_reset_rule resets to epoch 0
++	 * (1970) after every test -- so this must run before each test, not once
++	 * in suite setup, or certificates are rejected as "not yet valid".
++	 */
++	ret = clock_settime(CLOCK_REALTIME, &ts);
++	zassert_ok(ret, "failed to set CLOCK_REALTIME (%d)", ret);
++}
++#define TLS_EXT_BEFORE set_cert_validity_clock
++#else
++#define TLS_EXT_BEFORE NULL
++#endif /* CONFIG_WOLFSSL */
++
++ZTEST_SUITE(net_socket_tls_api_extension, NULL, setup, TLS_EXT_BEFORE, NULL, NULL);
+diff --git a/tests/net/socket/tls_ext/testcase.yaml b/tests/net/socket/tls_ext/testcase.yaml
+index 497e5f8c65e..ad10f166c21 100644
+--- a/tests/net/socket/tls_ext/testcase.yaml
++++ b/tests/net/socket/tls_ext/testcase.yaml
+@@ -8,3 +8,19 @@ tests:
+     platform_allow: qemu_x86
+     integration_platforms:
+       - qemu_x86
++
++  net.socket.tls.ext.wolfssl:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    tags: wolfssl
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl.conf
++
++  net.socket.tls.ext.wolfssl.verify_cb:
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    tags: wolfssl
++    extra_args:
++      - OVERLAY_CONFIG=overlay-wolfssl-verify-cb.conf
+diff --git a/tests/subsys/random/rng/prj_wolfssl.conf b/tests/subsys/random/rng/prj_wolfssl.conf
+new file mode 100644
+index 00000000000..39ca7fa6cc5
+--- /dev/null
++++ b/tests/subsys/random/rng/prj_wolfssl.conf
+@@ -0,0 +1,11 @@
++# Copyright (c) 2026 wolfSSL Inc.
++# SPDX-License-Identifier: Apache-2.0
++
++CONFIG_ZTEST=y
++CONFIG_LOG=y
++CONFIG_ENTROPY_GENERATOR=y
++CONFIG_POSIX_API=y
++CONFIG_POSIX_TIMERS=y
++CONFIG_POSIX_THREADS=y
++CONFIG_WOLFSSL=y
++CONFIG_WOLFSSL_CSPRNG_GENERATOR=y
+diff --git a/tests/subsys/random/rng/testcase.yaml b/tests/subsys/random/rng/testcase.yaml
+index 7534548a3dc..bcfd0f676e3 100644
+--- a/tests/subsys/random/rng/testcase.yaml
++++ b/tests/subsys/random/rng/testcase.yaml
+@@ -24,6 +24,16 @@ tests:
+     min_ram: 16
+     integration_platforms:
+       - native_sim
++  crypto.rng.random_wolfssl:
++    extra_args: CONF_FILE=prj_wolfssl.conf
++    filter: CONFIG_ENTROPY_HAS_DRIVER
++    min_ram: 16
++    platform_allow:
++      - native_sim
++      - native_sim/native/64
++    integration_platforms:
++      - native_sim
++    tags: wolfssl
+   drivers.rng.random_psa_crypto:
+     filter: CONFIG_BUILD_WITH_TFM
+     arch_exclude: posix

--- a/zephyr/4.4/zephyr-tls-4.4.1.patch
+++ b/zephyr/4.4/zephyr-tls-4.4.1.patch
@@ -1,0 +1,6268 @@
+diff --git a/include/zephyr/net/net_compat.h b/include/zephyr/net/net_compat.h
+index 927c8d5087e..df4b2d5e180 100644
+--- a/include/zephyr/net/net_compat.h
++++ b/include/zephyr/net/net_compat.h
+@@ -172,6 +172,7 @@ extern "C" {
+ #define TLS_DTLS_HANDSHAKE_ON_CONNECT     ZSOCK_TLS_DTLS_HANDSHAKE_ON_CONNECT
+ #define TLS_CERT_VERIFY_RESULT            ZSOCK_TLS_CERT_VERIFY_RESULT
+ #define TLS_CERT_VERIFY_CALLBACK          ZSOCK_TLS_CERT_VERIFY_CALLBACK
++#define TLS_CERT_VERIFY_CALLBACK_WOLFSSL  ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL
+ #define TLS_PEER_VERIFY_NONE              ZSOCK_TLS_PEER_VERIFY_NONE
+ #define TLS_PEER_VERIFY_OPTIONAL          ZSOCK_TLS_PEER_VERIFY_OPTIONAL
+ #define TLS_PEER_VERIFY_REQUIRED          ZSOCK_TLS_PEER_VERIFY_REQUIRED
+@@ -190,6 +191,8 @@ extern "C" {
+ #define TLS_DTLS_CID_STATUS_BIDIRECTIONAL ZSOCK_TLS_DTLS_CID_STATUS_BIDIRECTIONAL
+ 
+ #define tls_cert_verify_cb zsock_tls_cert_verify_cb
++#define tls_cert_verify_cb_wolfssl zsock_tls_cert_verify_cb_wolfssl
++#define tls_wolfssl_verify_cb_t zsock_tls_wolfssl_verify_cb_t
+ 
+ #define AI_PASSIVE      ZSOCK_AI_PASSIVE
+ #define AI_CANONNAME    ZSOCK_AI_CANONNAME
+diff --git a/include/zephyr/net/socket.h b/include/zephyr/net/socket.h
+index 322309c26f0..de832814d8e 100644
+--- a/include/zephyr/net/socket.h
++++ b/include/zephyr/net/socket.h
+@@ -173,7 +173,9 @@ extern "C" {
+ 
+ /** Socket option for preventing certificates from being copied to the mbedTLS
+  *  heap if possible. The option is only effective for DER certificates and is
+- *  ignored for PEM certificates.
++ *  ignored for PEM certificates. This option has no effect when using wolfSSL
++ *  as the underlying TLS implementation, the cert data is always copied to the
++ *  heap in that case.
+  */
+ #define ZSOCK_TLS_CERT_NOCOPY	       10
+ /** TLS socket option to use with offloading. The option instructs the network
+@@ -258,9 +260,21 @@ extern "C" {
+  *  certificates and decide whether to proceed or abort the handshake.
+  *
+  *  The option is only available if CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK
+- *  Kconfig option is enabled.
++ *  Kconfig option is enabled AND the mbedTLS backend is in use. Under
++ *  CONFIG_WOLFSSL, setsockopt(ZSOCK_TLS_CERT_VERIFY_CALLBACK) returns -ENOTSUP;
++ *  use ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL instead.
+  */
+ #define ZSOCK_TLS_CERT_VERIFY_CALLBACK 20
++/** Write-only socket option to register a wolfSSL-style cert-verify callback.
++ *  The option accepts a pointer to a @ref zsock_tls_cert_verify_cb_wolfssl
++ *  structure.
++ *
++ *  Only honored when CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK is enabled and CONFIG_WOLFSSL
++ *  is the active TLS backend; under the mbedTLS backend setsockopt returns
++ *  -ENOPROTOOPT. The numeric value (21) is reserved unconditionally so the
++ *  socket option-number space stays stable across backends.
++ */
++#define ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL 21
+ 
+ /* Valid values for @ref TLS_PEER_VERIFY option */
+ #define ZSOCK_TLS_PEER_VERIFY_NONE 0     /**< Peer verification disabled. */
+@@ -302,6 +316,43 @@ struct zsock_tls_cert_verify_cb {
+ 	/** A pointer to an opaque context passed to the callback. */
+ 	void *ctx;
+ };
++
++/** Callback type for @ref ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL.
++ *
++ *  The second parameter is the underlying WOLFSSL_X509_STORE_CTX, typed as
++ *  void* so the public header does not pull in <wolfssl/ssl.h>. Cast to
++ *  WOLFSSL_X509_STORE_CTX* inside the callback.
++ *
++ *  Shape matches the wolfSSL VerifyCallback signature
++ *  int (*)(int preverify_ok, WOLFSSL_X509_STORE_CTX *ctx).
++ *
++ *  Constraints (the TLS layer wraps this callback): it is invoked
++ *  synchronously per chain position and must return normally — it must NOT
++ *  longjmp/throw out of the call. The application context registered via
++ *  @ref zsock_tls_cert_verify_cb_wolfssl is presented through
++ *  store_ctx->userCtx for the duration of the call only; the callback must
++ *  not modify userCtx (the TLS layer restores its own bookkeeping pointer on
++ *  return, so any change is overwritten).
++ */
++typedef int (*zsock_tls_wolfssl_verify_cb_t)(int preverify_ok, void *store_ctx);
++
++/** Data structure for @ref ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL socket
++ *  option. Only honored by the wolfSSL TLS backend (CONFIG_WOLFSSL); the
++ *  type is defined unconditionally so documentation references and the
++ *  compat alias stay valid in mbedTLS builds.
++ */
++struct zsock_tls_cert_verify_cb_wolfssl {
++	/** Callback with wolfSSL VerifyCallback signature; see
++	 *  @ref zsock_tls_wolfssl_verify_cb_t.
++	 */
++	zsock_tls_wolfssl_verify_cb_t cb;
++
++	/** Application context pointer. Passed to the callback via
++	 *  WOLFSSL_X509_STORE_CTX->userCtx. If NULL, wolfSSL default
++	 *  behavior applies.
++	 */
++	void *ctx;
++};
+ /** @} */ /* for @name */
+ /** @} */ /* for @defgroup */
+ 
+diff --git a/include/zephyr/net/tls_verify.h b/include/zephyr/net/tls_verify.h
+new file mode 100644
+index 00000000000..92ac4f1dd22
+--- /dev/null
++++ b/include/zephyr/net/tls_verify.h
+@@ -0,0 +1,139 @@
++/*
++ * Copyright (c) 2026 wolfSSL Inc.
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++/** @file
++ * @brief Public TLS_CERT_VERIFY_RESULT bitmask constants for the wolfSSL
++ *        socket backend.
++ *
++ * The wolfSSL backend accumulates certificate verification errors into the
++ * TLS_CERT_VERIFY_RESULT getsockopt bitmask using the same hex values as
++ * mbedtls/x509.h's MBEDTLS_X509_BADCERT_* macros — the layout is part of
++ * the TLS_CERT_VERIFY_RESULT public contract and predates the wolfSSL
++ * backend. Applications that already include mbedtls/x509.h are
++ * automatically protected from redefinition by the #ifndef guards below.
++ *
++ * Under CONFIG_MBEDTLS this file is inert; applications pull the real
++ * macros from mbedtls/x509.h.
++ */
++
++#ifndef ZEPHYR_INCLUDE_NET_TLS_VERIFY_H_
++#define ZEPHYR_INCLUDE_NET_TLS_VERIFY_H_
++
++#include <stdint.h>
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#if defined(CONFIG_WOLFSSL)
++
++/* Hex values match mbedtls/x509.h. Guards let an application include both
++ * this header and mbedtls/x509.h (e.g., for mbedTLS in another TU) without
++ * redefinition warnings.
++ */
++#ifndef MBEDTLS_X509_BADCERT_EXPIRED
++#define MBEDTLS_X509_BADCERT_EXPIRED          0x01
++#endif
++#ifndef MBEDTLS_X509_BADCERT_REVOKED
++#define MBEDTLS_X509_BADCERT_REVOKED          0x02
++#endif
++#ifndef MBEDTLS_X509_BADCERT_CN_MISMATCH
++#define MBEDTLS_X509_BADCERT_CN_MISMATCH      0x04
++#endif
++#ifndef MBEDTLS_X509_BADCERT_NOT_TRUSTED
++#define MBEDTLS_X509_BADCERT_NOT_TRUSTED      0x08
++#endif
++#ifndef MBEDTLS_X509_BADCRL_NOT_TRUSTED
++#define MBEDTLS_X509_BADCRL_NOT_TRUSTED       0x10
++#endif
++#ifndef MBEDTLS_X509_BADCRL_EXPIRED
++#define MBEDTLS_X509_BADCRL_EXPIRED           0x20
++#endif
++#ifndef MBEDTLS_X509_BADCERT_MISSING
++#define MBEDTLS_X509_BADCERT_MISSING          0x40
++#endif
++#ifndef MBEDTLS_X509_BADCERT_SKIP_VERIFY
++#define MBEDTLS_X509_BADCERT_SKIP_VERIFY      0x80
++#endif
++#ifndef MBEDTLS_X509_BADCERT_OTHER
++#define MBEDTLS_X509_BADCERT_OTHER            0x0100
++#endif
++#ifndef MBEDTLS_X509_BADCERT_FUTURE
++#define MBEDTLS_X509_BADCERT_FUTURE           0x0200
++#endif
++#ifndef MBEDTLS_X509_BADCRL_FUTURE
++#define MBEDTLS_X509_BADCRL_FUTURE            0x0400
++#endif
++#ifndef MBEDTLS_X509_BADCERT_KEY_USAGE
++#define MBEDTLS_X509_BADCERT_KEY_USAGE        0x0800
++#endif
++#ifndef MBEDTLS_X509_BADCERT_EXT_KEY_USAGE
++#define MBEDTLS_X509_BADCERT_EXT_KEY_USAGE    0x1000
++#endif
++#ifndef MBEDTLS_X509_BADCERT_NS_CERT_TYPE
++#define MBEDTLS_X509_BADCERT_NS_CERT_TYPE     0x2000
++#endif
++#ifndef MBEDTLS_X509_BADCERT_BAD_MD
++#define MBEDTLS_X509_BADCERT_BAD_MD           0x4000
++#endif
++#ifndef MBEDTLS_X509_BADCERT_BAD_PK
++#define MBEDTLS_X509_BADCERT_BAD_PK           0x8000
++#endif
++#ifndef MBEDTLS_X509_BADCERT_BAD_KEY
++#define MBEDTLS_X509_BADCERT_BAD_KEY          0x010000
++#endif
++#ifndef MBEDTLS_X509_BADCRL_BAD_MD
++#define MBEDTLS_X509_BADCRL_BAD_MD            0x020000
++#endif
++#ifndef MBEDTLS_X509_BADCRL_BAD_PK
++#define MBEDTLS_X509_BADCRL_BAD_PK            0x040000
++#endif
++#ifndef MBEDTLS_X509_BADCRL_BAD_KEY
++#define MBEDTLS_X509_BADCRL_BAD_KEY           0x080000
++#endif
++
++#ifndef MBEDTLS_ERR_X509_CERT_VERIFY_FAILED
++/* Error code for verify failure (used in callback return values) */
++#define MBEDTLS_ERR_X509_CERT_VERIFY_FAILED   -0x2700
++#endif
++
++/* Compile-time consistency check: if a translation unit happens to pull in
++ * both this header and mbedtls/x509.h (e.g., an application that uses
++ * mbedTLS for some other purpose while linking the wolfSSL socket backend),
++ * the BUILD_ASSERTs below catch a value drift instead of letting the two
++ * sources of truth silently diverge. Guarded by __MBEDTLS_X509_H so we
++ * only fire when both headers have been included.
++ */
++#if defined(__MBEDTLS_X509_H) || defined(MBEDTLS_X509_H)
++#include <zephyr/sys/util.h>
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_EXPIRED       == 0x01,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_REVOKED       == 0x02,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_CN_MISMATCH   == 0x04,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_NOT_TRUSTED   == 0x08,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCRL_NOT_TRUSTED    == 0x10,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCRL_EXPIRED        == 0x20,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_MISSING       == 0x40,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_SKIP_VERIFY   == 0x80,     "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_OTHER         == 0x0100,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_FUTURE        == 0x0200,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCRL_FUTURE         == 0x0400,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_KEY_USAGE     == 0x0800,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_EXT_KEY_USAGE == 0x1000,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_NS_CERT_TYPE  == 0x2000,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_BAD_MD        == 0x4000,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_BAD_PK        == 0x8000,   "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCERT_BAD_KEY       == 0x010000, "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCRL_BAD_MD         == 0x020000, "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCRL_BAD_PK         == 0x040000, "ABI drift vs mbedtls/x509.h");
++BUILD_ASSERT(MBEDTLS_X509_BADCRL_BAD_KEY        == 0x080000, "ABI drift vs mbedtls/x509.h");
++#endif /* mbedtls/x509.h reachable */
++
++#endif /* CONFIG_WOLFSSL */
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* ZEPHYR_INCLUDE_NET_TLS_VERIFY_H_ */
+diff --git a/subsys/net/lib/sockets/CMakeLists.txt b/subsys/net/lib/sockets/CMakeLists.txt
+index 7e32b540ce4..a51a9a3b74d 100644
+--- a/subsys/net/lib/sockets/CMakeLists.txt
++++ b/subsys/net/lib/sockets/CMakeLists.txt
+@@ -39,3 +39,4 @@ endif()
+ zephyr_library_sources_ifdef(CONFIG_NET_SOCKETPAIR socketpair.c)
+ 
+ zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
++zephyr_library_link_libraries_ifdef(CONFIG_WOLFSSL wolfSSL)
+diff --git a/subsys/net/lib/sockets/Kconfig b/subsys/net/lib/sockets/Kconfig
+index 87fbe4c7bca..abf036a02f4 100644
+--- a/subsys/net/lib/sockets/Kconfig
++++ b/subsys/net/lib/sockets/Kconfig
+@@ -129,12 +129,76 @@ config NET_SOCKETS_SERVICE_STACK_SIZE
+ config NET_SOCKETS_SOCKOPT_TLS
+ 	bool "TCP TLS socket option support"
+ 	imply TLS_CREDENTIALS
+-	select MBEDTLS if NET_NATIVE
+-	select PSA_CRYPTO if NET_NATIVE
++	select MBEDTLS if NET_NATIVE && !WOLFSSL
++	select PSA_CRYPTO if NET_NATIVE && !WOLFSSL
++	# wolfSSL backend requirements. The integration calls a narrow set of
++	# non-base wolfSSL APIs; only the strict minimum is force-selected
++	# here to keep flash/RAM cost on constrained targets low:
++	#   SET_CIPHER_BYTES - wolfSSL_set_cipher_list_bytes (small)
++	#   OPENSSL_EXTRA_X509_SMALL - exposes WOLFSSL_X509_STORE_CTX::current_cert
++	#                      which the verify callback reads to perform the
++	#                      leaf CN/SAN match. wolfSSL gates the whole
++	#                      X509_STORE_CTX struct member on this flag.
++	#   ALWAYS_VERIFY_CB - fires verify cb on chain success too. Load-
++	#                      bearing: without it the leaf CN/SAN match in
++	#                      tls_wolfssl_verify_accumulate_cb is silently
++	#                      bypassed and a cert with mismatched CN/SAN
++	#                      would be accepted by TLS_PEER_VERIFY_REQUIRED.
++	# Session resumption (CONFIG_WOLFSSL_SESSION_EXPORT) is NOT forced:
++	# the integration's tls_session_store/restore become no-ops when
++	# HAVE_EXT_CACHE is undefined, so enabling it is an explicit opt-in.
++	# (wolfSSL_clear, wolfSSL_X509_check_host and wolfSSL_set_verify are
++	# always available in src/ssl.c / src/x509.c / src/ssl_api_cert.c.)
++	# Gated on `WOLFSSL && !MBEDTLS` because the backends are mutually
++	# exclusive: pulling these wolfSSL knobs in on an mbedTLS build (e.g.
++	# when CONFIG_WOLFSSL=y is enabled for the random subsystem only) is
++	# pure bloat and risks user confusion.
++	select WOLFSSL_SET_CIPHER_BYTES if WOLFSSL && !MBEDTLS
++	select WOLFSSL_OPENSSL_EXTRA_X509_SMALL if WOLFSSL && !MBEDTLS
++	select WOLFSSL_ALWAYS_VERIFY_CB if WOLFSSL && !MBEDTLS
+ 	help
+ 	  Enable TLS socket option support which automatically establishes
+ 	  a TLS connection to the remote host.
+ 
++choice NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE_CHOICE
++	prompt "wolfSSL TLS 1.3 PSK default ciphersuite"
++	depends on NET_SOCKETS_SOCKOPT_TLS && WOLFSSL && WOLFSSL_TLS_VERSION_1_3 \
++		&& WOLFSSL_PSK
++	default NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_GCM_SHA256
++	help
++	  TLS 1.3 PSK exchange binds a PSK to a single hash algorithm, but
++	  the Zephyr TLS_CREDENTIAL_PSK API doesn't carry that information.
++	  This choice fixes which ciphersuite the wolfSSL TLS 1.3 PSK
++	  callbacks return for any PSK presented. Enumerated rather than
++	  free-text so typos surface as a build-time Kconfig error.
++
++config NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_GCM_SHA256
++	bool "TLS13-AES128-GCM-SHA256 (mandatory-to-implement)"
++
++config NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES256_GCM_SHA384
++	bool "TLS13-AES256-GCM-SHA384"
++
++config NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CHACHA20_POLY1305_SHA256
++	bool "TLS13-CHACHA20-POLY1305-SHA256"
++
++config NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_CCM_SHA256
++	bool "TLS13-AES128-CCM-SHA256"
++
++config NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_CCM_8_SHA256
++	bool "TLS13-AES128-CCM-8-SHA256"
++
++endchoice
++
++config NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE
++	string
++	depends on NET_SOCKETS_SOCKOPT_TLS && WOLFSSL && WOLFSSL_TLS_VERSION_1_3 \
++		&& WOLFSSL_PSK
++	default "TLS13-AES128-GCM-SHA256"        if NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_GCM_SHA256
++	default "TLS13-AES256-GCM-SHA384"        if NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES256_GCM_SHA384
++	default "TLS13-CHACHA20-POLY1305-SHA256" if NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CHACHA20_POLY1305_SHA256
++	default "TLS13-AES128-CCM-SHA256"        if NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_CCM_SHA256
++	default "TLS13-AES128-CCM-8-SHA256"      if NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_AES128_CCM_8_SHA256
++
+ config NET_SOCKETS_TLS_CONNECT_TIMEOUT
+ 	int "Timeout value in milliseconds for TLS handshake"
+ 	depends on NET_SOCKETS_SOCKOPT_TLS
+@@ -155,15 +219,18 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+ 	bool "Set Maximum Fragment Length (MFL)"
+ 	default y
+ 	help
+-	  Call mbedtls_ssl_conf_max_frag_len() on created TLS context
+-	  configuration, so that Maximum Fragment Length (MFL) will be sent to
+-	  peer using RFC 6066 max_fragment_length extension.
++	  Configure the created TLS context so that Maximum Fragment Length (MFL)
++	  will be sent to peer using RFC 6066 max_fragment_length extension.
++
++	  For MbedTLS, Maximum Fragment Length (MFL) value is automatically
++	  chosen based on MBEDTLS_SSL_OUT_CONTENT_LEN and
++	  MBEDTLS_SSL_IN_CONTENT_LEN mbed TLS macros (which are configured by
++	  CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN in case of default mbed TLS config).
++	  With DTLS, MFL value may be further limited with
++	  NET_SOCKETS_DTLS_MAX_FRAGMENT_LENGTH.
+ 
+-	  Maximum Fragment Length (MFL) value is automatically chosen based on
+-	  MBEDTLS_SSL_OUT_CONTENT_LEN and MBEDTLS_SSL_IN_CONTENT_LEN mbed TLS
+-	  macros (which are configured by CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN in
+-	  case of default mbed TLS config). With DTLS, MFL value may be further
+-	  limited with NET_SOCKETS_DTLS_MAX_FRAGMENT_LENGTH.
++	  For WolfSSL, Maximum Fragment Length (MFL) value is set by the
++	  configuration option WOLFSSL_MAX_FRAGMENT_LEN.
+ 
+ 	  This is mostly useful for TLS client side to tell TLS server what is
+ 	  the maximum supported receive record length.
+@@ -171,7 +238,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+ config NET_SOCKETS_ENABLE_DTLS
+ 	bool "DTLS socket support"
+ 	depends on NET_SOCKETS_SOCKOPT_TLS
+-	select MBEDTLS_SSL_PROTO_DTLS if NET_NATIVE
++	select MBEDTLS_SSL_PROTO_DTLS if NET_NATIVE && !WOLFSSL
+ 	help
+ 	  Enable DTLS socket support. By default only TLS over TCP is supported.
+ 
+@@ -261,7 +328,7 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
+ config NET_SOCKETS_TLS_MAX_APP_PROTOCOLS
+ 	int "Maximum number of supported application layer protocols"
+ 	default 2
+-	depends on NET_SOCKETS_SOCKOPT_TLS && MBEDTLS_SSL_ALPN
++	depends on NET_SOCKETS_SOCKOPT_TLS && (MBEDTLS_SSL_ALPN || WOLFSSL_ALPN)
+ 	help
+ 	  This variable sets maximum number of supported application layer
+ 	  protocols over TLS/DTLS that can be set explicitly by a socket option.
+@@ -276,12 +343,41 @@ config NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT
+ 	  used for TLS/DTLS session resumption.
+ 
+ config NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK
+-	bool "TLS certificate verification callback support"
++	bool "TLS certificate verification callback support (mbedTLS backend only)"
+ 	depends on NET_SOCKETS_SOCKOPT_TLS
+ 	help
+-	  This option controls whether TLS_CERT_VERIFY_CALLBACK TLS socket option
+-	  is available to use. It allows to register a certificate verification
+-	  callback, which is called by the TLS backend during the TLS handshake.
++	  This option controls whether the TLS_CERT_VERIFY_CALLBACK TLS
++	  socket option is available to use. When set, applications can
++	  register a certificate verification callback that is invoked by
++	  the TLS backend during the handshake.
++
++	  This option is only honored by the mbedTLS backend. On the
++	  wolfSSL backend, setsockopt(TLS_CERT_VERIFY_CALLBACK) returns
++	  -ENOTSUP. wolfSSL users should use TLS_CERT_VERIFY_CALLBACK_WOLFSSL
++	  (CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK) instead.
++
++config NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK
++	bool "wolfSSL-style cert-verify callback"
++	depends on WOLFSSL
++	depends on NET_SOCKETS_SOCKOPT_TLS
++	select WOLFSSL_ALWAYS_VERIFY_CB
++	help
++	  Enable registration of wolfSSL-style VerifyCallback functions
++	  via the TLS_CERT_VERIFY_CALLBACK_WOLFSSL socket option.
++
++	  The wolfSSL-style callback receives the standard wolfSSL
++	  arguments:
++	    int callback(int preverify_ok, WOLFSSL_X509_STORE_CTX *ctx)
++
++	  This option may be enabled alongside
++	  CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK; the mbedTLS-style
++	  TLS_CERT_VERIFY_CALLBACK setsockopt simply returns -ENOTSUP
++	  when the wolfSSL backend is active.
++
++	  When a wolfSSL-style callback is registered, TLS_CERT_VERIFY_RESULT
++	  still returns accumulated MBEDTLS_X509_BADCERT_* flags for chain
++	  errors observed during verification; the callback additionally
++	  controls whether the handshake proceeds.
+ 
+ config NET_SOCKETS_OFFLOAD
+ 	bool "Offload Socket APIs"
+diff --git a/subsys/net/lib/sockets/sockets_tls.c b/subsys/net/lib/sockets/sockets_tls.c
+index 4c8bded0e47..7d5ed85aff3 100644
+--- a/subsys/net/lib/sockets/sockets_tls.c
++++ b/subsys/net/lib/sockets/sockets_tls.c
+@@ -41,6 +41,12 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ #include <mbedtls/error.h>
+ #include <mbedtls/platform.h>
+ #include <mbedtls/ssl_cache.h>
++
++#define ZTLS_IS_CLIENT         MBEDTLS_SSL_IS_CLIENT
++#define ZTLS_IS_SERVER         MBEDTLS_SSL_IS_SERVER
++#define ZTLS_ERROR_WANT_READ   MBEDTLS_ERR_SSL_WANT_READ
++#define ZTLS_ERROR_WANT_WRITE  MBEDTLS_ERR_SSL_WANT_WRITE
++
+ #endif /* CONFIG_MBEDTLS */
+ 
+ #include "sockets_internal.h"
+@@ -51,6 +57,93 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
+ #include <zephyr_mbedtls_priv.h>
+ #endif
+ 
++#if defined(CONFIG_WOLFSSL)
++/* wolfssl/wolfcrypt/settings.h's WOLFSSL_ZEPHYR block #defines POSIX
++ * socket names (socket, bind, connect, ..., getsockname) to their
++ * zsock_* counterparts so wolfSSL's internal wolfio.c reaches Zephyr's
++ * socket API directly. Those macros would textually rewrite identically
++ * named members of struct socket_op_vtable in this file's designated
++ * initializers further below.
++ *
++ * Suppress with a hard #undef right before each wolfSSL header include
++ * rather than save-and-restore via #pragma push_macro/pop_macro: the
++ * push form would silently capture (and later reinstall) whatever
++ * upstream header had previously defined these names as macros — a
++ * future addition would be invisible at review time and break the
++ * vtable. The #undef form makes it a build error instead.
++ *
++ * List mirrors the WOLFSSL_ZEPHYR remappings as of wolfSSL master —
++ * revisit on uprev.
++ */
++#undef socket
++#undef bind
++#undef connect
++#undef listen
++#undef accept
++#undef send
++#undef recv
++#undef sendto
++#undef recvfrom
++#undef setsockopt
++#undef getsockopt
++#undef shutdown
++#undef getpeername
++#undef getsockname
++
++#ifndef WOLFSSL_USER_SETTINGS
++#include <user_settings.h>
++#endif /* !WOLFSSL_USER_SETTINGS */
++#include <wolfssl/ssl.h>
++#include <wolfssl/error-ssl.h>
++#include <wolfssl/wolfcrypt/asn.h>
++#include <wolfssl/wolfcrypt/error-crypt.h>
++#include <wolfssl/wolfcrypt/memory.h>
++#include <zephyr/net/tls_verify.h>
++
++#undef socket
++#undef bind
++#undef connect
++#undef listen
++#undef accept
++#undef send
++#undef recv
++#undef sendto
++#undef recvfrom
++#undef setsockopt
++#undef getsockopt
++#undef shutdown
++#undef getpeername
++#undef getsockname
++
++/* The leaf CN/SAN match in tls_wolfssl_verify_accumulate_cb only runs
++ * when wolfSSL invokes the verify callback. Without WOLFSSL_ALWAYS_VERIFY_CB
++ * wolfSSL only invokes it on chain errors, so a chain that validates
++ * cleanly would skip hostname verification entirely. CONFIG_WOLFSSL_ALWAYS_VERIFY_CB
++ * is selected by NET_SOCKETS_SOCKOPT_TLS in the same Kconfig stanza.
++ */
++#if !defined(WOLFSSL_ALWAYS_VERIFY_CB)
++#error "Zephyr TLS sockets with wolfSSL require WOLFSSL_ALWAYS_VERIFY_CB " \
++       "(enable CONFIG_WOLFSSL_ALWAYS_VERIFY_CB)"
++#endif /* !WOLFSSL_ALWAYS_VERIFY_CB */
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && !defined(WOLFSSL_DTLS)
++#error "DTLS sockets enabled but wolfssl DTLS not enabled"
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && !WOLFSSL_DTLS */
++
++#define ZTLS_IS_CLIENT        0
++#define ZTLS_IS_SERVER        1
++#define ZTLS_ERROR_WANT_READ  WOLFSSL_ERROR_WANT_READ
++#define ZTLS_ERROR_WANT_WRITE WOLFSSL_ERROR_WANT_WRITE
++
++/* DTLS default timeout values, copied from mbedtls to replicate existing default behavior */
++/*
++ * Default range for DTLS retransmission timer value, in milliseconds.
++ * RFC 6347 4.2.4.1 says from 1 second to 60 seconds.
++ */
++#define DTLS_TIMEOUT_DFL_MIN    1000
++#define DTLS_TIMEOUT_DFL_MAX   60000
++#endif /* CONFIG_WOLFSSL */
++
+ #define LOG_ADDR_PORT_HELPER(addr)                                \
+ 	(addr)->sa_family == NET_AF_INET ?                        \
+ 		net_sprint_ipv4_addr(&net_sin(addr)->sin_addr) :  \
+@@ -125,14 +218,14 @@ struct tls_session_cache {
+ 	size_t session_len;
+ };
+ 
+-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_MBEDTLS)
+ struct tls_dtls_cid {
+ 	bool enabled;
+ 	unsigned char cid[MAX(MBEDTLS_SSL_CID_OUT_LEN_MAX,
+ 			      MBEDTLS_SSL_CID_IN_LEN_MAX)];
+ 	size_t cid_len;
+ };
+-#endif
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && CONFIG_MBEDTLS */
+ 
+ struct tls_session_context {
+ 	sys_snode_t node;
+@@ -154,9 +247,30 @@ struct tls_session_context {
+ 	mbedtls_ssl_context ssl;
+ #endif /* CONFIG_MBEDTLS */
+ 
++#if defined(CONFIG_WOLFSSL)
++	/* The wolfSSL SSL session object. Created lazily on session init
++	 * because it needs the per-socket WOLFSSL_CTX.
++	 */
++	WOLFSSL *wssl;
++
++	/* Back-pointer to the owning socket context. Planted per-session as
++	 * the wolfSSL cert-verify callback ctx so the callbacks record flags
++	 * on exactly the session being verified (not on active_session, which
++	 * may differ during DTLS multi-session dispatch).
++	 */
++	struct tls_context *tls_ctx;
++
++	/* Accumulated mbedTLS-compatible verify result flags for the
++	 * handshake performed on this session.
++	 */
++	uint32_t verify_result_flags;
++#endif /* CONFIG_WOLFSSL */
++
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_MBEDTLS)
+ 	/* Context information for DTLS timing. */
+ 	struct dtls_timing_context dtls_timing;
++#endif /* CONFIG_MBEDTLS */
+ 
+ 	/* DTLS peer address. */
+ 	struct net_sockaddr_storage dtls_peer_addr;
+@@ -183,6 +297,27 @@ __net_socket struct tls_context {
+ 	/** Information whether underlying socket is listening. */
+ 	bool is_listening : 1;
+ 
++#if defined(CONFIG_WOLFSSL)
++	/** Local read side was shut down via shutdown(SHUT_RD/SHUT_RDWR).
++	 *  Distinct from session_closed: send() must keep working.
++	 *
++	 *  One-way flag: once set, it's cleared only when the slot is
++	 *  recycled by tls_alloc() (which memsets the struct). There is no
++	 *  "un-shutdown" path because POSIX shutdown() is one-way too.
++	 *
++	 *  The mbedTLS backend does not consult this bit; field is gated to
++	 *  the wolfSSL backend to keep struct layout under MBEDTLS identical
++	 *  to upstream.
++	 */
++	bool recv_eof : 1;
++
++	/* Set once the "TLS_HOSTNAME ignored on a server socket" warning has
++	 * been emitted for this socket, so it warns at most once per context
++	 * (not once per session, nor once globally). Cleared on tls_alloc().
++	 */
++	bool server_hostname_warned : 1;
++#endif /* CONFIG_WOLFSSL */
++
+ 	/* TLS sessions associated with this socket. In most cases there will
+ 	 * be one session allocated per TLS context. DTLS server is an exception,
+ 	 * which can have multiple TLS sessions allocated at the same time.
+@@ -251,20 +386,51 @@ __net_socket struct tls_context {
+ 		uint32_t dtls_handshake_timeout_min;
+ 		uint32_t dtls_handshake_timeout_max;
+ 
++#if defined(CONFIG_MBEDTLS)
+ 		struct tls_dtls_cid dtls_cid;
++#endif
+ 
+ 		bool dtls_handshake_on_connect;
+ #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
+ 
+-#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
++#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK) && \
++	!defined(CONFIG_WOLFSSL)
+ 		struct zsock_tls_cert_verify_cb cert_verify;
+-#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
++#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK && !CONFIG_WOLFSSL */
++#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
++		struct zsock_tls_cert_verify_cb_wolfssl cert_verify_wolfssl;
++#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
+ 	} options;
+ 
+-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_MBEDTLS)
+ 	/** mbedTLS cookie context for DTLS */
+ 	mbedtls_ssl_cookie_ctx cookie;
+-#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && CONFIG_MBEDTLS */
++
++#if defined(CONFIG_WOLFSSL)
++	/** The wolfSSL context */
++	WOLFSSL_CTX *ctx;
++
++	/** The hostname to use as the SNI */
++	byte *host_name;
++
++	/* Length in bytes of the host_name */
++	word32 host_len;
++
++#ifndef NO_PSK
++	/* The Pre Shared Key to be used */
++	byte *psk;
++
++	/* Length in bytes of the Pre Shared Key data */
++	word32 psk_len;
++
++	/* The Identity associated with the value in psk */
++	byte *psk_id;
++
++	/* The Length in bytes of the psk identity */
++	word32 psk_id_len;
++#endif /* !NO_PSK */
++#endif /* CONFIG_WOLFSSL */
+ 
+ #if defined(CONFIG_MBEDTLS)
+ 	/** mbedTLS configuration. */
+@@ -299,7 +465,31 @@ BUILD_ASSERT(CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS >= CONFIG_NET_SOCKETS_T
+ 	     "CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS cannot be smaller than "
+ 	     "CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS");
+ 
++/* Client-side session cache. mbedTLS uses it unconditionally. wolfSSL only
++ * uses it when HAVE_EXT_CACHE is defined (CONFIG_WOLFSSL_SESSION_EXPORT)
++ * because session import/export requires the wolfSSL_d2i/i2d APIs gated
++ * on that macro — without it tls_session_store/restore are no-ops and
++ * the cache stays empty, so leave it (and its mutex / reset helper) out
++ * of .bss entirely.
++ */
++#if defined(CONFIG_MBEDTLS) || \
++    (defined(CONFIG_WOLFSSL) && defined(HAVE_EXT_CACHE))
++#define TLS_SESSION_CACHE_PRESENT 1
++#else
++#define TLS_SESSION_CACHE_PRESENT 0
++#endif
++
++#if TLS_SESSION_CACHE_PRESENT
+ static struct tls_session_cache client_cache[CONFIG_NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT];
++#endif
++
++#if defined(CONFIG_WOLFSSL) && defined(HAVE_EXT_CACHE)
++/* Guards client_cache for the wolfSSL backend. Never held across socket I/O.
++ * Not used by the mbedTLS backend so that its functions remain byte-identical
++ * to upstream.
++ */
++static K_MUTEX_DEFINE(client_cache_lock);
++#endif
+ 
+ #if defined(MBEDTLS_SSL_CACHE_C)
+ static mbedtls_ssl_cache_context server_cache;
+@@ -313,8 +503,15 @@ static struct k_mutex context_lock;
+  */
+ #define TLS_WAIT_MS 100
+ 
++static int tls_release(struct tls_context *tls);
++#if defined(CONFIG_MBEDTLS)
+ static int tls_mbedtls_reset_session(struct tls_context *context);
++#endif
++#if defined(CONFIG_WOLFSSL)
++static int tls_wolfssl_reset_session(struct tls_context *context);
++#endif
+ 
++#if defined(CONFIG_MBEDTLS)
+ static void tls_session_cache_reset(void)
+ {
+ 	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
+@@ -325,6 +522,37 @@ static void tls_session_cache_reset(void)
+ 
+ 	(void)memset(client_cache, 0, sizeof(client_cache));
+ }
++#elif defined(CONFIG_WOLFSSL) && defined(HAVE_EXT_CACHE)
++static void tls_session_cache_reset(void)
++{
++	k_mutex_lock(&client_cache_lock, K_FOREVER);
++	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
++		if (client_cache[i].session != NULL) {
++			XFREE(client_cache[i].session, NULL,
++			      DYNAMIC_TYPE_TMP_BUFFER);
++		}
++	}
++
++	(void)memset(client_cache, 0, sizeof(client_cache));
++	k_mutex_unlock(&client_cache_lock);
++}
++#endif
++
++#if defined(CONFIG_WOLFSSL) && defined(WOLFSSL_TLS13) && !defined(NO_PSK)
++/* TLS 1.3 PSK ciphersuite the integration's tls_psk_*_tls13_cb returns
++ * when a PSK is selected (the TLS 1.3 PSK exchange binds the PSK to a
++ * specific hash algorithm, so the callback must pick one). Validated at
++ * tls_init() against wolfSSL's cipher table.
++ *
++ * Limitation: a single build-time constant. Applications that register
++ * multiple PSKs with different binding hashes get all of them collapsed
++ * onto the same suite. Per-context overrides are not exposed because the
++ * Zephyr TLS_CREDENTIAL_PSK API doesn't carry the suite, and adding a
++ * setsockopt would couple application code to a wolfSSL-specific knob.
++ */
++static const char tls13_psk_default_ciphersuite[] =
++	CONFIG_NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE;
++#endif /* CONFIG_WOLFSSL && WOLFSSL_TLS13 && !NO_PSK */
+ 
+ bool net_socket_is_tls(void *obj)
+ {
+@@ -332,6 +560,7 @@ bool net_socket_is_tls(void *obj)
+ }
+ 
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_MBEDTLS)
+ /* mbedTLS-defined function for setting timer. */
+ static void dtls_timing_set_delay(void *data, uint32_t int_ms, uint32_t fin_ms)
+ {
+@@ -393,6 +622,7 @@ static int dtls_get_remaining_timeout(struct tls_session_context *session_ctx)
+ 
+ 	return timing->fin_ms - elapsed_ms;
+ }
++#endif /* CONFIG_MBEDTLS */
+ 
+ static void dtls_server_init_session_timeout(struct tls_session_context *session_ctx)
+ {
+@@ -416,7 +646,9 @@ static int tls_init(void)
+ #endif
+ 
+ 	(void)memset(tls_contexts, 0, sizeof(tls_contexts));
++#if TLS_SESSION_CACHE_PRESENT
+ 	(void)memset(client_cache, 0, sizeof(client_cache));
++#endif
+ 
+ 	k_mutex_init(&context_lock);
+ 
+@@ -424,6 +656,34 @@ static int tls_init(void)
+ 	mbedtls_ssl_cache_init(&server_cache);
+ #endif
+ 
++#if defined(CONFIG_WOLFSSL) && defined(WOLFSSL_TLS13) && !defined(NO_PSK)
++	/* Validate the configured TLS 1.3 PSK ciphersuite at init: a typo in
++	 * CONFIG_NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE is a build-
++	 * time bug, not a transient runtime issue, so fail loudly here
++	 * rather than at first handshake. __ASSERT panics dev builds (CONFIG_
++	 * ASSERT=y); returning non-zero from tls_init signals SYS_INIT
++	 * failure so release builds also surface the misconfiguration.
++	 */
++	{
++		byte cs0, cs1;
++		int  cs_flags = 0;
++		int  cs_ret = wolfSSL_get_cipher_suite_from_name(
++				tls13_psk_default_ciphersuite,
++				&cs0, &cs1, &cs_flags);
++
++		__ASSERT(cs_ret == 0,
++			 "CONFIG_NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE "
++			 "is not a wolfSSL-recognized TLS 1.3 suite: \"%s\"",
++			 tls13_psk_default_ciphersuite);
++		if (cs_ret != 0) {
++			NET_ERR("CONFIG_NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE "
++				"is not a wolfSSL-recognized TLS 1.3 suite: \"%s\"",
++				tls13_psk_default_ciphersuite);
++			return -EINVAL;
++		}
++	}
++#endif /* CONFIG_WOLFSSL && WOLFSSL_TLS13 && !NO_PSK */
++
+ 	return 0;
+ }
+ 
+@@ -484,8 +744,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
+ 	mbedtls_ssl_conf_max_frag_len(config, mfl_code);
+ }
+ #else
++#if defined(CONFIG_MBEDTLS)
+ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_sock_type type) {}
+ #endif
++#endif
+ 
+ static struct tls_session_context *tls_session_alloc(void)
+ {
+@@ -499,14 +761,33 @@ static struct tls_session_context *tls_session_alloc(void)
+ 
+ 	(void)memset(session_ctx, 0, sizeof(*session_ctx));
+ 	(void)k_sem_init(&session_ctx->tls_established, 0, 1);
++#if defined(CONFIG_MBEDTLS)
+ 	mbedtls_ssl_init(&session_ctx->ssl);
++#endif
++	/* The wolfSSL session object (wssl) is created lazily in
++	 * tls_wolfssl_session_init because it needs the WOLFSSL_CTX.
++	 */
+ 
+ 	return session_ctx;
+ }
+ 
+ static void tls_session_free(struct tls_session_context *session_ctx)
+ {
++#if defined(CONFIG_MBEDTLS)
+ 	mbedtls_ssl_free(&session_ctx->ssl);
++#endif
++#if defined(CONFIG_WOLFSSL)
++	if (session_ctx->wssl != NULL) {
++		/* wolfSSL_shutdown before handshake completion can corrupt
++		 * global state.
++		 */
++		if (wolfSSL_is_init_finished(session_ctx->wssl)) {
++			(void)wolfSSL_shutdown(session_ctx->wssl);
++		}
++		wolfSSL_free(session_ctx->wssl);
++		session_ctx->wssl = NULL;
++	}
++#endif /* CONFIG_WOLFSSL */
+ 	k_mem_slab_free(&tls_session_contexts, (void *)session_ctx);
+ }
+ 
+@@ -548,6 +829,15 @@ static struct tls_context *tls_alloc(void)
+ 	k_mutex_unlock(&context_lock);
+ 
+ 	if (tls) {
++#if defined(CONFIG_WOLFSSL)
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++		tls->options.dtls_handshake_timeout_min =
++			DTLS_TIMEOUT_DFL_MIN;
++		tls->options.dtls_handshake_timeout_max =
++			DTLS_TIMEOUT_DFL_MAX;
++		tls->options.dtls_handshake_on_connect = true;
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#else
+ 		mbedtls_ssl_config_init(&tls->config);
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 		mbedtls_ssl_cookie_init(&tls->cookie);
+@@ -568,6 +858,7 @@ static struct tls_context *tls_alloc(void)
+ #if defined(CONFIG_MBEDTLS_DEBUG)
+ 		mbedtls_ssl_conf_dbg(&tls->config, zephyr_mbedtls_debug, NULL);
+ #endif
++#endif /* CONFIG_WOLFSSL */
+ 	} else {
+ 		NET_WARN("Failed to allocate TLS context");
+ 	}
+@@ -591,12 +882,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
+ 	memcpy(&target_tls->options, &source_tls->options,
+ 	       sizeof(target_tls->options));
+ 
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++#if defined(CONFIG_WOLFSSL)
++	if (target_tls->options.is_hostname_set && source_tls->host_name) {
++		target_tls->host_name = XMALLOC(source_tls->host_len + 1,
++						NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		if (target_tls->host_name == NULL) {
++			tls_release(target_tls);
++			return NULL;
++		}
++
++		XMEMCPY(target_tls->host_name, source_tls->host_name,
++			 source_tls->host_len + 1);
++		target_tls->host_len = source_tls->host_len;
++	}
++#elif defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+ 	if (target_tls->options.is_hostname_set) {
+ 		mbedtls_ssl_set_hostname(&target_tls->active_session->ssl,
+ 					 source_tls->active_session->ssl.hostname);
+ 	}
+-#endif
++#endif /* CONFIG_WOLFSSL */
+ 
+ 	return target_tls;
+ }
+@@ -616,6 +920,25 @@ static int tls_release(struct tls_context *tls)
+ 		return -EBADF;
+ 	}
+ 
++#if defined(CONFIG_WOLFSSL)
++	if (NULL != tls->host_name) {
++		XFREE(tls->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		tls->host_name = NULL;
++	}
++#ifndef NO_PSK
++	if (NULL != tls->psk) {
++		wc_ForceZero(tls->psk, tls->psk_len);
++		XFREE(tls->psk, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		tls->psk = NULL;
++		tls->psk_len = 0;
++	}
++	if (NULL != tls->psk_id) {
++		XFREE(tls->psk_id, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		tls->psk_id = NULL;
++		tls->psk_id_len = 0;
++	}
++#endif /* !NO_PSK */
++#else
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	mbedtls_ssl_cookie_free(&tls->cookie);
+ #endif
+@@ -625,6 +948,7 @@ static int tls_release(struct tls_context *tls)
+ 	mbedtls_x509_crt_free(&tls->own_cert);
+ 	mbedtls_pk_free(&tls->priv_key);
+ #endif
++#endif /* CONFIG_WOLFSSL */
+ 
+ 	while ((node = sys_slist_get(&tls->sessions)) != NULL) {
+ 		struct tls_session_context *session_ctx =
+@@ -633,11 +957,41 @@ static int tls_release(struct tls_context *tls)
+ 		tls_session_free(session_ctx);
+ 	}
+ 
++#if defined(CONFIG_WOLFSSL)
++	/* Free the CTX only after all sessions referencing it are gone.
++	 *
++	 * Detach the pointer under context_lock: the global session-cache
++	 * purge (tls_opt_session_cache_purge_set) walks tls_contexts under
++	 * that lock and may call into another socket's CTX. Detaching under
++	 * the same lock guarantees the purge either sees a valid CTX (and
++	 * finishes with it before this release proceeds) or sees NULL. The
++	 * free itself happens outside the lock.
++	 */
++	{
++		WOLFSSL_CTX *wolf_ctx;
++
++		k_mutex_lock(&context_lock, K_FOREVER);
++		wolf_ctx = tls->ctx;
++		tls->ctx = NULL;
++		k_mutex_unlock(&context_lock);
++
++		if (wolf_ctx != NULL) {
++			wolfSSL_CTX_free(wolf_ctx);
++		}
++	}
++#endif /* CONFIG_WOLFSSL */
++
+ 	tls->is_used = false;
+ 
+ 	return 0;
+ }
+ 
++#if TLS_SESSION_CACHE_PRESENT || defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++/* Used by the session-cache helpers (which exist only when the cache is
++ * present) and by dtls_is_peer_addr_valid. With both gated out (typical
++ * "TCP-TLS-only, no session resumption" build, e.g. tests/net/lib/http_server/tls
++ * under the wolfSSL overlay) this function would trip -Werror=unused-function.
++ */
+ static bool peer_addr_cmp(const struct net_sockaddr *addr,
+ 			  const struct net_sockaddr *peer_addr)
+ {
+@@ -661,7 +1015,9 @@ static bool peer_addr_cmp(const struct net_sockaddr *addr,
+ 
+ 	return false;
+ }
++#endif /* TLS_SESSION_CACHE_PRESENT || CONFIG_NET_SOCKETS_ENABLE_DTLS */
+ 
++#if defined(CONFIG_MBEDTLS)
+ static int tls_session_save(const struct net_sockaddr *peer_addr,
+ 			    mbedtls_ssl_session *session)
+ {
+@@ -830,6 +1186,230 @@ static void tls_session_purge(void)
+ 	mbedtls_ssl_cache_init(&server_cache);
+ #endif
+ }
++#endif /* CONFIG_MBEDTLS */
++
++#if defined(CONFIG_WOLFSSL)
++#if defined(HAVE_EXT_CACHE)
++/* Caller must hold client_cache_lock. Only referenced by tls_session_store,
++ * which is itself gated on HAVE_EXT_CACHE (wolfSSL_i2d_SSL_SESSION isn't
++ * available without it).
++ */
++static struct tls_session_cache *tls_wolfssl_session_entry_reserve(
++	const struct net_sockaddr *peer_addr)
++{
++	struct tls_session_cache *entry = NULL;
++
++	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
++		if (client_cache[i].session == NULL) {
++			if (entry == NULL || entry->session != NULL) {
++				entry = &client_cache[i];
++			}
++		} else {
++			if (peer_addr_cmp(net_sad(&client_cache[i].peer_addr), peer_addr)) {
++				entry = &client_cache[i];
++				break;
++			}
++
++			if (entry == NULL ||
++			    (entry->session != NULL &&
++			     entry->timestamp < client_cache[i].timestamp)) {
++				entry = &client_cache[i];
++			}
++		}
++	}
++
++	if (entry == NULL) {
++		return NULL;
++	}
++
++	if (entry->session != NULL) {
++		XFREE(entry->session, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		entry->session = NULL;
++		entry->session_len = 0;
++	}
++
++	return entry;
++}
++#endif /* HAVE_EXT_CACHE */
++
++static void tls_session_store(struct tls_context *context,
++			      const struct net_sockaddr *addr,
++			      net_socklen_t addrlen)
++{
++#if !defined(HAVE_EXT_CACHE)
++	/* wolfSSL_i2d_SSL_SESSION() is gated on HAVE_EXT_CACHE. Without it,
++	 * session resumption (CONFIG_WOLFSSL_SESSION_EXPORT) is unavailable
++	 * and this becomes a no-op. The cache_enabled setsockopt still
++	 * compiles but has no effect on this build.
++	 */
++	ARG_UNUSED(context);
++	ARG_UNUSED(addr);
++	ARG_UNUSED(addrlen);
++#else
++	WOLFSSL_SESSION *session = NULL;
++	struct tls_session_cache *entry;
++	struct net_sockaddr_storage peer_addr = { 0 };
++	unsigned char *serialized = NULL;
++	int size;
++
++	if (!context->options.cache_enabled ||
++	    context->active_session->wssl == NULL) {
++		return;
++	}
++
++	if (addrlen > sizeof(peer_addr)) {
++		return;
++	}
++
++	memcpy(&peer_addr, addr, addrlen);
++
++	session = wolfSSL_get1_session(context->active_session->wssl);
++	if (session == NULL) {
++		NET_DBG("No session to save for %p", context);
++		return;
++	}
++
++	/* Query required buffer size. */
++	size = wolfSSL_i2d_SSL_SESSION(session, NULL);
++	if (size <= 0) {
++		NET_ERR("Failed to size session for %p", context);
++		goto exit;
++	}
++
++	serialized = XMALLOC((size_t)size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	if (serialized == NULL) {
++		NET_ERR("Failed to allocate session buffer.");
++		goto exit;
++	}
++
++	{
++		unsigned char *p = serialized;
++
++		size = wolfSSL_i2d_SSL_SESSION(session, &p);
++	}
++	if (size <= 0) {
++		NET_ERR("Failed to serialize session for %p", context);
++		goto exit;
++	}
++
++	k_mutex_lock(&client_cache_lock, K_FOREVER);
++	entry = tls_wolfssl_session_entry_reserve(net_sad(&peer_addr));
++	if (entry == NULL) {
++		k_mutex_unlock(&client_cache_lock);
++		NET_ERR("No cache slot for %p", context);
++		goto exit;
++	}
++
++	entry->session = serialized;
++	entry->session_len = (size_t)size;
++	entry->timestamp = k_uptime_get();
++	memcpy(&entry->peer_addr, &peer_addr, sizeof(peer_addr));
++	serialized = NULL;
++	k_mutex_unlock(&client_cache_lock);
++
++exit:
++	if (serialized != NULL) {
++		XFREE(serialized, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	}
++	wolfSSL_SESSION_free(session);
++#endif /* HAVE_EXT_CACHE */
++}
++
++static void tls_session_restore(struct tls_context *context,
++				const struct net_sockaddr *addr,
++				net_socklen_t addrlen)
++{
++#if !defined(HAVE_EXT_CACHE)
++	ARG_UNUSED(context);
++	ARG_UNUSED(addr);
++	ARG_UNUSED(addrlen);
++#else
++	struct tls_session_cache *entry = NULL;
++	WOLFSSL_SESSION *session = NULL;
++	struct net_sockaddr_storage peer_addr = { 0 };
++	unsigned char *serialized_copy = NULL;
++	size_t serialized_len = 0;
++	const unsigned char *p;
++
++	if (!context->options.cache_enabled ||
++	    context->active_session->wssl == NULL) {
++		return;
++	}
++
++	if (addrlen > sizeof(peer_addr)) {
++		return;
++	}
++
++	memcpy(&peer_addr, addr, addrlen);
++
++	k_mutex_lock(&client_cache_lock, K_FOREVER);
++
++	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
++		if (client_cache[i].session != NULL &&
++		    peer_addr_cmp(net_sad(&client_cache[i].peer_addr),
++				  net_sad(&peer_addr))) {
++			entry = &client_cache[i];
++			break;
++		}
++	}
++
++	if (entry == NULL) {
++		k_mutex_unlock(&client_cache_lock);
++		NET_DBG("Session not found for %p", context);
++		return;
++	}
++
++	/* Copy under lock so deserialization runs without blocking others. */
++	serialized_copy = XMALLOC(entry->session_len, NULL,
++				  DYNAMIC_TYPE_TMP_BUFFER);
++	if (serialized_copy == NULL) {
++		k_mutex_unlock(&client_cache_lock);
++		NET_ERR("Failed to allocate session copy");
++		return;
++	}
++	memcpy(serialized_copy, entry->session, entry->session_len);
++	serialized_len = entry->session_len;
++	k_mutex_unlock(&client_cache_lock);
++
++	p = serialized_copy;
++	session = wolfSSL_d2i_SSL_SESSION(NULL, &p, (long)serialized_len);
++	if (session == NULL) {
++		NET_ERR("Failed to load TLS session");
++		/* Evict any stale entry that still matches this peer. */
++		k_mutex_lock(&client_cache_lock, K_FOREVER);
++		for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
++			if (client_cache[i].session != NULL &&
++			    peer_addr_cmp(net_sad(&client_cache[i].peer_addr),
++					  net_sad(&peer_addr))) {
++				XFREE(client_cache[i].session, NULL,
++				      DYNAMIC_TYPE_TMP_BUFFER);
++				client_cache[i].session = NULL;
++				client_cache[i].session_len = 0;
++				break;
++			}
++		}
++		k_mutex_unlock(&client_cache_lock);
++		XFREE(serialized_copy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		return;
++	}
++
++	if (wolfSSL_set_session(context->active_session->wssl, session) !=
++	    WOLFSSL_SUCCESS) {
++		NET_DBG("Failed to set session for %p", context);
++	}
++
++	wolfSSL_SESSION_free(session);
++	XFREE(serialized_copy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++#endif /* HAVE_EXT_CACHE */
++}
++
++static void tls_session_purge(void)
++{
++#if TLS_SESSION_CACHE_PRESENT
++	tls_session_cache_reset();
++#endif
++}
++#endif /* CONFIG_WOLFSSL */
+ 
+ static inline int time_left(uint32_t start, uint32_t timeout)
+ {
+@@ -876,11 +1456,11 @@ static int wait(int sock, int timeout, int event)
+ 
+ static int wait_for_reason(int sock, int timeout, int reason)
+ {
+-	if (reason == MBEDTLS_ERR_SSL_WANT_READ) {
++	if (reason == ZTLS_ERROR_WANT_READ) {
+ 		return wait(sock, timeout, ZSOCK_POLLIN);
+ 	}
+ 
+-	if (reason == MBEDTLS_ERR_SSL_WANT_WRITE) {
++	if (reason == ZTLS_ERROR_WANT_WRITE) {
+ 		return wait(sock, timeout, ZSOCK_POLLOUT);
+ 	}
+ 
+@@ -949,12 +1529,13 @@ static void dtls_peer_address_get(struct tls_session_context *session_ctx,
+ 	*addrlen = len;
+ }
+ 
+-static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
++#if defined(CONFIG_WOLFSSL)
++static int dtls_wolf_tx(WOLFSSL *ssl, char *buf, int len, void *ctx)
+ {
+ 	struct tls_context *tls_ctx = ctx;
+ 	ssize_t sent;
+ 
+-	if (tls_ctx->options.role == MBEDTLS_SSL_IS_SERVER) {
++	if (tls_ctx->options.role == ZTLS_IS_SERVER) {
+ 		dtls_server_refresh_session_timeout(tls_ctx->active_session);
+ 	}
+ 
+@@ -963,21 +1544,20 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
+ 			    tls_ctx->active_session->dtls_peer_addrlen);
+ 	if (sent < 0) {
+ 		if (errno == EAGAIN) {
+-			return MBEDTLS_ERR_SSL_WANT_WRITE;
++			return WOLFSSL_CBIO_ERR_WANT_WRITE;
+ 		}
+ 
+-		return MBEDTLS_ERR_NET_SEND_FAILED;
++		return WOLFSSL_CBIO_ERR_GENERAL;
+ 	}
+ 
+ 	return sent;
+ }
+ 
+-static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
++static int dtls_wolf_server_rx(WOLFSSL *ssl, char *buf, int len, void *ctx)
+ {
+ 	struct tls_context *tls_ctx = ctx;
+ 	net_socklen_t addrlen = sizeof(struct net_sockaddr);
+ 	struct net_sockaddr_storage addr = { 0 };
+-	int err;
+ 	ssize_t received;
+ 	uint8_t tmp_buf;
+ 
+@@ -987,11 +1567,26 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
+ 				  net_sad(&addr), &addrlen);
+ 	if (received < 0) {
+ 		if (errno == EAGAIN) {
+-			return MBEDTLS_ERR_SSL_WANT_READ;
++			return WOLFSSL_CBIO_ERR_WANT_READ;
+ 		}
+ 
+ 		NET_ERR("DTLS server RX: failure %d", errno);
+-		return MBEDTLS_ERR_NET_RECV_FAILED;
++		return WOLFSSL_CBIO_ERR_GENERAL;
++	}
++
++	if (received == 0) {
++		/* Empty datagram (or local read-shutdown). Consume it here —
++		 * before the peer-address check — so a spoofed zero-length
++		 * packet can neither wedge the queue head nor drive session
++		 * switching/allocation. Then signal EOF if the local read side
++		 * was shut down (recv_eof), otherwise drop it: empty datagrams
++		 * carry no TLS record and are trivially spoofable. Do NOT
++		 * refresh any session timeout for it.
++		 */
++		(void)zsock_recvfrom(tls_ctx->sock, &tmp_buf, sizeof(tmp_buf),
++				     ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
++		return tls_ctx->recv_eof ? WOLFSSL_CBIO_ERR_CONN_CLOSE
++					 : WOLFSSL_CBIO_ERR_WANT_READ;
+ 	}
+ 
+ 	/* Check if the peer address matches the current session. */
+@@ -1000,7 +1595,7 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
+ 		/* Peer address does not match the current session, exit now
+ 		 * and try to find the appropriate session or allocate a new one.
+ 		 */
+-		return MBEDTLS_ERR_SSL_WANT_READ;
++		return WOLFSSL_CBIO_ERR_WANT_READ;
+ 	}
+ 
+ 	/* If the session matches, read the actual packet. */
+@@ -1008,7 +1603,18 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
+ 				  ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
+ 	if (received < 0) {
+ 		NET_ERR("DTLS server RX: failure %d", errno);
+-		return MBEDTLS_ERR_NET_RECV_FAILED;
++		return WOLFSSL_CBIO_ERR_GENERAL;
++	}
++
++	if (received == 0) {
++		/* Defensive fallback: empty datagrams are normally consumed by
++		 * the peek branch above, but a fresh one can race in between the
++		 * peek and this read. Same handling — EOF on local read-shutdown
++		 * (recv_eof), otherwise drop the spoofable empty datagram
++		 * (WANT_READ) without refreshing the session timeout.
++		 */
++		return tls_ctx->recv_eof ? WOLFSSL_CBIO_ERR_CONN_CLOSE
++					 : WOLFSSL_CBIO_ERR_WANT_READ;
+ 	}
+ 
+ 	dtls_server_refresh_session_timeout(tls_ctx->active_session);
+@@ -1017,11 +1623,135 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
+ 	if (tls_ctx->active_session->dtls_peer_addrlen == 0) {
+ 		dtls_peer_address_set(tls_ctx->active_session, net_sad(&addr), addrlen);
+ 
+-		err = mbedtls_ssl_set_client_transport_id(&tls_ctx->active_session->ssl,
+-							 (const unsigned char *)&addr,
+-							 addrlen);
+-		if (err < 0) {
+-			return err;
++		if (wolfSSL_dtls_set_peer(ssl, (void *)&addr,
++				(unsigned int)addrlen) != WOLFSSL_SUCCESS) {
++			/* Roll back stored peer so retry doesn't
++			 * falsely match.
++			 */
++			tls_ctx->active_session->dtls_peer_addrlen = 0;
++			return WOLFSSL_CBIO_ERR_GENERAL;
++		}
++	}
++
++	return received;
++}
++
++static int dtls_wolf_client_rx(WOLFSSL *ssl, char *buf, int len, void *ctx)
++{
++	struct tls_context *tls_ctx = ctx;
++	net_socklen_t addrlen = sizeof(struct net_sockaddr);
++	struct net_sockaddr_storage addr = { 0 };
++	ssize_t received;
++
++	received = zsock_recvfrom(tls_ctx->sock, buf, len,
++				  ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
++	if (received < 0) {
++		if (errno == EAGAIN) {
++			return WOLFSSL_CBIO_ERR_WANT_READ;
++		}
++
++		return WOLFSSL_CBIO_ERR_GENERAL;
++	}
++
++	if (received == 0) {
++		/* Local read shutdown (recv_eof) → EOF; an empty UDP
++		 * datagram from the network (spoofable, carries no TLS
++		 * record) → drop and keep the session.
++		 */
++		return tls_ctx->recv_eof ? WOLFSSL_CBIO_ERR_CONN_CLOSE
++					 : WOLFSSL_CBIO_ERR_WANT_READ;
++	}
++
++	if (tls_ctx->active_session->dtls_peer_addrlen == 0) {
++		/* For clients it's incorrect to receive when
++		 * no peer has been set up.
++		 */
++		return WOLFSSL_CBIO_ERR_GENERAL;
++	}
++
++	if (!dtls_is_peer_addr_valid(tls_ctx->active_session, net_sad(&addr), addrlen)) {
++		/* Received packet from a different peer, drop and retry. */
++		return WOLFSSL_CBIO_ERR_WANT_READ;
++	}
++
++	return received;
++}
++#endif /* CONFIG_WOLFSSL */
++
++#if defined(CONFIG_MBEDTLS)
++static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
++{
++	struct tls_context *tls_ctx = ctx;
++	ssize_t sent;
++
++	if (tls_ctx->options.role == MBEDTLS_SSL_IS_SERVER) {
++		dtls_server_refresh_session_timeout(tls_ctx->active_session);
++	}
++
++	sent = zsock_sendto(tls_ctx->sock, buf, len, ZSOCK_MSG_DONTWAIT,
++			    net_sad(&tls_ctx->active_session->dtls_peer_addr),
++			    tls_ctx->active_session->dtls_peer_addrlen);
++	if (sent < 0) {
++		if (errno == EAGAIN) {
++			return MBEDTLS_ERR_SSL_WANT_WRITE;
++		}
++
++		return MBEDTLS_ERR_NET_SEND_FAILED;
++	}
++
++	return sent;
++}
++
++static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
++{
++	struct tls_context *tls_ctx = ctx;
++	net_socklen_t addrlen = sizeof(struct net_sockaddr);
++	struct net_sockaddr_storage addr = { 0 };
++	int err;
++	ssize_t received;
++	uint8_t tmp_buf;
++
++	/* Peek the packet first to check the peer address. */
++	received = zsock_recvfrom(tls_ctx->sock, &tmp_buf, sizeof(tmp_buf),
++				  ZSOCK_MSG_DONTWAIT | ZSOCK_MSG_PEEK,
++				  net_sad(&addr), &addrlen);
++	if (received < 0) {
++		if (errno == EAGAIN) {
++			return MBEDTLS_ERR_SSL_WANT_READ;
++		}
++
++		NET_ERR("DTLS server RX: failure %d", errno);
++		return MBEDTLS_ERR_NET_RECV_FAILED;
++	}
++
++	/* Check if the peer address matches the current session. */
++	if (tls_ctx->active_session->dtls_peer_addrlen != 0 &&
++	    !dtls_is_peer_addr_valid(tls_ctx->active_session, net_sad(&addr), addrlen)) {
++		/* Peer address does not match the current session, exit now
++		 * and try to find the appropriate session or allocate a new one.
++		 */
++		return MBEDTLS_ERR_SSL_WANT_READ;
++	}
++
++	/* If the session matches, read the actual packet. */
++	received = zsock_recvfrom(tls_ctx->sock, buf, len,
++				  ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
++	if (received < 0) {
++		NET_ERR("DTLS server RX: failure %d", errno);
++		return MBEDTLS_ERR_NET_RECV_FAILED;
++	}
++
++	dtls_server_refresh_session_timeout(tls_ctx->active_session);
++
++	/* Only allow to store peer address for DTLS servers. */
++	if (tls_ctx->active_session->dtls_peer_addrlen == 0) {
++		dtls_peer_address_set(tls_ctx->active_session, net_sad(&addr), addrlen);
++
++		err = mbedtls_ssl_set_client_transport_id(&tls_ctx->active_session->ssl,
++							 (const unsigned char *)&addr,
++							 addrlen);
++		if (err < 0) {
++			return err;
+ 		}
+ 	}
+ 
+@@ -1059,9 +1789,16 @@ static int dtls_client_rx(void *ctx, unsigned char *buf, size_t len)
+ 
+ 	return received;
+ }
++#endif /* CONFIG_MBEDTLS */
+ 
++#if defined(CONFIG_MBEDTLS)
+ static int tls_mbedtls_session_init(struct tls_session_context *session_ctx,
+ 				    struct tls_context *tls_ctx, bool is_server);
++#endif
++#if defined(CONFIG_WOLFSSL)
++static int tls_wolfssl_session_init(struct tls_session_context *session_ctx,
++				    struct tls_context *tls_ctx, bool is_server);
++#endif
+ 
+ /* Returns
+  * - 0 when session was switched,
+@@ -1106,6 +1843,21 @@ static int dtls_server_new_active_session(struct tls_context *tls_ctx,
+ 		return -ENOMEM;
+ 	}
+ 
++#if defined(CONFIG_WOLFSSL)
++	ret = tls_wolfssl_session_init(session_ctx, tls_ctx, true);
++	if (ret < 0) {
++		tls_session_free(session_ctx);
++		return ret;
++	}
++
++	dtls_peer_address_set(session_ctx, addr, addrlen);
++
++	if (wolfSSL_dtls_set_peer(session_ctx->wssl, (void *)addr,
++				  (unsigned int)addrlen) != WOLFSSL_SUCCESS) {
++		tls_session_free(session_ctx);
++		return -ENOMEM;
++	}
++#else
+ 	ret = tls_mbedtls_session_init(session_ctx, tls_ctx, true);
+ 	if (ret < 0) {
+ 		tls_session_free(session_ctx);
+@@ -1128,6 +1880,7 @@ static int dtls_server_new_active_session(struct tls_context *tls_ctx,
+ 					 tls_ctx->active_session->ssl.hostname);
+ 	}
+ #endif
++#endif /* CONFIG_WOLFSSL */
+ 
+ 	sys_slist_append(&tls_ctx->sessions, &session_ctx->node);
+ 	tls_ctx->active_session = session_ctx;
+@@ -1274,7 +2027,11 @@ static int dtls_server_free_active_session(struct tls_context *tls_ctx)
+ 						      session_ctx, node);
+ 	} else {
+ 		/* Last session, just reset it. */
++#if defined(CONFIG_WOLFSSL)
++		ret = tls_wolfssl_reset_session(tls_ctx);
++#else
+ 		ret = tls_mbedtls_reset_session(tls_ctx);
++#endif
+ 	}
+ 
+ 	tls_ctx->error = 0;
+@@ -1290,7 +2047,14 @@ static bool dtls_server_check_expired_sessions(struct tls_context *tls_ctx)
+ 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&tls_ctx->sessions, session_ctx, next, node) {
+ 		if (sys_timepoint_expired(session_ctx->session_expiry)) {
+ 			tls_ctx->active_session = session_ctx;
++#if defined(CONFIG_WOLFSSL)
++			if (tls_ctx->active_session->wssl != NULL &&
++			    wolfSSL_is_init_finished(tls_ctx->active_session->wssl)) {
++				(void)wolfSSL_shutdown(tls_ctx->active_session->wssl);
++			}
++#else
+ 			(void)mbedtls_ssl_close_notify(&tls_ctx->active_session->ssl);
++#endif
+ 			(void)dtls_server_free_active_session(tls_ctx);
+ 			expired = true;
+ 		}
+@@ -1300,6 +2064,7 @@ static bool dtls_server_check_expired_sessions(struct tls_context *tls_ctx)
+ }
+ #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
+ 
++#if defined(CONFIG_MBEDTLS)
+ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
+ {
+ 	struct tls_context *tls_ctx = ctx;
+@@ -1335,6 +2100,85 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
+ 
+ 	return received;
+ }
++#endif /* CONFIG_MBEDTLS */
++
++#if defined(CONFIG_WOLFSSL)
++static int tls_wolf_tx(WOLFSSL *ssl, char *buf, int len, void *ctx)
++{
++	struct tls_context *tls_ctx = ctx;
++	ssize_t sent;
++
++	sent = zsock_sendto(tls_ctx->sock, buf, len,
++			    ZSOCK_MSG_DONTWAIT, NULL, 0);
++
++	if (sent < 0) {
++		switch (errno) {
++		case EAGAIN:
++			return WOLFSSL_CBIO_ERR_WANT_WRITE;
++		case ECONNRESET:
++			return WOLFSSL_CBIO_ERR_CONN_RST;
++		case EINTR:
++			return WOLFSSL_CBIO_ERR_ISR;
++		case EPIPE:
++			return WOLFSSL_CBIO_ERR_CONN_CLOSE;
++		default:
++			return WOLFSSL_CBIO_ERR_GENERAL;
++		}
++	}
++
++	return sent;
++}
++
++static int tls_wolf_rx(WOLFSSL *ssl, char *buf, int len, void *ctx)
++{
++	struct tls_context *tls_ctx = ctx;
++	ssize_t received;
++
++	received = zsock_recvfrom(tls_ctx->sock, buf, len,
++				  ZSOCK_MSG_DONTWAIT, NULL, 0);
++
++	if (received < 0) {
++		switch (errno) {
++		case EAGAIN:
++			if (!wolfSSL_dtls(ssl)) {
++				return WOLFSSL_CBIO_ERR_WANT_READ;
++			} else {
++				return WOLFSSL_CBIO_ERR_TIMEOUT;
++			}
++		case ECONNRESET:
++			return WOLFSSL_CBIO_ERR_CONN_RST;
++		case EINTR:
++			return WOLFSSL_CBIO_ERR_ISR;
++		case ECONNREFUSED:
++			return WOLFSSL_CBIO_ERR_WANT_READ;
++		case ECONNABORTED:
++			return WOLFSSL_CBIO_ERR_CONN_CLOSE;
++		default:
++			return WOLFSSL_CBIO_ERR_GENERAL;
++		}
++	} else if (received == 0) {
++		return WOLFSSL_CBIO_ERR_CONN_CLOSE;
++	}
++
++	return received;
++}
++
++static bool crt_is_pem(const unsigned char *buf, size_t buflen)
++{
++	return (buflen != 0 && buf[buflen - 1] == '\0' &&
++		strstr((const char *)buf, "-----BEGIN CERTIFICATE-----") != NULL);
++}
++
++/* Match any PEM private-key flavor: "PRIVATE KEY-----" covers
++ * "-----BEGIN PRIVATE KEY-----", "...RSA PRIVATE KEY-----",
++ * "...EC PRIVATE KEY-----", "...ENCRYPTED PRIVATE KEY-----".
++ */
++static bool key_is_pem(const unsigned char *buf, size_t buflen)
++{
++	return (buflen != 0 && buf[buflen - 1] == '\0' &&
++		strstr((const char *)buf, "PRIVATE KEY-----") != NULL);
++}
++#endif /* CONFIG_WOLFSSL */
+ 
+ #if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
+@@ -1347,7 +2191,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
+ static int tls_add_ca_certificate(struct tls_context *tls,
+ 				  struct tls_credential *ca_cert)
+ {
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++#if defined(CONFIG_WOLFSSL)
++	int ret;
++	int format = WOLFSSL_FILETYPE_ASN1;
++
++	if (crt_is_pem(ca_cert->buf, ca_cert->len)) {
++		format = WOLFSSL_FILETYPE_PEM;
++	}
++	ret = wolfSSL_CTX_load_verify_buffer(tls->ctx, ca_cert->buf,
++					     ca_cert->len, format);
++
++	if (ret != WOLFSSL_SUCCESS) {
++		NET_ERR("Failed to install CA certificate into wolfSSL CTX "
++			"(wolfSSL_CTX_load_verify_buffer=%d)", ret);
++		return -EINVAL;
++	}
++
++	return 0;
++#elif defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+ 	int err;
+ 
+ 	if (tls->options.cert_nocopy == ZSOCK_TLS_CERT_NOCOPY_NONE ||
+@@ -1371,6 +2232,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
+ 	return -ENOTSUP;
+ }
+ 
++#if defined(CONFIG_MBEDTLS)
+ static void tls_set_ca_chain(struct tls_context *tls)
+ {
+ #if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+@@ -1379,11 +2241,27 @@ static void tls_set_ca_chain(struct tls_context *tls)
+ 				      &mbedtls_x509_crt_profile_default);
+ #endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
+ }
++#endif /* CONFIG_MBEDTLS */
+ 
+ static int tls_add_own_cert(struct tls_context *tls,
+ 			    struct tls_credential *own_cert)
+ {
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++#if defined(CONFIG_WOLFSSL)
++	int ret = 0;
++	int format = WOLFSSL_FILETYPE_ASN1;
++
++	if (crt_is_pem(own_cert->buf, own_cert->len)) {
++		format = WOLFSSL_FILETYPE_PEM;
++	}
++	ret = wolfSSL_CTX_use_certificate_buffer(tls->ctx, own_cert->buf,
++						 own_cert->len, format);
++	if (ret != WOLFSSL_SUCCESS) {
++		NET_ERR("Failed to parse certificate");
++		return -EINVAL;
++	}
++
++	return 0;
++#elif defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+ 	int err;
+ 
+ 	if (tls->options.cert_nocopy == ZSOCK_TLS_CERT_NOCOPY_NONE ||
+@@ -1406,6 +2284,7 @@ static int tls_add_own_cert(struct tls_context *tls,
+ 	return -ENOTSUP;
+ }
+ 
++#if defined(CONFIG_MBEDTLS)
+ static int tls_set_own_cert(struct tls_context *tls)
+ {
+ #if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+@@ -1420,11 +2299,27 @@ static int tls_set_own_cert(struct tls_context *tls)
+ 
+ 	return -ENOTSUP;
+ }
++#endif /* CONFIG_MBEDTLS */
+ 
+ static int tls_set_private_key(struct tls_context *tls,
+ 			       struct tls_credential *priv_key)
+ {
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++#if defined(CONFIG_WOLFSSL)
++	int ret = 0;
++	int format = WOLFSSL_FILETYPE_ASN1;
++
++	if (key_is_pem(priv_key->buf, priv_key->len)) {
++		format = WOLFSSL_FILETYPE_PEM;
++	}
++	ret = wolfSSL_CTX_use_PrivateKey_buffer(tls->ctx, priv_key->buf,
++						priv_key->len, format);
++	if (ret != WOLFSSL_SUCCESS) {
++		NET_ERR("Failed to parse private key");
++		return -EINVAL;
++	}
++
++	return 0;
++#elif defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+ 	int err;
+ 
+ 	err = mbedtls_pk_parse_key(&tls->priv_key, priv_key->buf,
+@@ -1443,6 +2338,47 @@ static int tls_set_psk(struct tls_context *tls,
+ 		       struct tls_credential *psk,
+ 		       struct tls_credential *psk_id)
+ {
++#if defined(CONFIG_WOLFSSL)
++#ifndef NO_PSK
++	if (NULL != tls->psk) {
++		wc_ForceZero(tls->psk, tls->psk_len);
++		XFREE(tls->psk, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		tls->psk = NULL;
++		tls->psk_len = 0;
++	}
++	tls->psk = (byte *)XMALLOC(
++			psk->len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	if (tls->psk == NULL) {
++		return -ENOMEM;
++	}
++
++	XMEMCPY(tls->psk, psk->buf, psk->len);
++	tls->psk_len = psk->len;
++
++	if (NULL != tls->psk_id) {
++		XFREE(tls->psk_id, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		tls->psk_id = NULL;
++		tls->psk_id_len = 0;
++	}
++	tls->psk_id = (byte *)XMALLOC(
++			psk_id->len + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	if (tls->psk_id == NULL) {
++		wc_ForceZero(tls->psk, tls->psk_len);
++		XFREE(tls->psk, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		tls->psk = NULL;
++		tls->psk_len = 0;
++		return -ENOMEM;
++	}
++
++	XMEMCPY(tls->psk_id, psk_id->buf, psk_id->len);
++	tls->psk_id[psk_id->len] = '\0';
++	tls->psk_id_len = psk_id->len;
++
++	return 0;
++#else
++	return -ENOTSUP;
++#endif /* !NO_PSK */
++#else
+ #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
+ 	int err = mbedtls_ssl_conf_psk(&tls->config,
+ 				       psk->buf, psk->len,
+@@ -1454,6 +2390,7 @@ static int tls_set_psk(struct tls_context *tls,
+ 
+ 	return 0;
+ #endif
++#endif /* CONFIG_WOLFSSL */
+ 
+ 	return -ENOTSUP;
+ }
+@@ -1496,6 +2433,7 @@ static int tls_set_credential(struct tls_context *tls,
+ 	return 0;
+ }
+ 
++#if defined(CONFIG_MBEDTLS)
+ static int tls_mbedtls_set_credentials(struct tls_context *tls)
+ {
+ 	struct tls_credential *cred;
+@@ -1890,145 +2828,131 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
+ 
+ 	return 0;
+ }
++#endif /* CONFIG_MBEDTLS */
+ 
+-static int tls_check_cert(struct tls_credential *cert)
++#if defined(CONFIG_WOLFSSL)
++#ifndef NO_PSK
++static unsigned int tls_psk_server_cb(WOLFSSL *ssl, const char *identity,
++				      unsigned char *key,
++				      unsigned int key_max_len)
+ {
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+-	mbedtls_x509_crt cert_ctx;
+-	int err;
++	struct tls_context *context = NULL;
+ 
+-	mbedtls_x509_crt_init(&cert_ctx);
++	context = (struct tls_context *)wolfSSL_get_psk_callback_ctx(ssl);
++	if (context == NULL) {
++		return 0;
++	}
+ 
+-	if (crt_is_pem(cert->buf, cert->len)) {
+-		err = mbedtls_x509_crt_parse(&cert_ctx, cert->buf, cert->len);
+-	} else {
+-		/* For DER case, use the no copy version of the parsing function
+-		 * to avoid unnecessary heap allocations.
+-		 */
+-		err = mbedtls_x509_crt_parse_der_nocopy(&cert_ctx, cert->buf,
+-							cert->len);
++	if (context->psk == NULL || context->psk_id == NULL) {
++		return 0;
+ 	}
+ 
+-	if (err != 0) {
+-		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
+-			"certificate", cert->tag, -err);
+-		return -EINVAL;
++	if (context->psk_len == 0 || context->psk_len > key_max_len) {
++		return 0;
+ 	}
+ 
+-	mbedtls_x509_crt_free(&cert_ctx);
++	if (XSTRCMP(identity, (const char *)context->psk_id) != 0) {
++		return 0;
++	}
+ 
+-	return err;
+-#else
+-	NET_ERR("TLS with certificates disabled. "
+-		"Reconfigure mbed TLS to support certificate based key exchange.");
++	XMEMCPY(key, context->psk, context->psk_len);
+ 
+-	return -ENOTSUP;
+-#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
++	return context->psk_len;
+ }
+ 
+-static int tls_check_priv_key(struct tls_credential *priv_key)
++static unsigned int tls_psk_client_cb(WOLFSSL *ssl, const char *hint,
++				      char *identity,
++				      unsigned int id_max_len,
++				      unsigned char *key,
++				      unsigned int key_max_len)
+ {
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+-	mbedtls_pk_context key_ctx;
+-	int err;
+-
+-	mbedtls_pk_init(&key_ctx);
++	struct tls_context *context = NULL;
+ 
+-	err = mbedtls_pk_parse_key(&key_ctx, priv_key->buf,
+-				   priv_key->len, NULL, 0);
+-	if (err != 0) {
+-		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
+-			"private key", priv_key->tag, -err);
+-		err = -EINVAL;
++	context = (struct tls_context *)wolfSSL_get_psk_callback_ctx(ssl);
++	if (context == NULL) {
++		return 0;
+ 	}
+ 
+-	mbedtls_pk_free(&key_ctx);
++	if (context->psk == NULL || context->psk_id == NULL) {
++		return 0;
++	}
+ 
+-	return err;
+-#else
+-	NET_ERR("TLS with certificates disabled. "
+-		"Reconfigure mbed TLS to support certificate based key exchange.");
++	if (context->psk_len == 0 || context->psk_len > key_max_len ||
++	    context->psk_id_len == 0 ||
++	    context->psk_id_len + 1 > id_max_len) {
++		return 0;
++	}
+ 
+-	return -ENOTSUP;
+-#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
++	XMEMCPY(identity, context->psk_id, context->psk_id_len);
++	identity[context->psk_id_len] = '\0';
++	XMEMCPY(key, context->psk, context->psk_len);
++
++	return context->psk_len;
+ }
+ 
+-static int tls_check_psk(struct tls_credential *psk)
++#ifdef WOLFSSL_TLS13
++/* TLS 1.3 PSK callbacks. tls13_psk_default_ciphersuite is defined above
++ * tls_init() so the latter can validate the configured suite name.
++ */
++static unsigned int tls_psk_server_tls13_cb(WOLFSSL *ssl, const char *identity,
++					    unsigned char *key,
++					    unsigned int key_max_len,
++					    const char **ciphersuite)
+ {
+-#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
+-	struct tls_credential *psk_id;
++	unsigned int key_len = tls_psk_server_cb(ssl, identity, key, key_max_len);
+ 
+-	psk_id = credential_get(psk->tag, TLS_CREDENTIAL_PSK_ID);
+-	if (psk_id == NULL) {
+-		NET_ERR("No matching PSK ID found for tag %d", psk->tag);
+-		return -EINVAL;
++	if (key_len == 0) {
++		return 0;
+ 	}
+ 
+-	if (psk->len == 0 || psk_id->len == 0) {
+-		NET_ERR("PSK or PSK ID empty on tag %d", psk->tag);
+-		return -EINVAL;
+-	}
++	*ciphersuite = tls13_psk_default_ciphersuite;
++	return key_len;
++}
+ 
+-	return 0;
+-#else
+-	NET_ERR("TLS with PSK disabled. "
+-		"Reconfigure mbed TLS to support PSK based key exchange.");
++static unsigned int tls_psk_client_tls13_cb(WOLFSSL *ssl, const char *hint,
++					    char *identity,
++					    unsigned int id_max_len,
++					    unsigned char *key,
++					    unsigned int key_max_len,
++					    const char **ciphersuite)
++{
++	unsigned int key_len = tls_psk_client_cb(ssl, hint, identity,
++						 id_max_len, key, key_max_len);
+ 
+-	return -ENOTSUP;
+-#endif
++	if (key_len == 0) {
++		return 0;
++	}
++
++	*ciphersuite = tls13_psk_default_ciphersuite;
++	return key_len;
+ }
++#endif /* WOLFSSL_TLS13 */
++#endif /* !NO_PSK */
+ 
+-static int tls_check_credentials(const sec_tag_t *sec_tags, int sec_tag_count)
++static int tls_wolfssl_set_credentials(struct tls_context *tls)
+ {
+-	int err = 0;
++	struct tls_credential *cred;
++	sec_tag_t tag;
++	int i, err = 0;
++	bool tag_found;
+ 
+ 	credentials_lock();
+ 
+-	for (int i = 0; i < sec_tag_count; i++) {
+-		sec_tag_t tag = sec_tags[i];
+-		struct tls_credential *cred = NULL;
+-		bool tag_found = false;
++	for (i = 0; i < tls->options.sec_tag_list.sec_tag_count; i++) {
++		tag = tls->options.sec_tag_list.sec_tags[i];
++		cred = NULL;
++		tag_found = false;
+ 
+ 		while ((cred = credential_next_get(tag, cred)) != NULL) {
+ 			tag_found = true;
+ 
+-			switch (cred->type) {
+-			case TLS_CREDENTIAL_CA_CERTIFICATE:
+-				__fallthrough;
+-			case TLS_CREDENTIAL_PUBLIC_CERTIFICATE:
+-				err = tls_check_cert(cred);
+-				if (err != 0) {
+-					goto exit;
+-				}
+-
+-				break;
+-			case TLS_CREDENTIAL_PRIVATE_KEY:
+-				err = tls_check_priv_key(cred);
+-				if (err != 0) {
+-					goto exit;
+-				}
+-
+-				break;
+-			case TLS_CREDENTIAL_PSK:
+-				err = tls_check_psk(cred);
+-				if (err != 0) {
+-					goto exit;
+-				}
+-
+-				break;
+-			case TLS_CREDENTIAL_PSK_ID:
+-				/* Ignore PSK ID - it will be verified together
+-				 * with PSK.
+-				 */
+-				break;
+-			default:
+-				return -EINVAL;
++			err = tls_set_credential(tls, cred);
++			if (err != 0) {
++				goto exit;
+ 			}
+ 		}
+ 
+-		/* If no credential is found with such a tag, report an error. */
+ 		if (!tag_found) {
+-			NET_ERR("No TLS credential found with tag %d", tag);
+ 			err = -ENOENT;
+ 			goto exit;
+ 		}
+@@ -2040,832 +2964,2213 @@ exit:
+ 	return err;
+ }
+ 
+-static int tls_opt_sec_tag_list_set(struct tls_context *context,
+-				    const void *optval, net_socklen_t optlen)
++static int tls_wolfssl_set_session_cache_mode(struct tls_context *context)
+ {
+-	int sec_tag_cnt;
+-	int ret;
+-
+-	if (!optval) {
+-		return -EINVAL;
++	if ((context->options.role == ZTLS_IS_SERVER) &&
++	    (0 == context->options.cache_enabled)) {
++		if (wolfSSL_CTX_set_session_cache_mode(context->ctx,
++				SSL_SESS_CACHE_OFF) != WOLFSSL_SUCCESS) {
++			return -EINVAL;
++		}
+ 	}
+ 
+-	if (optlen % sizeof(sec_tag_t) != 0) {
+-		return -EINVAL;
+-	}
++	return 0;
++}
+ 
+-	sec_tag_cnt = optlen / sizeof(sec_tag_t);
+-	if (sec_tag_cnt >
+-		ARRAY_SIZE(context->options.sec_tag_list.sec_tags)) {
+-		return -EINVAL;
++/* Server side does not auto-match a hostname against the peer
++ * (mbedTLS parity: mbedtls_ssl_set_hostname() is a client-only concept).
++ * For clients, SNI is registered here; the CN/SAN match itself is
++ * performed inside the verify callback against the leaf certificate
++ * via wolfSSL_X509_check_host(), which avoids wolfSSL_check_domain_name()'s
++ * strict FQDN syntax requirement.
++ */
++static int tls_wolfssl_set_hostname(struct tls_context *context,
++				    struct tls_session_context *session_ctx)
++{
++	if (context->options.role != ZTLS_IS_CLIENT) {
++		if (context->options.is_hostname_set &&
++		    !context->server_hostname_warned) {
++			/* mbedTLS parity: hostname is a client-side concept
++			 * (used for SNI and CN/SAN match against the server
++			 * cert). Setting it on a server socket has no effect.
++			 * Warn once per socket so an application that expects
++			 * server-side enforcement of a peer CN isn't silently
++			 * fooled.
++			 */
++			context->server_hostname_warned = true;
++			NET_WARN("TLS_HOSTNAME set on a server socket is "
++				 "ignored; no CN/SAN match is performed "
++				 "against client certs.");
++		}
++		return 0;
+ 	}
+ 
+-	ret = tls_check_credentials((const sec_tag_t *)optval, sec_tag_cnt);
+-	if (ret < 0) {
+-		return ret;
++	if (context->options.is_hostname_set) {
++		if (wolfSSL_UseSNI(session_ctx->wssl, WOLFSSL_SNI_HOST_NAME,
++				   (const char *)context->host_name,
++				   context->host_len) != WOLFSSL_SUCCESS) {
++			return -EINVAL;
++		}
+ 	}
+ 
+-	memcpy(context->options.sec_tag_list.sec_tags, optval, optlen);
+-	context->options.sec_tag_list.sec_tag_count = sec_tag_cnt;
+-
+ 	return 0;
+ }
+ 
+-static int sock_opt_protocol_get(struct tls_context *context,
+-				 void *optval, net_socklen_t *optlen)
++/* Returns true when the leaf cert's CN/SAN matches the hostname configured
++ * on this client context. Only called once a hostname is known to be set.
++ */
++static bool tls_wolfssl_leaf_hostname_matches(struct tls_context *context,
++					      WOLFSSL_X509 *cert)
+ {
+-	int protocol = (int)context->tls_version;
++	int ret;
+ 
+-	if (*optlen != sizeof(protocol)) {
+-		return -EINVAL;
++	if (cert == NULL) {
++		return false;
+ 	}
+ 
+-	*(int *)optval = protocol;
+-
+-	return 0;
++	ret = wolfSSL_X509_check_host(cert,
++				      (const char *)context->host_name,
++				      context->host_len, 0, NULL);
++	return ret == WOLFSSL_SUCCESS;
+ }
+ 
+-static int tls_opt_sec_tag_list_get(struct tls_context *context,
+-				    void *optval, net_socklen_t *optlen)
++/* If the leaf cert (depth 0) is being verified on a client context and
++ * its CN/SAN doesn't match the configured TLS_HOSTNAME, record the
++ * mbedTLS-compatible mismatch flag (on the session being verified) and
++ * clear *effective_ok. Called from both verify callbacks.
++ */
++static void tls_wolfssl_apply_leaf_hostname_check(struct tls_context *context,
++						  struct tls_session_context *session_ctx,
++						  WOLFSSL_X509_STORE_CTX *store,
++						  int *effective_ok)
+ {
+-	int len;
+-
+-	if (*optlen % sizeof(sec_tag_t) != 0 || *optlen == 0) {
+-		return -EINVAL;
++	if (store->error_depth != 0) {
++		return;
++	}
++	if (context->options.role != ZTLS_IS_CLIENT) {
++		return;
++	}
++	/* mbedTLS parity: when no TLS_HOSTNAME is configured the CN/SAN check
++	 * is skipped and chain validity alone governs (mirrors not calling
++	 * mbedtls_ssl_set_hostname()). Only enforce a match when a hostname
++	 * was actually set.
++	 */
++	if (!context->options.is_hostname_set || context->host_len == 0) {
++		return;
++	}
++	if (tls_wolfssl_leaf_hostname_matches(context, store->current_cert)) {
++		return;
+ 	}
+ 
+-	len = MIN(context->options.sec_tag_list.sec_tag_count *
+-		  sizeof(sec_tag_t), *optlen);
+-
+-	memcpy(optval, context->options.sec_tag_list.sec_tags, len);
+-	*optlen = len;
+-
+-	return 0;
++	session_ctx->verify_result_flags |= MBEDTLS_X509_BADCERT_CN_MISMATCH;
++	*effective_ok = 0;
+ }
+ 
+-static int tls_opt_hostname_set(struct tls_context *context,
+-				const void *optval, net_socklen_t optlen)
++/* Map wolfSSL verify error to mbedTLS flag bits. */
++static uint32_t tls_wolfssl_error_to_mbedtls_flags(int error)
+ {
+-	ARG_UNUSED(optlen);
+-
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+-	if (mbedtls_ssl_set_hostname(&context->active_session->ssl, optval) != 0) {
+-		return -EINVAL;
++	switch (error) {
++	case 0:
++		return 0;
++	case ASN_AFTER_DATE_E:
++		return MBEDTLS_X509_BADCERT_EXPIRED;
++	case ASN_BEFORE_DATE_E:
++		return MBEDTLS_X509_BADCERT_FUTURE;
++	case ASN_NO_SIGNER_E:
++	case ASN_SELF_SIGNED_E:
++		return MBEDTLS_X509_BADCERT_NOT_TRUSTED;
++	case CRL_CERT_REVOKED:
++	case OCSP_CERT_REVOKED:
++		return MBEDTLS_X509_BADCERT_REVOKED;
++	case DOMAIN_NAME_MISMATCH:
++		return MBEDTLS_X509_BADCERT_CN_MISMATCH;
++	case ASN_SIG_CONFIRM_E:
++	case ASN_SIG_HASH_E:
++	case ASN_SIG_KEY_E:
++		return MBEDTLS_X509_BADCERT_NOT_TRUSTED;
++	case EXT_NOT_ALLOWED:
++	case KEYUSAGE_E:
++		return MBEDTLS_X509_BADCERT_KEY_USAGE;
++	case EXTKEYUSAGE_E:
++		return MBEDTLS_X509_BADCERT_EXT_KEY_USAGE;
++	case CRL_CERT_DATE_ERR:
++		return MBEDTLS_X509_BADCRL_EXPIRED;
++	case ASN_CRL_NO_SIGNER_E:
++		return MBEDTLS_X509_BADCRL_NOT_TRUSTED;
++	case ASN_PATHLEN_SIZE_E:
++	case ASN_PATHLEN_INV_E:
++	case MAX_CHAIN_ERROR:
++	case NOT_CA_ERROR:
++		return MBEDTLS_X509_BADCERT_NOT_TRUSTED;
++	case ASN_NO_PEM_HEADER:
++		return MBEDTLS_X509_BADCERT_MISSING;
++	default:
++		return MBEDTLS_X509_BADCERT_OTHER;
+ 	}
+-#else
+-	return -ENOPROTOOPT;
+-#endif
+-
+-	context->options.is_hostname_set = true;
+-
+-	return 0;
+ }
+ 
+-static int tls_opt_ciphersuite_list_set(struct tls_context *context,
+-					const void *optval, net_socklen_t optlen)
++static int tls_wolfssl_verify_accumulate_cb(int preverify_ok,
++					     WOLFSSL_X509_STORE_CTX *store)
+ {
+-	int cipher_cnt;
++	struct tls_session_context *session_ctx;
++	struct tls_context *context;
++	int effective_ok;
+ 
+-	if (!optval) {
+-		return -EINVAL;
++	if (store == NULL || store->userCtx == NULL) {
++		return preverify_ok;
+ 	}
+ 
+-	if (optlen % sizeof(int) != 0) {
+-		return -EINVAL;
++	session_ctx = (struct tls_session_context *)store->userCtx;
++	context = session_ctx->tls_ctx;
++	effective_ok = preverify_ok;
++
++	if (!preverify_ok && store->error != 0) {
++		session_ctx->verify_result_flags |=
++			tls_wolfssl_error_to_mbedtls_flags(store->error);
+ 	}
+ 
+-	cipher_cnt = optlen / sizeof(int);
++	tls_wolfssl_apply_leaf_hostname_check(context, session_ctx, store, &effective_ok);
+ 
+-	/* + 1 for 0-termination. */
+-	if (cipher_cnt + 1 > ARRAY_SIZE(context->options.ciphersuites)) {
+-		return -EINVAL;
++	/* OPTIONAL: return 1 so handshake continues after recording flags.
++	 * Surface a warning when we're about to silently let an invalid
++	 * chain through — applications that set OPTIONAL but never read
++	 * TLS_CERT_VERIFY_RESULT will otherwise accept bad certs with no
++	 * trace. mbedTLS prints similar info at debug verbosity.
++	 */
++	if (context->options.verify_level == ZSOCK_TLS_PEER_VERIFY_OPTIONAL) {
++		if (session_ctx->verify_result_flags != 0) {
++			NET_WARN("TLS_PEER_VERIFY_OPTIONAL: accepting chain with "
++				 "verify_result_flags=0x%x; application should "
++				 "read TLS_CERT_VERIFY_RESULT before trusting the peer",
++				 session_ctx->verify_result_flags);
++		}
++		return 1;
+ 	}
+ 
+-	memcpy(context->options.ciphersuites, optval, optlen);
+-	context->options.ciphersuites[cipher_cnt] = 0;
+-
+-	mbedtls_ssl_conf_ciphersuites(&context->config,
+-				      context->options.ciphersuites);
+-	return 0;
++	return effective_ok;
+ }
+ 
+-static int tls_opt_ciphersuite_list_get(struct tls_context *context,
+-					void *optval, net_socklen_t *optlen)
++#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
++static int tls_wolfssl_verify_cb_wrapper(int preverify_ok,
++					 WOLFSSL_X509_STORE_CTX *store)
+ {
+-	const int *selected_ciphers;
+-	int cipher_cnt, i = 0;
+-	int *ciphers = optval;
++	struct tls_session_context *session_ctx;
++	struct tls_context *context;
++	zsock_tls_wolfssl_verify_cb_t user_cb;
++	void *user_ctx;
++	int effective_ok;
++	int ret;
+ 
+-	if (*optlen % sizeof(int) != 0 || *optlen == 0) {
+-		return -EINVAL;
++	if (store == NULL || store->userCtx == NULL) {
++		return preverify_ok;
+ 	}
+ 
+-	if (context->options.ciphersuites[0] == 0) {
+-		/* No specific ciphersuites configured, return all available. */
+-		selected_ciphers = mbedtls_ssl_list_ciphersuites();
+-	} else {
+-		selected_ciphers = context->options.ciphersuites;
++	session_ctx = (struct tls_session_context *)store->userCtx;
++	context = session_ctx->tls_ctx;
++	effective_ok = preverify_ok;
++
++	if (!preverify_ok && store->error != 0) {
++		session_ctx->verify_result_flags |=
++			tls_wolfssl_error_to_mbedtls_flags(store->error);
+ 	}
+ 
+-	cipher_cnt = *optlen / sizeof(int);
+-	while (selected_ciphers[i] != 0) {
+-		ciphers[i] = selected_ciphers[i];
++	/* Mirror the accumulator's leaf hostname match so the application's
++	 * verify callback sees a consistent preverify_ok regardless of
++	 * whether it overrides the default accumulator.
++	 */
++	tls_wolfssl_apply_leaf_hostname_check(context, session_ctx, store, &effective_ok);
++
++	user_cb = context->options.cert_verify_wolfssl.cb;
++	user_ctx = context->options.cert_verify_wolfssl.ctx;
++	__ASSERT(user_cb != NULL,
++		 "verify wrapper installed without a user callback");
++
++	/* The customer callback expects to access its registered ctx through
++	 * store->userCtx (wolfSSL VerifyCallback signature has no separate
++	 * user-ctx parameter). Swap it in for the duration of the call and
++	 * restore unconditionally afterwards. Restore-on-return is sufficient
++	 * because wolfSSL invokes verify callbacks synchronously per-chain
++	 * position; the callback must not longjmp out and must not modify
++	 * userCtx itself (any such modification is overwritten on restore).
++	 * These constraints are documented on the public socket option.
++	 */
++	store->userCtx = user_ctx;
++	ret = user_cb(effective_ok, store);
++	store->userCtx = session_ctx;
+ 
+-		if (++i == cipher_cnt) {
++	return ret;
++}
++#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
++
++static int tls_wolfssl_set_verify(struct tls_context *context,
++				  struct tls_session_context *session_ctx)
++{
++	int verifyLevel = -1;
++	VerifyCallback cb = NULL;
++
++	if (context->options.verify_level != -1) {
++		switch (context->options.verify_level) {
++		case ZSOCK_TLS_PEER_VERIFY_NONE:
++			verifyLevel = WOLFSSL_VERIFY_NONE;
++			break;
++		case ZSOCK_TLS_PEER_VERIFY_OPTIONAL:
++			verifyLevel = WOLFSSL_VERIFY_PEER;
++			break;
++		case ZSOCK_TLS_PEER_VERIFY_REQUIRED:
++			if (context->options.role == ZTLS_IS_SERVER) {
++				verifyLevel = WOLFSSL_VERIFY_PEER |
++					      WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT |
++					      WOLFSSL_VERIFY_FAIL_EXCEPT_PSK;
++			} else {
++				verifyLevel = WOLFSSL_VERIFY_PEER;
++			}
+ 			break;
++		default:
++			return -EINVAL;
+ 		}
+ 	}
+ 
+-	*optlen = i * sizeof(int);
++	session_ctx->verify_result_flags = 0;
+ 
+-	return 0;
+-}
++	/* SetCertCbCtx plants the session so the chosen callback records flags
++	 * on exactly the session being verified and reaches the context via
++	 * session_ctx->tls_ctx.
++	 */
++	wolfSSL_SetCertCbCtx(session_ctx->wssl, session_ctx);
+ 
+-static struct tls_session_context *get_latest_session(struct tls_context *context)
+-{
+-	struct tls_session_context *session_ctx = NULL;
+-	struct tls_session_context *latest_session_ctx = NULL;
++#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
++	if (context->options.cert_verify_wolfssl.cb != NULL) {
++		cb = tls_wolfssl_verify_cb_wrapper;
++	} else {
++		cb = tls_wolfssl_verify_accumulate_cb;
++	}
++#else
++	cb = tls_wolfssl_verify_accumulate_cb;
++#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
+ 
+-	SYS_SLIST_FOR_EACH_CONTAINER(&context->sessions, session_ctx, node) {
+-		if ((latest_session_ctx == NULL) ||
+-		    (session_ctx->handshake_timestamp >
+-		     latest_session_ctx->handshake_timestamp)) {
+-			latest_session_ctx = session_ctx;
++	if (verifyLevel != -1 || cb != NULL) {
++		if (verifyLevel == -1) {
++			/* Match mbedTLS defaults: required for clients,
++			 * none for servers.
++			 */
++			if (context->options.role == ZTLS_IS_SERVER) {
++				verifyLevel = WOLFSSL_VERIFY_NONE;
++			} else {
++				verifyLevel = WOLFSSL_VERIFY_PEER;
++			}
+ 		}
++		wolfSSL_set_verify(session_ctx->wssl, verifyLevel, cb);
+ 	}
+ 
+-	return latest_session_ctx;
++	return 0;
+ }
+ 
+-static int tls_opt_ciphersuite_used_get(struct tls_context *context,
+-					void *optval, net_socklen_t *optlen)
++static int tls_wolfssl_set_ciphersuites(struct tls_context *context,
++					struct tls_session_context *session_ctx)
+ {
+-	struct tls_session_context *session_ctx;
+-	const char *ciph;
++	/* mbedtls-style IDs are 16-bit but stored in int[]; pack each as a
++	 * big-endian 2-byte pair for wolfSSL_set_cipher_list_bytes.
++	 */
++	byte cs_bytes[CONFIG_NET_SOCKETS_TLS_MAX_CIPHERSUITES * 2];
++	int cipher_cnt = 0;
+ 
+-	if (*optlen != sizeof(int)) {
+-		return -EINVAL;
++	/* Nothing to set */
++	if (context->options.ciphersuites[0] == 0) {
++		return 0;
+ 	}
+ 
+-	session_ctx = get_latest_session(context);
+-	if (session_ctx == NULL) {
+-		return -ENOTCONN;
+-	}
++	for (int i = 0; context->options.ciphersuites[i] != 0; i++) {
++		int id = context->options.ciphersuites[i];
+ 
+-	ciph = mbedtls_ssl_get_ciphersuite(&session_ctx->ssl);
+-	if (ciph == NULL) {
+-		return -ENOTCONN;
++		/* Defensive bound: never write past cs_bytes even if the stored
++		 * list is somehow not terminated within MAX_CIPHERSUITES.
++		 */
++		if (cipher_cnt >= CONFIG_NET_SOCKETS_TLS_MAX_CIPHERSUITES) {
++			return -EINVAL;
++		}
++
++		/* All ciphersuite IDs fit in 16 bits */
++		if (id < 0 || id > 0xFFFF) {
++			return -EINVAL;
++		}
++
++		sys_put_be16((uint16_t)id, &cs_bytes[cipher_cnt * 2]);
++		cipher_cnt++;
+ 	}
+ 
+-	*(int *)optval = mbedtls_ssl_get_ciphersuite_id(ciph);
++	if (wolfSSL_set_cipher_list_bytes(session_ctx->wssl, cs_bytes,
++					  cipher_cnt * 2) != WOLFSSL_SUCCESS) {
++		return -EINVAL;
++	}
+ 
+ 	return 0;
+ }
+ 
+-static int tls_opt_alpn_list_set(struct tls_context *context,
+-				 const void *optval, net_socklen_t optlen)
++#ifdef HAVE_ALPN
++static int tls_wolfssl_set_alpn(struct tls_context *context,
++				struct tls_session_context *session_ctx)
+ {
+-	int alpn_cnt;
++	byte *alpn_buf = NULL;
++	int alpn_buf_len = 0;
++	byte *iter = NULL;
++	int len = 0;
++	int i = 0;
+ 
+-	if (!ALPN_MAX_PROTOCOLS) {
+-		return -EINVAL;
+-	}
++	if (ALPN_MAX_PROTOCOLS && context->options.alpn_list[0] != NULL) {
++		/* Convert from mbedtls format array of char * to single char *
++		 * comma delimited list */
++		i = 0;
++		while (context->options.alpn_list[i] != NULL) {
++			alpn_buf_len += XSTRLEN(context->options.alpn_list[i]) + 1;
++			i++;
++		}
+ 
+-	if (!optval) {
+-		return -EINVAL;
+-	}
++		alpn_buf = XMALLOC(alpn_buf_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		if (alpn_buf == NULL) {
++			return -ENOMEM;
++		}
+ 
+-	if (optlen % sizeof(const char *) != 0) {
+-		return -EINVAL;
+-	}
++		i = 0;
++		iter = alpn_buf;
++		while (context->options.alpn_list[i] != NULL) {
++			len = XSTRLEN(context->options.alpn_list[i]);
++			XMEMCPY(iter, context->options.alpn_list[i], len);
++			iter += len;
++			*iter++ = ',';
++			i++;
++		}
+ 
+-	alpn_cnt = optlen / sizeof(const char *);
+-	/* + 1 for NULL-termination. */
+-	if (alpn_cnt + 1 > ARRAY_SIZE(context->options.alpn_list)) {
+-		return -EINVAL;
+-	}
++		/* Replace final trailing comma with NULL terminator */
++		*(iter - 1) = '\0';
++		if (wolfSSL_UseALPN(session_ctx->wssl, alpn_buf, alpn_buf_len - 1,
++				    WOLFSSL_ALPN_FAILED_ON_MISMATCH) != WOLFSSL_SUCCESS) {
++			XFREE(alpn_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++			return -EINVAL;
++		}
+ 
+-	memcpy(context->options.alpn_list, optval, optlen);
+-	context->options.alpn_list[alpn_cnt] = NULL;
++		XFREE(alpn_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	}
+ 
+ 	return 0;
+ }
++#endif /* HAVE_ALPN */
+ 
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+-static int tls_opt_dtls_handshake_timeout_get(struct tls_context *context,
+-					      void *optval, net_socklen_t *optlen,
+-					      bool is_max)
++static int tls_wolfssl_set_dtls_timeouts(struct tls_context *context,
++					 struct tls_session_context *session_ctx)
+ {
+-	uint32_t *val = (uint32_t *)optval;
+-
+-	if (sizeof(uint32_t) != *optlen) {
+-		return -EINVAL;
+-	}
++	if (context->type == NET_SOCK_DGRAM) {
++		if (wolfSSL_dtls_set_timeout_max(session_ctx->wssl,
++				(int)context->options.dtls_handshake_timeout_max) != WOLFSSL_SUCCESS) {
++			return -EINVAL;
++		}
++		if (wolfSSL_dtls_set_timeout_init(session_ctx->wssl,
++				(int)context->options.dtls_handshake_timeout_min) != WOLFSSL_SUCCESS) {
++			return -EINVAL;
++		}
+ 
+-	if (is_max) {
+-		*val = context->options.dtls_handshake_timeout_max;
+-	} else {
+-		*val = context->options.dtls_handshake_timeout_min;
++		/* Underlying socket always acts like non-blocking due to IO callback overrides */
++		wolfSSL_dtls_set_using_nonblock(session_ctx->wssl, 1);
+ 	}
+ 
+ 	return 0;
+ }
++#endif
+ 
+-static int tls_opt_dtls_handshake_timeout_set(struct tls_context *context,
+-					      const void *optval,
+-					      net_socklen_t optlen, bool is_max)
++/* Apply a per-SSL option setter to every session that already has a live
++ * WOLFSSL object. Used by the setsockopt handlers so a live option change
++ * reaches all sessions of a multi-session (DTLS server) socket, not just
++ * the active one. Sessions created later pick the option up via
++ * tls_wolfssl_session_setup. No-op before init, when no session has a
++ * WOLFSSL object yet.
++ *
++ * Always returns 0: the authoritative effect of the setsockopt is the
++ * stored option (which every future session applies); pushing it into
++ * already-live sessions is best effort. Failing the call midway would
++ * leave the stored option and the session states inconsistent — e.g. a
++ * session whose handshake already completed may legitimately refuse a
++ * late SNI/ciphersuite update. Argument validation must therefore happen
++ * in the option handler before the option is stored, not in the setter.
++ */
++static int tls_wolfssl_apply_all_sessions(
++	struct tls_context *context,
++	int (*setter)(struct tls_context *context,
++		      struct tls_session_context *session_ctx))
+ {
+-	uint32_t *val = (uint32_t *)optval;
+-
+-	if (!optval) {
+-		return -EINVAL;
+-	}
++	struct tls_session_context *session_ctx;
++	int ret;
+ 
+-	if (sizeof(uint32_t) != optlen) {
+-		return -EINVAL;
+-	}
++	SYS_SLIST_FOR_EACH_CONTAINER(&context->sessions, session_ctx, node) {
++		if (session_ctx->wssl == NULL) {
++			continue;
++		}
+ 
+-	/* If mbedTLS context not inited, it will
+-	 * use these values upon init.
+-	 */
+-	if (is_max) {
+-		context->options.dtls_handshake_timeout_max = *val;
+-	} else {
+-		context->options.dtls_handshake_timeout_min = *val;
++		ret = setter(context, session_ctx);
++		if (ret != 0) {
++			NET_WARN("Failed to apply TLS option to live session "
++				 "%p (%d); new sessions will use it",
++				 session_ctx, ret);
++		}
+ 	}
+ 
+-	/* If mbedTLS context already inited, we need to
+-	 * update mbedTLS config for it to take effect
+-	 */
+-	mbedtls_ssl_conf_handshake_timeout(&context->config,
+-			context->options.dtls_handshake_timeout_min,
+-			context->options.dtls_handshake_timeout_max);
+-
+ 	return 0;
+ }
+ 
+-static int tls_opt_dtls_connection_id_set(struct tls_context *context,
+-					  const void *optval, net_socklen_t optlen)
++/* Apply all per-SSL-object settings. Runs both on first session init and
++ * again after wolfSSL_clear() in tls_wolfssl_reset_session — wolfSSL_clear
++ * drops per-SSL state configured after wolfSSL_new().
++ */
++static int tls_wolfssl_session_setup(struct tls_session_context *session_ctx,
++				     struct tls_context *tls_ctx, bool is_server)
+ {
+-#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
+-	int value;
++	int ret;
+ 
+-	if (optlen > 0 && optval == NULL) {
+-		return -EINVAL;
+-	}
++	/* Record the owning context so the verify callbacks (planted below in
++	 * tls_wolfssl_set_verify) can reach it for the exact session.
++	 */
++	session_ctx->tls_ctx = tls_ctx;
+ 
+-	if (optlen != sizeof(int)) {
++	if (wolfSSL_set_fd(session_ctx->wssl, tls_ctx->sock) != WOLFSSL_SUCCESS) {
+ 		return -EINVAL;
+ 	}
+ 
+-	value = *((int *)optval);
+-
+-	switch (value) {
+-	case ZSOCK_TLS_DTLS_CID_DISABLED:
+-		context->options.dtls_cid.enabled = false;
+-		context->options.dtls_cid.cid_len = 0;
+-		break;
+-	case ZSOCK_TLS_DTLS_CID_SUPPORTED:
+-		context->options.dtls_cid.enabled = true;
+-		context->options.dtls_cid.cid_len = 0;
+-		break;
+-	case ZSOCK_TLS_DTLS_CID_ENABLED:
+-		context->options.dtls_cid.enabled = true;
+-		if (context->options.dtls_cid.cid_len == 0) {
+-			/* generate random self cid */
+-#if defined(CONFIG_CSPRNG_ENABLED)
+-			sys_csrand_get(context->options.dtls_cid.cid,
+-				       MBEDTLS_SSL_CID_OUT_LEN_MAX);
+-#else
+-			sys_rand_get(context->options.dtls_cid.cid,
+-				     MBEDTLS_SSL_CID_OUT_LEN_MAX);
+-#endif
+-			context->options.dtls_cid.cid_len = MBEDTLS_SSL_CID_OUT_LEN_MAX;
+-		}
+-		break;
+-	default:
++	if (tls_ctx->type == NET_SOCK_STREAM) {
++		wolfSSL_SSLSetIORecv(session_ctx->wssl, tls_wolf_rx);
++		wolfSSL_SSLSetIOSend(session_ctx->wssl, tls_wolf_tx);
++	}
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	else if (tls_ctx->type == NET_SOCK_DGRAM) {
++		wolfSSL_SSLSetIORecv(session_ctx->wssl,
++				     is_server ? dtls_wolf_server_rx :
++						 dtls_wolf_client_rx);
++		wolfSSL_SSLSetIOSend(session_ctx->wssl, dtls_wolf_tx);
++	}
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++	else {
+ 		return -EINVAL;
+ 	}
+ 
+-	return 0;
+-#else
+-	return -ENOPROTOOPT;
+-#endif /* CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID */
+-}
++	/* Set our TLS context as the read/write context since it contains the socket */
++	wolfSSL_SetIOReadCtx(session_ctx->wssl, (void *)tls_ctx);
++	wolfSSL_SetIOWriteCtx(session_ctx->wssl, (void *)tls_ctx);
+ 
+-static int tls_opt_dtls_connection_id_value_set(struct tls_context *context,
+-						const void *optval,
+-						net_socklen_t optlen)
+-{
+-#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
+-	if (optlen > 0 && optval == NULL) {
+-		return -EINVAL;
++#ifndef NO_PSK
++	if (NULL != tls_ctx->psk) {
++		wolfSSL_set_psk_callback_ctx(session_ctx->wssl, (void *)tls_ctx);
+ 	}
++#endif /* !NO_PSK */
+ 
+-	if (optlen > MBEDTLS_SSL_CID_IN_LEN_MAX) {
+-		return -EINVAL;
++	ret = tls_wolfssl_set_verify(tls_ctx, session_ctx);
++	if (ret != 0) {
++		return ret;
+ 	}
+ 
+-	context->options.dtls_cid.cid_len = optlen;
+-	memcpy(context->options.dtls_cid.cid, optval, optlen);
++	ret = tls_wolfssl_set_hostname(tls_ctx, session_ctx);
++	if (ret != 0) {
++		return ret;
++	}
+ 
+-	return 0;
+-#else
+-	return -ENOPROTOOPT;
+-#endif /* CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID */
+-}
++	ret = tls_wolfssl_set_ciphersuites(tls_ctx, session_ctx);
++	if (ret != 0) {
++		return ret;
++	}
+ 
+-static int tls_opt_dtls_connection_id_value_get(struct tls_context *context,
+-						void *optval, net_socklen_t *optlen)
+-{
+-#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
++#ifdef HAVE_ALPN
++	ret = tls_wolfssl_set_alpn(tls_ctx, session_ctx);
++	if (ret != 0) {
++		return ret;
++	}
++#endif /* HAVE_ALPN */
+ 
+-	if (*optlen < context->options.dtls_cid.cid_len) {
+-		return -EINVAL;
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	ret = tls_wolfssl_set_dtls_timeouts(tls_ctx, session_ctx);
++	if (ret != 0) {
++		return ret;
+ 	}
+ 
+-	*optlen = context->options.dtls_cid.cid_len;
+-	memcpy(optval, context->options.dtls_cid.cid, *optlen);
++	dtls_server_init_session_timeout(session_ctx);
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
+ 
+ 	return 0;
+-#else
+-	return -ENOPROTOOPT;
+-#endif
+ }
+ 
+-static int tls_opt_dtls_peer_connection_id_value_get(struct tls_context *context,
+-						     void *optval,
+-						     net_socklen_t *optlen)
++static int tls_wolfssl_session_init(struct tls_session_context *session_ctx,
++				    struct tls_context *tls_ctx, bool is_server)
+ {
+-#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
+-	struct tls_session_context *session_ctx;
+-	int enabled = false;
+ 	int ret;
+-	size_t optlen_local;
+ 
+-	if (!context->is_initialized) {
+-		return -ENOTCONN;
++	if (session_ctx->wssl == NULL) {
++		session_ctx->wssl = wolfSSL_new(tls_ctx->ctx);
++		if (session_ctx->wssl == NULL) {
++			return -ENOMEM;
++		}
+ 	}
+ 
+-	session_ctx = get_latest_session(context);
+-	if (session_ctx == NULL) {
+-		return -ENOTCONN;
++#if defined(HAVE_SECURE_RENEGOTIATION)
++	if (wolfSSL_UseSecureRenegotiation(session_ctx->wssl) != WOLFSSL_SUCCESS) {
++		ret = -EINVAL;
++		goto err_cleanup;
+ 	}
++#endif /* HAVE_SECURE_RENEGOTIATION */
+ 
+-	if (*optlen < MBEDTLS_SSL_CID_OUT_LEN_MAX) {
+-		return -EINVAL;
++	ret = tls_wolfssl_session_setup(session_ctx, tls_ctx, is_server);
++	if (ret != 0) {
++		goto err_cleanup;
+ 	}
+ 
+-	ret = mbedtls_ssl_get_peer_cid(&session_ctx->ssl, &enabled, optval, &optlen_local);
+-	if (enabled) {
+-		*optlen = optlen_local;
+-	} else {
+-		*optlen = 0;
+-	}
++	return 0;
++
++err_cleanup:
++	wolfSSL_free(session_ctx->wssl);
++	session_ctx->wssl = NULL;
++
+ 	return ret;
+-#else
+-	return -ENOPROTOOPT;
+-#endif
+ }
+ 
+-static int tls_opt_dtls_connection_id_status_get(struct tls_context *context,
+-					  void *optval, net_socklen_t *optlen)
++static int tls_wolfssl_reset_session(struct tls_context *context)
+ {
+-#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
+-	struct tls_session_context *session_ctx;
+-	struct tls_dtls_cid cid;
+-	int ret;
+-	int val;
+-	int enabled;
+-	bool have_self_cid;
+-	bool have_peer_cid;
++	struct tls_session_context *session_ctx = context->active_session;
+ 
+-	if (sizeof(int) != *optlen) {
+-		return -EINVAL;
+-	}
++	if (session_ctx->wssl != NULL) {
++		bool is_server = context->options.role == ZTLS_IS_SERVER;
++		int ret;
+ 
+-	if (!context->is_initialized) {
+-		return -ENOTCONN;
+-	}
++		/* Bring the SSL object back to a reusable post-init state so
++		 * the next handshake on this session starts a fresh handshake
++		 * (parity with mbedtls_ssl_session_reset).
++		 */
++		if (wolfSSL_clear(session_ctx->wssl) != WOLFSSL_SUCCESS) {
++			return -EIO;
++		}
+ 
+-	session_ctx = get_latest_session(context);
+-	if (session_ctx == NULL) {
+-		return -ENOTCONN;
++		/* wolfSSL_clear drops per-SSL settings configured after
++		 * wolfSSL_new — re-apply them.
++		 */
++		ret = tls_wolfssl_session_setup(session_ctx, context, is_server);
++		if (ret != 0) {
++			return ret;
++		}
+ 	}
+ 
+-	ret = mbedtls_ssl_get_peer_cid(&session_ctx->ssl, &enabled,
+-				       cid.cid, &cid.cid_len);
+-	if (ret) {
+-		/* Handshake is not complete */
+-		return -EAGAIN;
+-	}
++	session_ctx->handshake_timestamp = 0;
++	session_ctx->verify_result_flags = 0;
+ 
+-	cid.enabled = (enabled == MBEDTLS_SSL_CID_ENABLED);
+-	have_self_cid = (context->options.dtls_cid.cid_len != 0);
+-	have_peer_cid = (cid.cid_len != 0);
++	k_sem_reset(&session_ctx->tls_established);
+ 
+-	if (!context->options.dtls_cid.enabled) {
+-		val = ZSOCK_TLS_DTLS_CID_STATUS_DISABLED;
+-	} else if (have_self_cid && have_peer_cid) {
+-		val = ZSOCK_TLS_DTLS_CID_STATUS_BIDIRECTIONAL;
+-	} else if (have_self_cid) {
+-		val = ZSOCK_TLS_DTLS_CID_STATUS_DOWNLINK;
+-	} else if (have_peer_cid) {
+-		val = ZSOCK_TLS_DTLS_CID_STATUS_UPLINK;
+-	} else {
+-		val = ZSOCK_TLS_DTLS_CID_STATUS_DISABLED;
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	/* Server role: reset the address so that a new
++	 *              client can connect w/o a need to reopen a socket
++	 * Client role: keep peer addr so socket can continue to be used
++	 *              even on handshake timeout
++	 */
++	if (context->options.role == ZTLS_IS_SERVER) {
++		(void)memset(&session_ctx->dtls_peer_addr, 0,
++			     sizeof(session_ctx->dtls_peer_addr));
++		session_ctx->dtls_peer_addrlen = 0;
+ 	}
++#endif
+ 
+-	*((int *)optval) = val;
+ 	return 0;
+-#else
+-	return -ENOPROTOOPT;
+-#endif
+ }
+ 
+-static int tls_opt_dtls_handshake_on_connect_set(struct tls_context *context,
+-						 const void *optval,
+-						 net_socklen_t optlen)
++static int tls_wolfssl_handshake(struct tls_context *context,
++				 k_timeout_t timeout)
+ {
+-	int *val = (int *)optval;
++	k_timepoint_t end;
++	int ret;
++	int err;
+ 
+-	if (!optval) {
+-		return -EINVAL;
+-	}
++	context->active_session->handshake_in_progress = true;
+ 
+-	if (sizeof(int) != optlen) {
+-		return -EINVAL;
+-	}
++	end = sys_timepoint_calc(timeout);
+ 
+-	context->options.dtls_handshake_on_connect = (bool)*val;
++	while ((ret = wolfSSL_negotiate(context->active_session->wssl)) !=
++	       WOLFSSL_SUCCESS) {
++		err = wolfSSL_get_error(context->active_session->wssl, ret);
++		if (err == WOLFSSL_ERROR_WANT_READ ||
++		    err == WOLFSSL_ERROR_WANT_WRITE) {
++			int timeout_ms;
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++			int timeout_dtls = SYS_FOREVER_MS;
++			uint32_t wait_start = 0U;
++#endif
+ 
+-	return 0;
+-}
++			/* Blocking timeout. */
++			timeout = sys_timepoint_timeout(end);
++			if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
++				ret = -EAGAIN;
++				break;
++			}
+ 
+-static int tls_opt_dtls_handshake_on_connect_get(struct tls_context *context,
+-						 void *optval,
+-						 net_socklen_t *optlen)
+-{
+-	if (*optlen != sizeof(int)) {
+-		return -EINVAL;
+-	}
++			/* Block. */
++			timeout_ms = timeout_to_ms(&timeout);
+ 
+-	*(int *)optval = context->options.dtls_handshake_on_connect;
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++			if (context->type == NET_SOCK_DGRAM) {
++				if (context->options.role == ZTLS_IS_SERVER) {
++					/* DTLS server may need to switch session. */
++					int err2 = dtls_server_switch_session_on_rx(context);
+ 
+-	return 0;
+-}
+-#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++					if (err2 == 0) {
++						/* Switched the session, repeat the loop. */
++						context->active_session->handshake_in_progress =
++							true;
++						continue;
++					}
++				}
+ 
+-static int tls_opt_alpn_list_get(struct tls_context *context,
+-				 void *optval, net_socklen_t *optlen)
+-{
+-	const char **alpn_list = context->options.alpn_list;
+-	int alpn_cnt, i = 0;
+-	const char **ret_list = optval;
++				/* wolfSSL reports the DTLS retransmission
++				 * timeout in seconds.
++				 */
++				timeout_dtls =
++					wolfSSL_dtls_get_current_timeout(
++						context->active_session->wssl) *
++					MSEC_PER_SEC;
+ 
+-	if (!ALPN_MAX_PROTOCOLS) {
+-		return -EINVAL;
+-	}
++				if (timeout_ms == SYS_FOREVER_MS) {
++					timeout_ms = timeout_dtls;
++				} else {
++					timeout_ms = MIN(timeout_dtls,
++							 timeout_ms);
++				}
++			}
+ 
+-	if (*optlen % sizeof(const char *) != 0 || *optlen == 0) {
+-		return -EINVAL;
+-	}
++			wait_start = k_uptime_get_32();
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
+ 
+-	alpn_cnt = *optlen / sizeof(const char *);
+-	while (alpn_list[i] != NULL) {
+-		ret_list[i] = alpn_list[i];
++			ret = wait_for_reason(context->sock, timeout_ms, err);
++			if (ret < 0) {
++				break;
++			}
+ 
+-		if (++i == alpn_cnt) {
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++			/* wait_for_reason() returns 0 both when the socket
++			 * became ready and when the poll timed out. Only
++			 * report a timeout to wolfSSL when the DTLS
++			 * retransmission timer elapsed — calling
++			 * wolfSSL_dtls_got_timeout() on an early data-ready
++			 * wakeup would needlessly retransmit the flight and
++			 * double wolfSSL's internal timer. Residual: if data
++			 * arrives at/after timer expiry, one retransmission
++			 * still precedes reading it; that is indistinguishable
++			 * here without an extra poll and is harmless (the
++			 * peer discards duplicate flights).
++			 */
++			if (context->type == NET_SOCK_DGRAM && ret == 0 &&
++			    timeout_dtls != SYS_FOREVER_MS &&
++			    (k_uptime_get_32() - wait_start) >=
++			    (uint32_t)timeout_dtls) {
++				ret = wolfSSL_dtls_got_timeout(
++					context->active_session->wssl);
++				if (ret != WOLFSSL_SUCCESS) {
++					err = wolfSSL_get_error(
++						context->active_session->wssl, ret);
++					if (err != WOLFSSL_ERROR_WANT_READ &&
++					    err != WOLFSSL_ERROR_WANT_WRITE) {
++						NET_ERR("DTLS handshake timeout");
++						if (tls_wolfssl_reset_session(context) == 0) {
++							context->error = ETIMEDOUT;
++							ret = -ETIMEDOUT;
++						} else {
++							context->error = ECONNABORTED;
++							ret = -ECONNABORTED;
++						}
++						break;
++					}
++				}
++			}
++#endif
++
++			continue;
++		} else {
++			NET_ERR("TLS handshake error: %d", err);
++			ret = tls_wolfssl_reset_session(context);
++			if (ret == 0) {
++				context->error = ECONNABORTED;
++				ret = -ECONNABORTED;
++				break;
++			}
++
++			/* Avoid constant loop if tls_wolfssl_reset_session fails */
++			NET_ERR("TLS reset error: %d", ret);
++			context->error = ECONNABORTED;
++			ret = -ECONNABORTED;
+ 			break;
+ 		}
+ 	}
+ 
+-	*optlen = i * sizeof(const char *);
++	if (ret == WOLFSSL_SUCCESS) {
++		ret = 0;
++		context->active_session->handshake_timestamp = k_uptime_get();
++		k_sem_give(&context->active_session->tls_established);
++	}
+ 
+-	return 0;
+-}
++	context->active_session->handshake_in_progress = false;
+ 
+-static int tls_opt_session_cache_set(struct tls_context *context,
+-				     const void *optval, net_socklen_t optlen)
+-{
+-	int *val = (int *)optval;
++	return ret;
++}
+ 
+-	if (!optval) {
+-		return -EINVAL;
++static WOLFSSL_METHOD *tls_wolfssl_get_method(struct tls_context *context,
++					      bool is_server)
++{
++	if (context->type == NET_SOCK_STREAM) {
++		switch (context->tls_version) {
++#ifdef WOLFSSL_TLS13
++		case NET_IPPROTO_TLS_1_3:
++			return is_server ? wolfTLSv1_3_server_method()
++					 : wolfTLSv1_3_client_method();
++#endif /* WOLFSSL_TLS13 */
++#ifndef WOLFSSL_NO_TLS12
++		case NET_IPPROTO_TLS_1_2:
++			return is_server ? wolfTLSv1_2_server_method()
++					 : wolfTLSv1_2_client_method();
++#endif /* !WOLFSSL_NO_TLS12 */
++		case NET_IPPROTO_TLS_1_1:
++		case NET_IPPROTO_TLS_1_0:
++			/* user_settings.h defines NO_OLD_TLS. */
++			return NULL;
++		default:
++			return NULL;
++		}
+ 	}
+-
+-	if (sizeof(int) != optlen) {
+-		return -EINVAL;
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(WOLFSSL_DTLS)
++	else if (context->type == NET_SOCK_DGRAM) {
++		switch (context->tls_version) {
++#ifndef WOLFSSL_NO_TLS12
++		case NET_IPPROTO_DTLS_1_2:
++			return is_server ? wolfDTLSv1_2_server_method()
++					 : wolfDTLSv1_2_client_method();
++#endif /* !WOLFSSL_NO_TLS12 */
++		default:
++			/* DTLS 1.0 and 1.3 are not currently wired up on the
++			 * wolfSSL backend; refuse rather than silently
++			 * substituting a different version.
++			 */
++			return NULL;
++		}
+ 	}
+-
+-	context->options.cache_enabled = (*val == ZSOCK_TLS_SESSION_CACHE_ENABLED);
+-
+-	return 0;
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && WOLFSSL_DTLS */
++	return NULL;
+ }
+ 
+-static int tls_opt_session_cache_get(struct tls_context *context,
+-				     void *optval, net_socklen_t *optlen)
++static int tls_wolfssl_init(struct tls_context *context, bool is_server)
+ {
+-	int cache_enabled = context->options.cache_enabled ?
+-			    ZSOCK_TLS_SESSION_CACHE_ENABLED :
+-			    ZSOCK_TLS_SESSION_CACHE_DISABLED;
++	WOLFSSL_METHOD *method;
++	int ret;
+ 
+-	if (*optlen != sizeof(cache_enabled)) {
+-		return -EINVAL;
+-	}
++	context->options.role = is_server ? ZTLS_IS_SERVER : ZTLS_IS_CLIENT;
+ 
+-	*(int *)optval = cache_enabled;
++#if defined(CONFIG_WOLFSSL_DEBUG)
++	wolfSSL_Debugging_ON();
++#endif /* CONFIG_WOLFSSL_DEBUG */
+ 
+-	return 0;
+-}
++	method = tls_wolfssl_get_method(context, is_server);
+ 
+-static int tls_opt_cert_verify_result_get(struct tls_context *context,
+-					  void *optval, net_socklen_t *optlen)
+-{
+-	struct tls_session_context *session_ctx;
++	if (method == NULL) {
++		return -ENOTSUP;
++	}
+ 
+-	if (*optlen != sizeof(uint32_t)) {
+-		return -EINVAL;
++	if (context->ctx == NULL) {
++		context->ctx = wolfSSL_CTX_new(method);
++		if (context->ctx == NULL) {
++			return -ENOMEM;
++		}
+ 	}
+ 
+-	session_ctx = get_latest_session(context);
+-	if (session_ctx == NULL) {
+-		return -ENOTCONN;
++	ret = tls_wolfssl_set_credentials(context);
++	if (ret != 0) {
++		goto err_cleanup;
+ 	}
+ 
+-	*(uint32_t *)optval = mbedtls_ssl_get_verify_result(&session_ctx->ssl);
++#ifndef NO_PSK
++	if (NULL != context->psk) {
++		if (is_server) {
++			wolfSSL_CTX_set_psk_server_callback(context->ctx,
++							    tls_psk_server_cb);
++#ifdef WOLFSSL_TLS13
++			wolfSSL_CTX_set_psk_server_tls13_callback(
++				context->ctx, tls_psk_server_tls13_cb);
++#endif /* WOLFSSL_TLS13 */
++		} else {
++			wolfSSL_CTX_set_psk_client_callback(context->ctx,
++							    tls_psk_client_cb);
++#ifdef WOLFSSL_TLS13
++			wolfSSL_CTX_set_psk_client_tls13_callback(
++				context->ctx, tls_psk_client_tls13_cb);
++#endif /* WOLFSSL_TLS13 */
++		}
++	}
++#endif /* !NO_PSK */
+ 
+-	return 0;
+-}
++#if defined(CONFIG_WOLFSSL_MAX_FRAGMENT_LEN)
++	if (wolfSSL_CTX_UseMaxFragment(context->ctx,
++				       CONFIG_WOLFSSL_MAX_FRAGMENT_LEN) != WOLFSSL_SUCCESS) {
++		ret = -EINVAL;
++		goto err_cleanup;
++	}
++#endif /* CONFIG_WOLFSSL_MAX_FRAGMENT_LEN */
+ 
+-static int tls_opt_session_cache_purge_set(struct tls_context *context,
+-					   const void *optval, net_socklen_t optlen)
+-{
+-	ARG_UNUSED(context);
+-	ARG_UNUSED(optval);
+-	ARG_UNUSED(optlen);
++	ret = tls_wolfssl_set_session_cache_mode(context);
++	if (ret != 0) {
++		goto err_cleanup;
++	}
+ 
+-	tls_session_purge();
++	ret = tls_wolfssl_session_init(context->active_session, context,
++				       is_server);
++	if (ret != 0) {
++		goto err_cleanup;
++	}
+ 
+-	return 0;
+-}
++	context->is_initialized = true;
+ 
+-static int tls_opt_peer_verify_set(struct tls_context *context,
+-				   const void *optval, net_socklen_t optlen)
+-{
+-	int *peer_verify;
++	return 0;
+ 
+-	if (!optval) {
+-		return -EINVAL;
++err_cleanup:
++	if (context->ctx != NULL) {
++		wolfSSL_CTX_free(context->ctx);
++		context->ctx = NULL;
+ 	}
+ 
+-	if (optlen != sizeof(int)) {
+-		return -EINVAL;
+-	}
++	return ret;
++}
++#endif /* CONFIG_WOLFSSL */
++
++#if defined(CONFIG_WOLFSSL)
++/* wolfSSL_X509_load_certificate_buffer is gated in
++ * modules/crypto/wolfssl/src/x509.c around line 6055 on
++ *   OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || WOLFSSL_WPAS_SMALL ||
++ *   KEEP_PEER_CERT || SESSION_CERTS
++ * (the OPENSSL_EXTRA_X509_SMALL arm is our downstream patch). The Zephyr
++ * TLS sockets backend force-selects WOLFSSL_OPENSSL_EXTRA_X509_SMALL, so
++ * the function is normally available — but if a wolfSSL uprev drops the
++ * downstream patch and no user-supplied flag fills the gap, the build
++ * would fail with an obscure linker error. Fail loudly here instead.
++ */
++#if !defined(OPENSSL_EXTRA) && !defined(OPENSSL_EXTRA_X509_SMALL) && \
++    !defined(WOLFSSL_WPAS_SMALL) && !defined(KEEP_PEER_CERT) && \
++    !defined(SESSION_CERTS)
++#error "tls_check_cert needs wolfSSL_X509_load_certificate_buffer. Either "\
++       "re-apply the modules/crypto/wolfssl/src/x509.c gate-relaxation "\
++       "patch (OPENSSL_EXTRA_X509_SMALL) or enable one of OPENSSL_EXTRA, "\
++       "WOLFSSL_WPAS_SMALL, KEEP_PEER_CERT, SESSION_CERTS."
++#endif /* X509 gate flags */
++#endif /* CONFIG_WOLFSSL */
+ 
+-	peer_verify = (int *)optval;
++static int tls_check_cert(struct tls_credential *cert)
++{
++#if defined(CONFIG_WOLFSSL)
++	/* Parse the cert here so setsockopt(TLS_SEC_TAG_LIST) returns EINVAL
++	 * on malformed credentials (mbedTLS-parity contract exercised by
++	 * test_tls_bad_cred). The X509 is freed immediately so no peer-cert
++	 * retention is needed — the OPENSSL_EXTRA_X509_SMALL arm of the gate
++	 * (see modules/crypto/wolfssl/src/x509.c:6055) is our downstream
++	 * relaxation so KEEP_PEER_CERT isn't forced just for validation.
++	 */
++	WOLFSSL_X509 *x509;
++	int fmt;
+ 
+-	if (*peer_verify != MBEDTLS_SSL_VERIFY_NONE &&
+-	    *peer_verify != MBEDTLS_SSL_VERIFY_OPTIONAL &&
+-	    *peer_verify != MBEDTLS_SSL_VERIFY_REQUIRED) {
++	fmt = crt_is_pem(cert->buf, cert->len) ?
++	      WOLFSSL_FILETYPE_PEM : WOLFSSL_FILETYPE_ASN1;
++
++	x509 = wolfSSL_X509_load_certificate_buffer(cert->buf,
++						     (int)cert->len, fmt);
++	if (x509 == NULL) {
++		NET_ERR("Failed to parse %s on tag %d",
++			"certificate", cert->tag);
+ 		return -EINVAL;
+ 	}
+ 
+-	context->options.verify_level = *peer_verify;
++	wolfSSL_X509_free(x509);
+ 
+ 	return 0;
+-}
++#else
++#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++	mbedtls_x509_crt cert_ctx;
++	int err;
+ 
+-static int tls_opt_cert_nocopy_set(struct tls_context *context,
+-				   const void *optval, net_socklen_t optlen)
+-{
+-	int *cert_nocopy;
++	mbedtls_x509_crt_init(&cert_ctx);
+ 
+-	if (!optval) {
+-		return -EINVAL;
++	if (crt_is_pem(cert->buf, cert->len)) {
++		err = mbedtls_x509_crt_parse(&cert_ctx, cert->buf, cert->len);
++	} else {
++		/* For DER case, use the no copy version of the parsing function
++		 * to avoid unnecessary heap allocations.
++		 */
++		err = mbedtls_x509_crt_parse_der_nocopy(&cert_ctx, cert->buf,
++							cert->len);
+ 	}
+ 
+-	if (optlen != sizeof(int)) {
++	if (err != 0) {
++		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
++			"certificate", cert->tag, -err);
+ 		return -EINVAL;
+ 	}
+ 
+-	cert_nocopy = (int *)optval;
+-
+-	if (*cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_NONE &&
+-	    *cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_OPTIONAL) {
+-		return -EINVAL;
+-	}
++	mbedtls_x509_crt_free(&cert_ctx);
+ 
+-	context->options.cert_nocopy = *cert_nocopy;
++	return err;
++#else
++	NET_ERR("TLS with certificates disabled. "
++		"Reconfigure mbed TLS to support certificate based key exchange.");
+ 
+-	return 0;
++	return -ENOTSUP;
++#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
++#endif /* CONFIG_WOLFSSL */
+ }
+ 
+-static int tls_opt_dtls_role_set(struct tls_context *context,
+-				 const void *optval, net_socklen_t optlen)
++static int tls_check_priv_key(struct tls_credential *priv_key)
+ {
+-	int *role;
++#if defined(CONFIG_WOLFSSL)
++	WOLFSSL_CTX *tmp_ctx;
++	int fmt;
++	int ret;
+ 
+-	if (!optval) {
+-		return -EINVAL;
++	tmp_ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
++	if (tmp_ctx == NULL) {
++		return -ENOMEM;
+ 	}
+ 
+-	if (optlen != sizeof(int)) {
+-		return -EINVAL;
+-	}
++	fmt = key_is_pem(priv_key->buf, priv_key->len) ?
++	      WOLFSSL_FILETYPE_PEM : WOLFSSL_FILETYPE_ASN1;
+ 
+-	role = (int *)optval;
+-	if (*role != MBEDTLS_SSL_IS_CLIENT &&
+-	    *role != MBEDTLS_SSL_IS_SERVER) {
++	ret = wolfSSL_CTX_use_PrivateKey_buffer(tmp_ctx, priv_key->buf,
++						(long)priv_key->len, fmt);
++	wolfSSL_CTX_free(tmp_ctx);
++
++	if (ret != WOLFSSL_SUCCESS) {
++		NET_ERR("Failed to parse %s on tag %d",
++			"private key", priv_key->tag);
+ 		return -EINVAL;
+ 	}
+ 
+-	context->options.role = *role;
+-
+ 	return 0;
+-}
++#elif defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++	mbedtls_pk_context key_ctx;
++	int err;
+ 
+-#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
+-static int tls_opt_cert_verify_callback_set(struct tls_context *context,
+-					    const void *optval,
+-					    net_socklen_t optlen)
++	mbedtls_pk_init(&key_ctx);
++
++	err = mbedtls_pk_parse_key(&key_ctx, priv_key->buf,
++				   priv_key->len, NULL, 0);
++	if (err != 0) {
++		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
++			"private key", priv_key->tag, -err);
++		err = -EINVAL;
++	}
++
++	mbedtls_pk_free(&key_ctx);
++
++	return err;
++#else
++	NET_ERR("TLS with certificates disabled. "
++		"Reconfigure mbed TLS to support certificate based key exchange.");
++
++	return -ENOTSUP;
++#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
++}
++
++static int tls_check_psk(struct tls_credential *psk)
+ {
+-	struct zsock_tls_cert_verify_cb *cert_verify;
++#if defined(CONFIG_WOLFSSL)
++	struct tls_credential *psk_id;
+ 
+-	if (!optval) {
++	psk_id = credential_get(psk->tag, TLS_CREDENTIAL_PSK_ID);
++	if (psk_id == NULL) {
++		NET_ERR("No matching PSK ID found for tag %d", psk->tag);
+ 		return -EINVAL;
+ 	}
+ 
+-	if (optlen != sizeof(struct zsock_tls_cert_verify_cb)) {
++	if (psk->len == 0 || psk_id->len == 0) {
++		NET_ERR("PSK or PSK ID empty on tag %d", psk->tag);
+ 		return -EINVAL;
+ 	}
+ 
+-	cert_verify = (struct zsock_tls_cert_verify_cb *)optval;
+-	if (cert_verify->cb == NULL) {
++	return 0;
++#elif defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
++	struct tls_credential *psk_id;
++
++	psk_id = credential_get(psk->tag, TLS_CREDENTIAL_PSK_ID);
++	if (psk_id == NULL) {
++		NET_ERR("No matching PSK ID found for tag %d", psk->tag);
+ 		return -EINVAL;
+ 	}
+ 
+-	context->options.cert_verify = *cert_verify;
++	if (psk->len == 0 || psk_id->len == 0) {
++		NET_ERR("PSK or PSK ID empty on tag %d", psk->tag);
++		return -EINVAL;
++	}
+ 
+ 	return 0;
+-}
+-#else /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
+-static int tls_opt_cert_verify_callback_set(struct tls_context *context,
+-					    const void *optval,
+-					    net_socklen_t optlen)
+-{
+-	NET_ERR("TLS_CERT_VERIFY_CALLBACK option requires "
+-		"CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK enabled");
++#else
++	NET_ERR("TLS with PSK disabled. "
++		"Reconfigure mbed TLS to support PSK based key exchange.");
+ 
+-	return -ENOPROTOOPT;
++	return -ENOTSUP;
++#endif
+ }
+-#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
+ 
+-static int protocol_check(int family, int type, int *proto)
++static int tls_check_credentials(const sec_tag_t *sec_tags, int sec_tag_count)
+ {
+-	if (family != NET_AF_INET && family != NET_AF_INET6) {
+-		return -EAFNOSUPPORT;
+-	}
++	int err = 0;
+ 
+-	if (*proto >= NET_IPPROTO_TLS_1_0 && *proto <= NET_IPPROTO_TLS_1_3) {
+-		if (type != NET_SOCK_STREAM) {
+-			return -EPROTOTYPE;
+-		}
++	credentials_lock();
+ 
+-		*proto = NET_IPPROTO_TCP;
+-	} else if (*proto >= NET_IPPROTO_DTLS_1_0 && *proto <= NET_IPPROTO_DTLS_1_2) {
+-		if (!IS_ENABLED(CONFIG_NET_SOCKETS_ENABLE_DTLS)) {
+-			return -EPROTONOSUPPORT;
+-		}
++	for (int i = 0; i < sec_tag_count; i++) {
++		sec_tag_t tag = sec_tags[i];
++		struct tls_credential *cred = NULL;
++		bool tag_found = false;
+ 
+-		if (type != NET_SOCK_DGRAM) {
+-			return -EPROTOTYPE;
++		while ((cred = credential_next_get(tag, cred)) != NULL) {
++			tag_found = true;
++
++			switch (cred->type) {
++			case TLS_CREDENTIAL_CA_CERTIFICATE:
++				__fallthrough;
++			case TLS_CREDENTIAL_PUBLIC_CERTIFICATE:
++				err = tls_check_cert(cred);
++				if (err != 0) {
++					goto exit;
++				}
++
++				break;
++			case TLS_CREDENTIAL_PRIVATE_KEY:
++				err = tls_check_priv_key(cred);
++				if (err != 0) {
++					goto exit;
++				}
++
++				break;
++			case TLS_CREDENTIAL_PSK:
++				err = tls_check_psk(cred);
++				if (err != 0) {
++					goto exit;
++				}
++
++				break;
++			case TLS_CREDENTIAL_PSK_ID:
++				/* Ignore PSK ID - it will be verified together
++				 * with PSK.
++				 */
++				break;
++			default:
++				return -EINVAL;
++			}
+ 		}
+ 
+-		*proto = NET_IPPROTO_UDP;
+-	} else {
+-		return -EPROTONOSUPPORT;
++		/* If no credential is found with such a tag, report an error. */
++		if (!tag_found) {
++			NET_ERR("No TLS credential found with tag %d", tag);
++			err = -ENOENT;
++			goto exit;
++		}
+ 	}
+ 
+-	return 0;
++exit:
++	credentials_unlock();
++
++	return err;
+ }
+ 
+-static int ztls_socket(int family, int type, int proto)
++static int tls_opt_sec_tag_list_set(struct tls_context *context,
++				    const void *optval, net_socklen_t optlen)
+ {
+-	enum net_ip_protocol_secure tls_proto = proto;
+-	int fd = zvfs_reserve_fd();
+-	int sock = -1;
++	int sec_tag_cnt;
+ 	int ret;
+-	struct tls_context *ctx;
+ 
+-	if (fd < 0) {
+-		return -1;
++	if (!optval) {
++		return -EINVAL;
+ 	}
+ 
+-	ret = protocol_check(family, type, &proto);
+-	if (ret < 0) {
+-		errno = -ret;
+-		goto free_fd;
++	if (optlen % sizeof(sec_tag_t) != 0) {
++		return -EINVAL;
+ 	}
+ 
+-	ctx = tls_alloc();
+-	if (ctx == NULL) {
+-		errno = ENOMEM;
+-		goto free_fd;
++	sec_tag_cnt = optlen / sizeof(sec_tag_t);
++	if (sec_tag_cnt >
++		ARRAY_SIZE(context->options.sec_tag_list.sec_tags)) {
++		return -EINVAL;
+ 	}
+ 
+-	sock = zsock_socket(family, type, proto);
+-	if (sock < 0) {
+-		goto release_tls;
++	ret = tls_check_credentials((const sec_tag_t *)optval, sec_tag_cnt);
++	if (ret < 0) {
++		return ret;
+ 	}
+ 
+-	ctx->tls_version = tls_proto;
+-	ctx->type = (proto == NET_IPPROTO_TCP) ? NET_SOCK_STREAM : NET_SOCK_DGRAM;
+-	ctx->sock = sock;
++	memcpy(context->options.sec_tag_list.sec_tags, optval, optlen);
++	context->options.sec_tag_list.sec_tag_count = sec_tag_cnt;
+ 
+-	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+-			    ZVFS_MODE_IFSOCK);
++	return 0;
++}
+ 
+-	return fd;
++static int sock_opt_protocol_get(struct tls_context *context,
++				 void *optval, net_socklen_t *optlen)
++{
++	int protocol = (int)context->tls_version;
+ 
+-release_tls:
+-	(void)tls_release(ctx);
++	if (*optlen != sizeof(protocol)) {
++		return -EINVAL;
++	}
+ 
+-free_fd:
+-	zvfs_free_fd(fd);
++	*(int *)optval = protocol;
+ 
+-	return -1;
++	return 0;
+ }
+ 
+-int ztls_close_ctx(struct tls_context *ctx, int sock)
++static int tls_opt_sec_tag_list_get(struct tls_context *context,
++				    void *optval, net_socklen_t *optlen)
+ {
+-	struct tls_session_context *session_ctx = NULL;
+-	int ret, err = 0;
+-
+-	/* Try to send close notification. */
+-	ctx->flags = 0;
++	int len;
+ 
+-	SYS_SLIST_FOR_EACH_CONTAINER(&ctx->sessions, session_ctx, node) {
+-		(void)mbedtls_ssl_close_notify(&session_ctx->ssl);
++	if (*optlen % sizeof(sec_tag_t) != 0 || *optlen == 0) {
++		return -EINVAL;
+ 	}
+ 
+-	err = tls_release(ctx);
+-	ret = zsock_close(ctx->sock);
+-
+-	if (ret == 0) {
+-		(void)sock_obj_core_dealloc(sock);
+-	}
++	len = MIN(context->options.sec_tag_list.sec_tag_count *
++		  sizeof(sec_tag_t), *optlen);
+ 
+-	/* In case close fails, we propagate errno value set by close.
+-	 * In case close succeeds, but tls_release fails, set errno
+-	 * according to tls_release return value.
+-	 */
+-	if (ret == 0 && err < 0) {
+-		errno = -err;
+-		ret = -1;
+-	}
++	memcpy(optval, context->options.sec_tag_list.sec_tags, len);
++	*optlen = len;
+ 
+-	return ret;
++	return 0;
+ }
+ 
+-int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
+-		     net_socklen_t addrlen)
++static int tls_opt_hostname_set(struct tls_context *context,
++				const void *optval, net_socklen_t optlen)
+ {
+-	int ret;
+-	int sock_flags;
+-	bool is_non_block;
+-
+-	sock_flags = zsock_fcntl(ctx->sock, ZVFS_F_GETFL, 0);
+-	if (sock_flags < 0) {
+-		return -EIO;
++#if defined(CONFIG_WOLFSSL)
++	if (NULL != context->host_name) {
++		XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++		context->host_name = NULL;
++		context->host_len = 0;
+ 	}
+ 
+-	is_non_block = sock_flags & ZVFS_O_NONBLOCK;
+-	if (is_non_block) {
+-		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL,
+-				  sock_flags & ~ZVFS_O_NONBLOCK);
++	if (optval == NULL) {
++		context->options.is_hostname_set = false;
++		return 0;
+ 	}
+ 
+-	ret = zsock_connect(ctx->sock, addr, addrlen);
+-	if (ret < 0) {
+-		return ret;
++	/* The mbedTLS backend treats optval as a C string and ignores
++	 * optlen entirely. Tolerate a NUL-terminated optval here too so
++	 * an application passing strlen() + 1 doesn't end up with a NUL
++	 * byte embedded in the SNI / hostname match on this backend only.
++	 */
++	if (optlen > 0 && ((const char *)optval)[optlen - 1] == '\0') {
++		optlen--;
+ 	}
+ 
+-	if (is_non_block) {
+-		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL, sock_flags);
++	/* RFC 6066 SNI HostName is at most 2^16 - 1; reject anything larger
++	 * so the unchecked `optlen + 1` below cannot wrap. net_socklen_t is
++	 * unsigned, so the lower bound is implicit.
++	 */
++	if (optlen > UINT16_MAX) {
++		return -EINVAL;
+ 	}
+ 
+-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+-	if (ctx->type == NET_SOCK_DGRAM) {
+-		dtls_peer_address_set(ctx->active_session, addr, addrlen);
++	/* +1 for NUL — wolfSSL APIs require C strings. */
++	context->host_name = XMALLOC(optlen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	if (context->host_name == NULL) {
++		context->options.is_hostname_set = false;
++		return -ENOMEM;
+ 	}
+-#endif
+ 
+-	if (ctx->type == NET_SOCK_STREAM
+-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+-	    || (ctx->type == NET_SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
+-#endif
+-	    ) {
++	XMEMCPY(context->host_name, optval, optlen);
++	context->host_name[optlen] = '\0';
++	context->host_len = optlen;
++	context->options.is_hostname_set = true;
++
++	return tls_wolfssl_apply_all_sessions(context,
++					      tls_wolfssl_set_hostname);
++#else
++	ARG_UNUSED(optlen);
++
++#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
++	if (mbedtls_ssl_set_hostname(&context->active_session->ssl, optval) != 0) {
++		return -EINVAL;
++	}
++#else
++	return -ENOPROTOOPT;
++#endif
++
++	context->options.is_hostname_set = true;
++
++	return 0;
++#endif /* CONFIG_WOLFSSL */
++}
++
++static int tls_opt_ciphersuite_list_set(struct tls_context *context,
++					const void *optval, net_socklen_t optlen)
++{
++	int cipher_cnt;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen % sizeof(int) != 0) {
++		return -EINVAL;
++	}
++
++	cipher_cnt = optlen / sizeof(int);
++
++	/* + 1 for 0-termination. */
++	if (cipher_cnt + 1 > ARRAY_SIZE(context->options.ciphersuites)) {
++		return -EINVAL;
++	}
++
++#if defined(CONFIG_WOLFSSL)
++	/* Validate before storing — tls_wolfssl_apply_all_sessions is
++	 * best-effort and must not be relied on for argument validation.
++	 */
++	for (int i = 0; i < cipher_cnt; i++) {
++		int id = ((const int *)optval)[i];
++
++		/* All ciphersuite IDs fit in 16 bits */
++		if (id < 0 || id > 0xFFFF) {
++			return -EINVAL;
++		}
++	}
++
++	XMEMCPY(context->options.ciphersuites, optval, optlen);
++	context->options.ciphersuites[cipher_cnt] = 0;
++
++	return tls_wolfssl_apply_all_sessions(context,
++					      tls_wolfssl_set_ciphersuites);
++#else
++	memcpy(context->options.ciphersuites, optval, optlen);
++	context->options.ciphersuites[cipher_cnt] = 0;
++
++	mbedtls_ssl_conf_ciphersuites(&context->config,
++				      context->options.ciphersuites);
++	return 0;
++#endif /* CONFIG_WOLFSSL */
++}
++
++static int tls_opt_ciphersuite_list_get(struct tls_context *context,
++					void *optval, net_socklen_t *optlen)
++{
++	const int *selected_ciphers;
++	int cipher_cnt, i = 0;
++	int *ciphers = optval;
++
++	if (*optlen % sizeof(int) != 0 || *optlen == 0) {
++		return -EINVAL;
++	}
++
++#if defined(CONFIG_WOLFSSL)
++	if (context->options.ciphersuites[0] != 0) {
++		/* Return user-configured ciphersuites */
++		selected_ciphers = context->options.ciphersuites;
++		cipher_cnt = *optlen / sizeof(int);
++		while (selected_ciphers[i] != 0) {
++			ciphers[i] = selected_ciphers[i];
++			if (++i == cipher_cnt) {
++				break;
++			}
++		}
++		*optlen = i * sizeof(int);
++		return 0;
++	} else {
++		const char *cipherName;
++		int numCipherSuites = 0;
++		byte b1, b2;
++		int flags = 0;
++
++		cipher_cnt = *optlen / sizeof(int);
++
++		while ((cipherName = wolfSSL_get_cipher_list(numCipherSuites)) != NULL) {
++			if (wolfSSL_get_cipher_suite_from_name(cipherName,
++							       &b1, &b2,
++							       &flags) != 0) {
++				numCipherSuites++;
++				continue;
++			}
++
++			byte cs_arr[2] = { b1, b2 };
++
++			ciphers[i] = (int)sys_get_be16(cs_arr);
++
++			if (++i == cipher_cnt) {
++				break;
++			}
++			numCipherSuites++;
++		}
++
++		*optlen = i * sizeof(int);
++		return 0;
++	}
++#else
++	if (context->options.ciphersuites[0] == 0) {
++		/* No specific ciphersuites configured, return all available. */
++		selected_ciphers = mbedtls_ssl_list_ciphersuites();
++	} else {
++		selected_ciphers = context->options.ciphersuites;
++	}
++
++	cipher_cnt = *optlen / sizeof(int);
++	while (selected_ciphers[i] != 0) {
++		ciphers[i] = selected_ciphers[i];
++
++		if (++i == cipher_cnt) {
++			break;
++		}
++	}
++
++	*optlen = i * sizeof(int);
++
++	return 0;
++#endif /* CONFIG_WOLFSSL */
++}
++
++static struct tls_session_context *get_latest_session(struct tls_context *context)
++{
++	struct tls_session_context *session_ctx = NULL;
++	struct tls_session_context *latest_session_ctx = NULL;
++
++	SYS_SLIST_FOR_EACH_CONTAINER(&context->sessions, session_ctx, node) {
++		if ((latest_session_ctx == NULL) ||
++		    (session_ctx->handshake_timestamp >
++		     latest_session_ctx->handshake_timestamp)) {
++			latest_session_ctx = session_ctx;
++		}
++	}
++
++	return latest_session_ctx;
++}
++
++static int tls_opt_ciphersuite_used_get(struct tls_context *context,
++					void *optval, net_socklen_t *optlen)
++{
++	struct tls_session_context *session_ctx;
++	const char *ciph;
++
++	if (*optlen != sizeof(int)) {
++		return -EINVAL;
++	}
++
++	session_ctx = get_latest_session(context);
++	if (session_ctx == NULL) {
++		return -ENOTCONN;
++	}
++
++#if defined(CONFIG_WOLFSSL)
++	{
++		byte b1, b2;
++		int flags = 0;
++
++		if (session_ctx->wssl == NULL) {
++			return -ENOTCONN;
++		}
++
++		ciph = wolfSSL_get_cipher_name(session_ctx->wssl);
++		if (ciph == NULL) {
++			return -ENOTCONN;
++		}
++
++		if (wolfSSL_get_cipher_suite_from_name(ciph, &b1, &b2, &flags) != 0) {
++			/* Not a connection-state error: the session is up but
++			 * the cipher name didn't resolve back to a known ID.
++			 */
++			return -ENOENT;
++		}
++
++		byte cs_arr[2] = { b1, b2 };
++		*(int *)optval = (int)sys_get_be16(cs_arr);
++	}
++#else
++	ciph = mbedtls_ssl_get_ciphersuite(&session_ctx->ssl);
++	if (ciph == NULL) {
++		return -ENOTCONN;
++	}
++
++	*(int *)optval = mbedtls_ssl_get_ciphersuite_id(ciph);
++#endif /* CONFIG_WOLFSSL */
++
++	return 0;
++}
++
++static int tls_opt_alpn_list_set(struct tls_context *context,
++				 const void *optval, net_socklen_t optlen)
++{
++	int alpn_cnt;
++
++	if (!ALPN_MAX_PROTOCOLS) {
++		return -EINVAL;
++	}
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen % sizeof(const char *) != 0) {
++		return -EINVAL;
++	}
++
++	alpn_cnt = optlen / sizeof(const char *);
++	/* + 1 for NULL-termination. */
++	if (alpn_cnt + 1 > ARRAY_SIZE(context->options.alpn_list)) {
++		return -EINVAL;
++	}
++
++	memcpy(context->options.alpn_list, optval, optlen);
++	context->options.alpn_list[alpn_cnt] = NULL;
++
++#if defined(CONFIG_WOLFSSL) && defined(HAVE_ALPN)
++	return tls_wolfssl_apply_all_sessions(context, tls_wolfssl_set_alpn);
++#else
++	return 0;
++#endif /* CONFIG_WOLFSSL && HAVE_ALPN */
++}
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++static int tls_opt_dtls_handshake_timeout_get(struct tls_context *context,
++					      void *optval, net_socklen_t *optlen,
++					      bool is_max)
++{
++	uint32_t *val = (uint32_t *)optval;
++
++	if (sizeof(uint32_t) != *optlen) {
++		return -EINVAL;
++	}
++
++	if (is_max) {
++		*val = context->options.dtls_handshake_timeout_max;
++	} else {
++		*val = context->options.dtls_handshake_timeout_min;
++	}
++
++	return 0;
++}
++
++static int tls_opt_dtls_handshake_timeout_set(struct tls_context *context,
++					      const void *optval,
++					      net_socklen_t optlen, bool is_max)
++{
++	uint32_t *val = (uint32_t *)optval;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (sizeof(uint32_t) != optlen) {
++		return -EINVAL;
++	}
++
++	/* If mbedTLS context not inited, it will
++	 * use these values upon init.
++	 */
++	if (is_max) {
++		context->options.dtls_handshake_timeout_max = *val;
++	} else {
++		context->options.dtls_handshake_timeout_min = *val;
++	}
++
++	/* If context already inited, we need to
++	 * update config for it to take effect
++	 */
++#if defined(CONFIG_WOLFSSL)
++	return tls_wolfssl_apply_all_sessions(context,
++					      tls_wolfssl_set_dtls_timeouts);
++#else
++	mbedtls_ssl_conf_handshake_timeout(&context->config,
++			context->options.dtls_handshake_timeout_min,
++			context->options.dtls_handshake_timeout_max);
++#endif /* CONFIG_WOLFSSL */
++
++	return 0;
++}
++
++static int tls_opt_dtls_connection_id_set(struct tls_context *context,
++					  const void *optval, net_socklen_t optlen)
++{
++#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
++	int value;
++
++	if (optlen > 0 && optval == NULL) {
++		return -EINVAL;
++	}
++
++	if (optlen != sizeof(int)) {
++		return -EINVAL;
++	}
++
++	value = *((int *)optval);
++
++	switch (value) {
++	case ZSOCK_TLS_DTLS_CID_DISABLED:
++		context->options.dtls_cid.enabled = false;
++		context->options.dtls_cid.cid_len = 0;
++		break;
++	case ZSOCK_TLS_DTLS_CID_SUPPORTED:
++		context->options.dtls_cid.enabled = true;
++		context->options.dtls_cid.cid_len = 0;
++		break;
++	case ZSOCK_TLS_DTLS_CID_ENABLED:
++		context->options.dtls_cid.enabled = true;
++		if (context->options.dtls_cid.cid_len == 0) {
++			/* generate random self cid */
++#if defined(CONFIG_CSPRNG_ENABLED)
++			sys_csrand_get(context->options.dtls_cid.cid,
++				       MBEDTLS_SSL_CID_OUT_LEN_MAX);
++#else
++			sys_rand_get(context->options.dtls_cid.cid,
++				     MBEDTLS_SSL_CID_OUT_LEN_MAX);
++#endif
++			context->options.dtls_cid.cid_len = MBEDTLS_SSL_CID_OUT_LEN_MAX;
++		}
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++#else
++	return -ENOPROTOOPT;
++#endif /* CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID */
++}
++
++static int tls_opt_dtls_connection_id_value_set(struct tls_context *context,
++						const void *optval,
++						net_socklen_t optlen)
++{
++#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
++	if (optlen > 0 && optval == NULL) {
++		return -EINVAL;
++	}
++
++	if (optlen > MBEDTLS_SSL_CID_IN_LEN_MAX) {
++		return -EINVAL;
++	}
++
++	context->options.dtls_cid.cid_len = optlen;
++	memcpy(context->options.dtls_cid.cid, optval, optlen);
++
++	return 0;
++#else
++	return -ENOPROTOOPT;
++#endif /* CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID */
++}
++
++static int tls_opt_dtls_connection_id_value_get(struct tls_context *context,
++						void *optval, net_socklen_t *optlen)
++{
++#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
++
++	if (*optlen < context->options.dtls_cid.cid_len) {
++		return -EINVAL;
++	}
++
++	*optlen = context->options.dtls_cid.cid_len;
++	memcpy(optval, context->options.dtls_cid.cid, *optlen);
++
++	return 0;
++#else
++	return -ENOPROTOOPT;
++#endif
++}
++
++static int tls_opt_dtls_peer_connection_id_value_get(struct tls_context *context,
++						     void *optval,
++						     net_socklen_t *optlen)
++{
++#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
++	struct tls_session_context *session_ctx;
++	int enabled = false;
++	int ret;
++	size_t optlen_local;
++
++	if (!context->is_initialized) {
++		return -ENOTCONN;
++	}
++
++	session_ctx = get_latest_session(context);
++	if (session_ctx == NULL) {
++		return -ENOTCONN;
++	}
++
++	if (*optlen < MBEDTLS_SSL_CID_OUT_LEN_MAX) {
++		return -EINVAL;
++	}
++
++	ret = mbedtls_ssl_get_peer_cid(&session_ctx->ssl, &enabled, optval, &optlen_local);
++	if (enabled) {
++		*optlen = optlen_local;
++	} else {
++		*optlen = 0;
++	}
++	return ret;
++#else
++	return -ENOPROTOOPT;
++#endif
++}
++
++static int tls_opt_dtls_connection_id_status_get(struct tls_context *context,
++					  void *optval, net_socklen_t *optlen)
++{
++#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
++	struct tls_session_context *session_ctx;
++	struct tls_dtls_cid cid;
++	int ret;
++	int val;
++	int enabled;
++	bool have_self_cid;
++	bool have_peer_cid;
++
++	if (sizeof(int) != *optlen) {
++		return -EINVAL;
++	}
++
++	if (!context->is_initialized) {
++		return -ENOTCONN;
++	}
++
++	session_ctx = get_latest_session(context);
++	if (session_ctx == NULL) {
++		return -ENOTCONN;
++	}
++
++	ret = mbedtls_ssl_get_peer_cid(&session_ctx->ssl, &enabled,
++				       cid.cid, &cid.cid_len);
++	if (ret) {
++		/* Handshake is not complete */
++		return -EAGAIN;
++	}
++
++	cid.enabled = (enabled == MBEDTLS_SSL_CID_ENABLED);
++	have_self_cid = (context->options.dtls_cid.cid_len != 0);
++	have_peer_cid = (cid.cid_len != 0);
++
++	if (!context->options.dtls_cid.enabled) {
++		val = ZSOCK_TLS_DTLS_CID_STATUS_DISABLED;
++	} else if (have_self_cid && have_peer_cid) {
++		val = ZSOCK_TLS_DTLS_CID_STATUS_BIDIRECTIONAL;
++	} else if (have_self_cid) {
++		val = ZSOCK_TLS_DTLS_CID_STATUS_DOWNLINK;
++	} else if (have_peer_cid) {
++		val = ZSOCK_TLS_DTLS_CID_STATUS_UPLINK;
++	} else {
++		val = ZSOCK_TLS_DTLS_CID_STATUS_DISABLED;
++	}
++
++	*((int *)optval) = val;
++	return 0;
++#else
++	return -ENOPROTOOPT;
++#endif
++}
++
++static int tls_opt_dtls_handshake_on_connect_set(struct tls_context *context,
++						 const void *optval,
++						 net_socklen_t optlen)
++{
++	int *val = (int *)optval;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (sizeof(int) != optlen) {
++		return -EINVAL;
++	}
++
++	context->options.dtls_handshake_on_connect = (bool)*val;
++
++	return 0;
++}
++
++static int tls_opt_dtls_handshake_on_connect_get(struct tls_context *context,
++						 void *optval,
++						 net_socklen_t *optlen)
++{
++	if (*optlen != sizeof(int)) {
++		return -EINVAL;
++	}
++
++	*(int *)optval = context->options.dtls_handshake_on_connect;
++
++	return 0;
++}
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++
++static int tls_opt_alpn_list_get(struct tls_context *context,
++				 void *optval, net_socklen_t *optlen)
++{
++	const char **alpn_list = context->options.alpn_list;
++	int alpn_cnt, i = 0;
++	const char **ret_list = optval;
++
++	if (!ALPN_MAX_PROTOCOLS) {
++		return -EINVAL;
++	}
++
++	if (*optlen % sizeof(const char *) != 0 || *optlen == 0) {
++		return -EINVAL;
++	}
++
++	alpn_cnt = *optlen / sizeof(const char *);
++	while (alpn_list[i] != NULL) {
++		ret_list[i] = alpn_list[i];
++
++		if (++i == alpn_cnt) {
++			break;
++		}
++	}
++
++	*optlen = i * sizeof(const char *);
++
++	return 0;
++}
++
++static int tls_opt_session_cache_set(struct tls_context *context,
++				     const void *optval, net_socklen_t optlen)
++{
++	int *val = (int *)optval;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (sizeof(int) != optlen) {
++		return -EINVAL;
++	}
++
++	context->options.cache_enabled = (*val == ZSOCK_TLS_SESSION_CACHE_ENABLED);
++
++	return 0;
++}
++
++static int tls_opt_session_cache_get(struct tls_context *context,
++				     void *optval, net_socklen_t *optlen)
++{
++	int cache_enabled = context->options.cache_enabled ?
++			    ZSOCK_TLS_SESSION_CACHE_ENABLED :
++			    ZSOCK_TLS_SESSION_CACHE_DISABLED;
++
++	if (*optlen != sizeof(cache_enabled)) {
++		return -EINVAL;
++	}
++
++	*(int *)optval = cache_enabled;
++
++	return 0;
++}
++
++static int tls_opt_cert_verify_result_get(struct tls_context *context,
++					  void *optval, net_socklen_t *optlen)
++{
++	struct tls_session_context *session_ctx;
++
++	if (*optlen != sizeof(uint32_t)) {
++		return -EINVAL;
++	}
++
++	session_ctx = get_latest_session(context);
++	if (session_ctx == NULL) {
++		return -ENOTCONN;
++	}
++
++#if defined(CONFIG_WOLFSSL)
++	if (session_ctx->wssl == NULL) {
++		return -ENOTCONN;
++	}
++
++	/* With CONFIG_WOLFSSL_ALWAYS_VERIFY_CB selected by
++	 * NET_SOCKETS_SOCKOPT_TLS, the verify callback runs at every chain
++	 * position (including success), so verify_result_flags reflects
++	 * everything wolfSSL detected. No need to call
++	 * wolfSSL_get_verify_result() as a fallback.
++	 */
++	*(uint32_t *)optval = session_ctx->verify_result_flags;
++#else
++	*(uint32_t *)optval = mbedtls_ssl_get_verify_result(&session_ctx->ssl);
++#endif /* CONFIG_WOLFSSL */
++
++	return 0;
++}
++
++static int tls_opt_session_cache_purge_set(struct tls_context *context,
++					   const void *optval, net_socklen_t optlen)
++{
++	ARG_UNUSED(context);
++	ARG_UNUSED(optval);
++	ARG_UNUSED(optlen);
++
++#if defined(CONFIG_WOLFSSL) && defined(HAVE_EXT_CACHE)
++	/* wolfSSL's internal (server-side) session cache is global, but
++	 * flushing it requires a live CTX handle and the socket this option
++	 * is invoked on may never have been connected. Find any in-use
++	 * context that owns a CTX so the purge works regardless of which
++	 * socket it is called on — parity with the mbedTLS backend, which
++	 * purges its global server_cache.
++	 */
++	k_mutex_lock(&context_lock, K_FOREVER);
++	for (int i = 0; i < ARRAY_SIZE(tls_contexts); i++) {
++		if (tls_contexts[i].is_used && tls_contexts[i].ctx != NULL) {
++			wolfSSL_CTX_flush_sessions(tls_contexts[i].ctx, -1);
++			break;
++		}
++	}
++	k_mutex_unlock(&context_lock);
++#endif
++	tls_session_purge();
++
++	return 0;
++}
++
++static int tls_opt_peer_verify_set(struct tls_context *context,
++				   const void *optval, net_socklen_t optlen)
++{
++	int *peer_verify;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen != sizeof(int)) {
++		return -EINVAL;
++	}
++
++	peer_verify = (int *)optval;
++
++	if (*peer_verify != ZSOCK_TLS_PEER_VERIFY_NONE &&
++	    *peer_verify != ZSOCK_TLS_PEER_VERIFY_OPTIONAL &&
++	    *peer_verify != ZSOCK_TLS_PEER_VERIFY_REQUIRED) {
++		return -EINVAL;
++	}
++
++	context->options.verify_level = *peer_verify;
++
++	return 0;
++}
++
++static int tls_opt_cert_nocopy_set(struct tls_context *context,
++				   const void *optval, net_socklen_t optlen)
++{
++	int *cert_nocopy;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen != sizeof(int)) {
++		return -EINVAL;
++	}
++
++	cert_nocopy = (int *)optval;
++
++	if (*cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_NONE &&
++	    *cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_OPTIONAL) {
++		return -EINVAL;
++	}
++
++	context->options.cert_nocopy = *cert_nocopy;
++
++	return 0;
++}
++
++static int tls_opt_dtls_role_set(struct tls_context *context,
++				 const void *optval, net_socklen_t optlen)
++{
++	int *role;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen != sizeof(int)) {
++		return -EINVAL;
++	}
++
++	role = (int *)optval;
++	if (*role != ZTLS_IS_CLIENT &&
++	    *role != ZTLS_IS_SERVER) {
++		return -EINVAL;
++	}
++
++	context->options.role = *role;
++
++	return 0;
++}
++
++#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
++#if defined(CONFIG_WOLFSSL)
++/* wolfSSL consumers should use TLS_CERT_VERIFY_CALLBACK_WOLFSSL. */
++static int tls_opt_cert_verify_callback_set(struct tls_context *context,
++					    const void *optval,
++					    net_socklen_t optlen)
++{
++	ARG_UNUSED(context);
++	ARG_UNUSED(optval);
++	ARG_UNUSED(optlen);
++
++	NET_ERR("TLS_CERT_VERIFY_CALLBACK is not supported by the wolfSSL "
++		"backend; use TLS_CERT_VERIFY_CALLBACK_WOLFSSL");
++
++	return -ENOTSUP;
++}
++#else /* CONFIG_WOLFSSL (mbedTLS backend) */
++static int tls_opt_cert_verify_callback_set(struct tls_context *context,
++					    const void *optval,
++					    net_socklen_t optlen)
++{
++	struct zsock_tls_cert_verify_cb *cert_verify;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen != sizeof(struct zsock_tls_cert_verify_cb)) {
++		return -EINVAL;
++	}
++
++	cert_verify = (struct zsock_tls_cert_verify_cb *)optval;
++	if (cert_verify->cb == NULL) {
++		return -EINVAL;
++	}
++
++	context->options.cert_verify = *cert_verify;
++
++	return 0;
++}
++#endif /* CONFIG_WOLFSSL */
++#else /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
++static int tls_opt_cert_verify_callback_set(struct tls_context *context,
++					    const void *optval,
++					    net_socklen_t optlen)
++{
++	ARG_UNUSED(context);
++	ARG_UNUSED(optval);
++	ARG_UNUSED(optlen);
++
++#if defined(CONFIG_WOLFSSL)
++	/* The wolfSSL backend never supports TLS_CERT_VERIFY_CALLBACK; the
++	 * public contract (socket.h / Kconfig help) promises -ENOTSUP
++	 * regardless of CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK.
++	 */
++	NET_ERR("TLS_CERT_VERIFY_CALLBACK is not supported by the wolfSSL "
++		"backend; use TLS_CERT_VERIFY_CALLBACK_WOLFSSL");
++	return -ENOTSUP;
++#else
++	NET_ERR("TLS_CERT_VERIFY_CALLBACK option requires "
++		"CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK enabled");
++
++	return -ENOPROTOOPT;
++#endif
++}
++#endif /* CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK */
++
++#if defined(CONFIG_WOLFSSL)
++#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
++static int tls_opt_cert_verify_callback_wolfssl_set(struct tls_context *context,
++						    const void *optval,
++						    net_socklen_t optlen)
++{
++	struct zsock_tls_cert_verify_cb_wolfssl *wolfssl_cb;
++
++	if (!optval) {
++		return -EINVAL;
++	}
++
++	if (optlen != sizeof(struct zsock_tls_cert_verify_cb_wolfssl)) {
++		return -EINVAL;
++	}
++
++	wolfssl_cb = (struct zsock_tls_cert_verify_cb_wolfssl *)optval;
++	if (wolfssl_cb->cb == NULL) {
++		return -EINVAL;
++	}
++
++	context->options.cert_verify_wolfssl = *wolfssl_cb;
++
++	return 0;
++}
++#else
++static int tls_opt_cert_verify_callback_wolfssl_set(struct tls_context *context,
++						    const void *optval,
++						    net_socklen_t optlen)
++{
++	return -ENOPROTOOPT;
++}
++#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
++#endif /* CONFIG_WOLFSSL */
++
++static int protocol_check(int family, int type, int *proto)
++{
++	if (family != NET_AF_INET && family != NET_AF_INET6) {
++		return -EAFNOSUPPORT;
++	}
++
++	if (*proto >= NET_IPPROTO_TLS_1_0 && *proto <= NET_IPPROTO_TLS_1_3) {
++		if (type != NET_SOCK_STREAM) {
++			return -EPROTOTYPE;
++		}
++
++		*proto = NET_IPPROTO_TCP;
++	} else if (*proto >= NET_IPPROTO_DTLS_1_0 && *proto <= NET_IPPROTO_DTLS_1_2) {
++		if (!IS_ENABLED(CONFIG_NET_SOCKETS_ENABLE_DTLS)) {
++			return -EPROTONOSUPPORT;
++		}
++
++		if (type != NET_SOCK_DGRAM) {
++			return -EPROTOTYPE;
++		}
++
++		*proto = NET_IPPROTO_UDP;
++	} else {
++		return -EPROTONOSUPPORT;
++	}
++
++	return 0;
++}
++
++static int ztls_socket(int family, int type, int proto)
++{
++	enum net_ip_protocol_secure tls_proto = proto;
++	int fd = zvfs_reserve_fd();
++	int sock = -1;
++	int ret;
++	struct tls_context *ctx;
++
++	if (fd < 0) {
++		return -1;
++	}
++
++	ret = protocol_check(family, type, &proto);
++	if (ret < 0) {
++		errno = -ret;
++		goto free_fd;
++	}
++
++	ctx = tls_alloc();
++	if (ctx == NULL) {
++		errno = ENOMEM;
++		goto free_fd;
++	}
++
++	sock = zsock_socket(family, type, proto);
++	if (sock < 0) {
++		goto release_tls;
++	}
++
++	ctx->tls_version = tls_proto;
++	ctx->type = (proto == NET_IPPROTO_TCP) ? NET_SOCK_STREAM : NET_SOCK_DGRAM;
++	ctx->sock = sock;
++
++	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
++			    ZVFS_MODE_IFSOCK);
++
++	return fd;
++
++release_tls:
++	(void)tls_release(ctx);
++
++free_fd:
++	zvfs_free_fd(fd);
++
++	return -1;
++}
++
++int ztls_close_ctx(struct tls_context *ctx, int sock)
++{
++	struct tls_session_context *session_ctx = NULL;
++	int ret, err = 0;
++
++	/* Try to send close notification. */
++	ctx->flags = 0;
++
++#if defined(CONFIG_WOLFSSL)
++	/* wolfSSL shutdown (close-notify) is handled per-session in
++	 * tls_session_free via tls_release below.
++	 */
++	ARG_UNUSED(session_ctx);
++#else
++	SYS_SLIST_FOR_EACH_CONTAINER(&ctx->sessions, session_ctx, node) {
++		(void)mbedtls_ssl_close_notify(&session_ctx->ssl);
++	}
++#endif /* CONFIG_WOLFSSL */
++
++	err = tls_release(ctx);
++	ret = zsock_close(ctx->sock);
++
++	if (ret == 0) {
++		(void)sock_obj_core_dealloc(sock);
++	}
++
++	/* In case close fails, we propagate errno value set by close.
++	 * In case close succeeds, but tls_release fails, set errno
++	 * according to tls_release return value.
++	 */
++	if (ret == 0 && err < 0) {
++		errno = -err;
++		ret = -1;
++	}
++
++	return ret;
++}
++
++int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
++		     net_socklen_t addrlen)
++{
++	int ret;
++	int sock_flags;
++	bool is_non_block;
++
++	sock_flags = zsock_fcntl(ctx->sock, ZVFS_F_GETFL, 0);
++	if (sock_flags < 0) {
++		return -EIO;
++	}
++
++	is_non_block = sock_flags & ZVFS_O_NONBLOCK;
++	if (is_non_block) {
++		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL,
++				  sock_flags & ~ZVFS_O_NONBLOCK);
++	}
++
++	ret = zsock_connect(ctx->sock, addr, addrlen);
++	if (ret < 0) {
++		return ret;
++	}
++
++	if (is_non_block) {
++		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL, sock_flags);
++	}
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	if (ctx->type == NET_SOCK_DGRAM) {
++		dtls_peer_address_set(ctx->active_session, addr, addrlen);
++	}
++#endif
++
++	if (ctx->type == NET_SOCK_STREAM
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	    || (ctx->type == NET_SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
++#endif
++	    ) {
++#if defined(CONFIG_WOLFSSL)
++		ret = tls_wolfssl_init(ctx, false);
++		if (ret < 0) {
++			goto error;
++		}
++
++		/* Do not use any socket flags during the handshake. */
++		ctx->flags = 0;
++
++		tls_session_restore(ctx, addr, addrlen);
++
++		/* TODO For simplicity, TLS handshake blocks the socket
++		 * even for non-blocking socket.
++		 */
++		ret = tls_wolfssl_handshake(
++			ctx, K_MSEC(CONFIG_NET_SOCKETS_TLS_CONNECT_TIMEOUT));
++		if (ret < 0) {
++			if ((ret == -EAGAIN) && !is_non_block) {
++				ret = -ETIMEDOUT;
++			}
++
++			goto error;
++		}
++
++		tls_session_store(ctx, addr, addrlen);
++#else
+ 		ret = tls_mbedtls_init(ctx, false);
+ 		if (ret < 0) {
+ 			goto error;
+@@ -2890,6 +5195,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
+ 		}
+ 
+ 		tls_session_store(ctx, addr, addrlen);
++#endif /* CONFIG_WOLFSSL */
+ 	}
+ 
+ 	return 0;
+@@ -2930,6 +5236,30 @@ int ztls_accept_ctx(struct tls_context *parent, struct net_sockaddr *addr,
+ 
+ 	child->sock = sock;
+ 
++#if defined(CONFIG_WOLFSSL)
++	ret = tls_wolfssl_init(child, true);
++	if (ret < 0) {
++		goto error;
++	}
++
++	/* Do not use any socket flags during the handshake. */
++	child->flags = 0;
++
++	/* TODO For simplicity, TLS handshake blocks the socket even for
++	 * non-blocking socket.
++	 */
++	ret = tls_wolfssl_handshake(
++		child, K_MSEC(CONFIG_NET_SOCKETS_TLS_CONNECT_TIMEOUT));
++	if (ret < 0) {
++		if ((ret == -EAGAIN) && is_blocking(parent->sock, 0)) {
++			ret = -ETIMEDOUT;
++		}
++
++		goto error;
++	}
++
++	return fd;
++#else
+ 	ret = tls_mbedtls_init(child, true);
+ 	if (ret < 0) {
+ 		goto error;
+@@ -2952,6 +5282,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct net_sockaddr *addr,
+ 	}
+ 
+ 	return fd;
++#endif /* CONFIG_WOLFSSL */
+ 
+ error:
+ 	if (child != NULL) {
+@@ -2970,6 +5301,79 @@ error:
+ 	return -1;
+ }
+ 
++#if defined(CONFIG_WOLFSSL)
++static ssize_t send_tls_wolfssl(struct tls_context *ctx, const void *buf,
++				size_t len, int flags)
++{
++	const bool is_block = is_blocking(ctx->sock, flags);
++	int ret = 0;
++	int err = 0;
++	k_timeout_t timeout;
++	k_timepoint_t end;
++
++	if (ctx->error != 0) {
++		errno = ctx->error;
++		return -1;
++	}
++
++	if (ctx->active_session->session_closed) {
++		errno = ECONNABORTED;
++		return -1;
++	}
++
++	if (!is_block) {
++		timeout = K_NO_WAIT;
++	} else {
++		timeout = ctx->options.timeout_tx;
++	}
++
++	end = sys_timepoint_calc(timeout);
++
++	do {
++		ret = wolfSSL_write(ctx->active_session->wssl, buf, len);
++		if (ret > 0) {
++			return ret;
++		}
++
++		err = wolfSSL_get_error(ctx->active_session->wssl, ret);
++
++		if (err == WOLFSSL_ERROR_WANT_READ ||
++		    err == WOLFSSL_ERROR_WANT_WRITE) {
++			int timeout_ms;
++
++			if (!is_block) {
++				errno = EAGAIN;
++				break;
++			}
++
++			/* Blocking timeout. */
++			timeout = sys_timepoint_timeout(end);
++			if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
++				errno = EAGAIN;
++				break;
++			}
++
++			/* Block. */
++			timeout_ms = timeout_to_ms(&timeout);
++			ret = wait_for_reason(ctx->sock, timeout_ms, err);
++			if (ret < 0) {
++				errno = -ret;
++				break;
++			}
++		} else {
++			NET_ERR("TLS send error: %x", err);
++			tls_wolfssl_reset_session(ctx);
++			ctx->error = ECONNABORTED;
++			errno = ECONNABORTED;
++			break;
++		}
++	} while (true);
++
++	return -1;
++}
++#endif /* CONFIG_WOLFSSL */
++
++#if defined(CONFIG_MBEDTLS)
+ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
+ 			size_t len, int flags)
+ {
+@@ -3048,8 +5452,107 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
+ 
+ 	return -1;
+ }
++#endif /* CONFIG_MBEDTLS */
+ 
+-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_WOLFSSL) && defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++static ssize_t sendto_dtls_client_wolfssl(struct tls_context *ctx,
++					  const void *buf, size_t len,
++					  int flags,
++					  const struct net_sockaddr *dest_addr,
++					  net_socklen_t addrlen)
++{
++	int ret;
++
++	if (!dest_addr) {
++		/* No address provided, check if we have stored one,
++		 * otherwise return error.
++		 */
++		if (ctx->active_session->dtls_peer_addrlen == 0) {
++			ret = -EDESTADDRREQ;
++			goto error;
++		}
++	} else if (ctx->active_session->dtls_peer_addrlen == 0) {
++		/* Address provided and no peer address stored. */
++		dtls_peer_address_set(ctx->active_session, dest_addr, addrlen);
++	} else if (!dtls_is_peer_addr_valid(ctx->active_session, dest_addr, addrlen)) {
++		/* Address provided but it does not match stored one */
++		ret = -EISCONN;
++		goto error;
++	}
++
++	if (!ctx->is_initialized) {
++		ret = tls_wolfssl_init(ctx, false);
++		if (ret < 0) {
++			goto error;
++		}
++	}
++
++	if (!is_handshake_complete(ctx->active_session)) {
++		tls_session_restore(ctx, net_sad(&ctx->active_session->dtls_peer_addr),
++				    ctx->active_session->dtls_peer_addrlen);
++
++		/* TODO For simplicity, TLS handshake blocks the socket even for
++		 * non-blocking socket.
++		 * DTLS handshake timeout/retransmissions are limited by
++		 * wolfSSL, so K_FOREVER is fine here, the function will not
++		 * block indefinitely.
++		 */
++		ret = tls_wolfssl_handshake(ctx, K_FOREVER);
++		if (ret < 0) {
++			goto error;
++		}
++
++		/* Client socket ready to use again. */
++		ctx->error = 0;
++
++		tls_session_store(ctx, net_sad(&ctx->active_session->dtls_peer_addr),
++				  ctx->active_session->dtls_peer_addrlen);
++	}
++
++	return send_tls_wolfssl(ctx, buf, len, flags);
++
++error:
++	errno = -ret;
++	return -1;
++}
++
++static ssize_t sendto_dtls_server_wolfssl(struct tls_context *ctx,
++					  const void *buf, size_t len,
++					  int flags,
++					  const struct net_sockaddr *dest_addr,
++					  net_socklen_t addrlen)
++{
++	int ret;
++
++	if (dest_addr != NULL) {
++		/* Verify we have a session with the client. */
++		ret = dtls_server_switch_active_session(ctx, dest_addr, addrlen);
++		if (ret < 0) {
++			NET_DBG("No session found (TX) for [%s]:%d",
++				LOG_ADDR_PORT_HELPER(dest_addr));
++			errno = ENOTCONN;
++			return -1;
++		}
++	}
++
++	/* For DTLS server, require to have established DTLS connection
++	 * in order to send data.
++	 */
++	if (!is_handshake_complete(ctx->active_session)) {
++		errno = ENOTCONN;
++		return -1;
++	}
++
++	ret = send_tls_wolfssl(ctx, buf, len, flags);
++	if (ret < 0 && errno != EAGAIN) {
++		(void)dtls_server_free_active_session(ctx);
++	}
++
++	return ret;
++}
++#endif /* CONFIG_WOLFSSL && CONFIG_NET_SOCKETS_ENABLE_DTLS */
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_MBEDTLS)
+ static ssize_t sendto_dtls_client(struct tls_context *ctx, const void *buf,
+ 				  size_t len, int flags,
+ 				  const struct net_sockaddr *dest_addr,
+@@ -3143,7 +5646,7 @@ static ssize_t sendto_dtls_server(struct tls_context *ctx, const void *buf,
+ 
+ 	return ret;
+ }
+-#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && CONFIG_MBEDTLS */
+ 
+ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+ 			int flags, const struct net_sockaddr *dest_addr,
+@@ -3151,6 +5654,26 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+ {
+ 	ctx->flags = flags;
+ 
++#if defined(CONFIG_WOLFSSL)
++	/* TLS */
++	if (ctx->type == NET_SOCK_STREAM) {
++		return send_tls_wolfssl(ctx, buf, len, flags);
++	}
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	/* DTLS */
++	if (ctx->options.role == ZTLS_IS_SERVER) {
++		return sendto_dtls_server_wolfssl(ctx, buf, len, flags,
++						  dest_addr, addrlen);
++	}
++
++	return sendto_dtls_client_wolfssl(ctx, buf, len, flags,
++					  dest_addr, addrlen);
++#else
++	errno = ENOTSUP;
++	return -1;
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#else
+ 	/* TLS */
+ 	if (ctx->type == NET_SOCK_STREAM) {
+ 		return send_tls(ctx, buf, len, flags);
+@@ -3168,6 +5691,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+ 	errno = ENOTSUP;
+ 	return -1;
+ #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#endif /* CONFIG_WOLFSSL */
+ }
+ 
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+@@ -3257,24 +5781,133 @@ ssize_t ztls_sendmsg_ctx(struct tls_context *ctx, const struct net_msghdr *msg,
+ 				goto send_loop;
+ 			}
+ 
+-			return dtls_sendmsg_merge_and_send(ctx, msg, flags);
++			return dtls_sendmsg_merge_and_send(ctx, msg, flags);
++		}
++
++		/*
++		 * Current mbedTLS API (i.e. mbedtls_ssl_write()) allows only to send a single
++		 * contiguous buffer. This means that gather write using sendmsg() can only be
++		 * handled correctly if there is a single non-empty buffer in msg->msg_iov.
++		 */
++		if (msghdr_non_empty_iov_count(msg) > 1) {
++			errno = EMSGSIZE;
++			return -1;
++		}
++	}
++
++send_loop:
++	return tls_sendmsg_loop_and_send(ctx, msg, flags);
++}
++
++#if defined(CONFIG_WOLFSSL)
++static ssize_t recv_tls_wolfssl(struct tls_context *ctx, void *buf,
++				size_t max_len, int flags)
++{
++	size_t recv_len = 0;
++	const bool waitall = flags & ZSOCK_MSG_WAITALL;
++	const bool is_block = is_blocking(ctx->sock, flags);
++	k_timeout_t timeout;
++	k_timepoint_t end;
++	int ret;
++	int err;
++
++	if (ctx->error != 0) {
++		errno = ctx->error;
++		return -1;
++	}
++
++	if (ctx->active_session->session_closed || ctx->recv_eof) {
++		return 0;
++	}
++
++	if (!is_block) {
++		timeout = K_NO_WAIT;
++	} else {
++		timeout = ctx->options.timeout_rx;
++	}
++
++	end = sys_timepoint_calc(timeout);
++
++	do {
++		size_t read_len = max_len - recv_len;
++
++		ret = wolfSSL_read(ctx->active_session->wssl,
++				   (uint8_t *)buf + recv_len, read_len);
++		if (ret < 0) {
++			/* Local shutdown(SHUT_RD/RDWR) racing with a blocked
++			 * recv(): the underlying socket reports EOF, which
++			 * tls_wolf_rx returns as CBIO_ERR_CONN_CLOSE. wolfSSL
++			 * sets ssl->options.isClosed but does NOT map this
++			 * to ZERO_RETURN on the read path, so wolfSSL_get_error
++			 * below would land us in the EIO arm.
++			 *
++			 * Return what's been drained across earlier iterations
++			 * (recv_len) — POSIX semantics: a partial recv followed
++			 * by EOF reports the partial. recv_len may be 0 on the
++			 * first iteration, in which case the caller sees clean
++			 * EOF immediately. The DTLS sibling
++			 * (recvfrom_dtls_common_wolfssl) returns 0 here
++			 * unconditionally because its loop doesn't accumulate
++			 * across iterations.
++			 */
++			if (ctx->recv_eof) {
++				return recv_len;
++			}
++
++			err = wolfSSL_get_error(ctx->active_session->wssl, ret);
++			if (err == WOLFSSL_ERROR_WANT_READ ||
++			    err == WOLFSSL_ERROR_WANT_WRITE) {
++				int timeout_ms;
++
++				if (!is_block) {
++					ret = -EAGAIN;
++					goto err;
++				}
++
++				/* Blocking timeout. */
++				timeout = sys_timepoint_timeout(end);
++				if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
++					ret = -EAGAIN;
++					goto err;
++				}
++
++				timeout_ms = timeout_to_ms(&timeout);
++
++				/* Block. */
++				k_mutex_unlock(ctx->lock);
++				ret = wait_for_reason(ctx->sock, timeout_ms, err);
++				k_mutex_lock(ctx->lock, K_FOREVER);
++
++				if (ret >= 0) {
++					/* Retry. */
++					continue;
++				}
++			} else if (err == WOLFSSL_ERROR_ZERO_RETURN ||
++				   err == SOCKET_PEER_CLOSED_E) {
++				ctx->active_session->session_closed = true;
++				break;
++			} else {
++				NET_ERR("TLS recv error: %x", err);
++				ret = -EIO;
++			}
++
++err:
++			errno = -ret;
++			return -1;
+ 		}
+ 
+-		/*
+-		 * Current mbedTLS API (i.e. mbedtls_ssl_write()) allows only to send a single
+-		 * contiguous buffer. This means that gather write using sendmsg() can only be
+-		 * handled correctly if there is a single non-empty buffer in msg->msg_iov.
+-		 */
+-		if (msghdr_non_empty_iov_count(msg) > 1) {
+-			errno = EMSGSIZE;
+-			return -1;
++		if (ret == 0) {
++			break;
+ 		}
+-	}
+ 
+-send_loop:
+-	return tls_sendmsg_loop_and_send(ctx, msg, flags);
++		recv_len += ret;
++	} while ((recv_len == 0) || (waitall && (recv_len < max_len)));
++
++	return recv_len;
+ }
++#endif /* CONFIG_WOLFSSL */
+ 
++#if defined(CONFIG_MBEDTLS)
+ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+ 			size_t max_len, int flags)
+ {
+@@ -3321,61 +5954,415 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+ 				 * supported. See mbedtls_ssl_read API
+ 				 * documentation.
+ 				 */
+-				ctx->active_session->session_closed = true;
+-				break;
+-			}
++				ctx->active_session->session_closed = true;
++				break;
++			}
++
++			if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
++			    ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
++			    ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS ||
++			    ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS ||
++			    ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
++				int timeout_ms;
++
++				if (!is_block) {
++					ret = -EAGAIN;
++					goto err;
++				}
++
++				/* Blocking timeout. */
++				timeout = sys_timepoint_timeout(end);
++				if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
++					ret = -EAGAIN;
++					goto err;
++				}
++
++				timeout_ms = timeout_to_ms(&timeout);
++
++				/* Block. */
++				k_mutex_unlock(ctx->lock);
++				ret = wait_for_reason(ctx->sock, timeout_ms, ret);
++				k_mutex_lock(ctx->lock, K_FOREVER);
++
++				if (ret == 0) {
++					/* Retry. */
++					continue;
++				}
++			} else {
++				NET_ERR("TLS recv error: -%x", -ret);
++				ret = -EIO;
++			}
++
++err:
++			errno = -ret;
++			return -1;
++		}
++
++		if (ret == 0) {
++			break;
++		}
++
++		recv_len += ret;
++	} while ((recv_len == 0) || (waitall && (recv_len < max_len)));
++
++	return recv_len;
++}
++
++#endif /* CONFIG_MBEDTLS */
++
++#if defined(CONFIG_WOLFSSL) && defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++static ssize_t recvfrom_dtls_common_wolfssl(struct tls_context *ctx, void *buf,
++					    size_t max_len, int flags,
++					    struct net_sockaddr *src_addr,
++					    net_socklen_t *addrlen)
++{
++	int ret;
++	bool is_server = ctx->options.role == ZTLS_IS_SERVER;
++	bool is_block = is_blocking(ctx->sock, flags);
++	k_timeout_t timeout;
++	k_timepoint_t end;
++	int remaining;
++	bool retry;
++
++	if (ctx->error != 0) {
++		return -ctx->error;
++	}
++
++	if (ctx->recv_eof) {
++		return 0;
++	}
++
++	if (!is_block) {
++		timeout = K_NO_WAIT;
++	} else {
++		timeout = ctx->options.timeout_rx;
++	}
++
++	end = sys_timepoint_calc(timeout);
++
++	do {
++		int timeout_ms;
++
++		retry = false;
++		ret = wolfSSL_read(ctx->active_session->wssl, buf, max_len);
++		/* Note: <= 0, not < 0 — wolfSSL_read returns 0 for a clean
++		 * TLS-level closure (peer close-notify), with the actual
++		 * cause reported via wolfSSL_get_error (ZERO_RETURN).
++		 */
++		if (ret <= 0) {
++			int err;
++
++			/* Local shutdown(SHUT_RD/RDWR) racing with a blocked
++			 * recv(): same hazard as the TCP/TLS path, just
++			 * surfaced differently — the DTLS BIO callbacks map a
++			 * 0-byte recvfrom to CBIO_ERR_CONN_CLOSE (symmetry
++			 * with tls_wolf_rx); without this shortcut the next
++			 * iteration would still re-block.
++			 *
++			 * Return 0 unconditionally here (unlike the TCP/TLS
++			 * sibling recv_tls_wolfssl which returns its
++			 * accumulated recv_len). That's not a wolfSSL quirk
++			 * — DTLS recv reads at most one datagram per call,
++			 * with no cross-iteration accumulation, exactly
++			 * matching the mbedTLS DTLS path (recvfrom_dtls_common).
++			 * The asymmetry between TCP and DTLS is intrinsic to
++			 * stream-vs-datagram semantics.
++			 */
++			if (ctx->recv_eof) {
++				return 0;
++			}
++
++			err = wolfSSL_get_error(ctx->active_session->wssl, ret);
++
++			if (err == WOLFSSL_ERROR_WANT_READ ||
++			    err == WOLFSSL_ERROR_WANT_WRITE) {
++				if (is_server) {
++					int err2 = dtls_server_switch_session_on_rx(ctx);
++
++					/* If session swapping is successful, return early
++					 * so that recvfrom_dtls_server_wolfssl() can
++					 * proceed with another handshake. Otherwise, there
++					 * either really was no packet, or we've failed to
++					 * allocate a new session, so the packet was
++					 * dropped. In either case, just proceed as if
++					 * there were no packet.
++					 */
++					if (err2 == 0) {
++						return -EAGAIN;
++					}
++				}
++
++				if (!is_block) {
++					return -EAGAIN;
++				}
++
++				timeout = sys_timepoint_timeout(end);
++				if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
++					return -EAGAIN;
++				}
++
++				{
++					/* wolfSSL reports the DTLS timeout in
++					 * seconds.
++					 */
++					int timeout_dtls =
++						wolfSSL_dtls_get_current_timeout(
++							ctx->active_session->wssl) *
++						MSEC_PER_SEC;
++					int timeout_sock =
++						timeout_to_ms(&timeout);
++
++					if (timeout_sock == SYS_FOREVER_MS) {
++						timeout_ms = timeout_dtls;
++					} else {
++						timeout_ms = MIN(timeout_dtls,
++								 timeout_sock);
++					}
++				}
++
++				k_mutex_unlock(ctx->lock);
++				ret = wait_for_reason(ctx->sock, timeout_ms, err);
++				k_mutex_lock(ctx->lock, K_FOREVER);
++
++				if (ret >= 0) {
++					retry = true;
++					continue;
++				}
++
++				return ret;
++			}
++
++			if (err == SOCKET_PEER_CLOSED_E ||
++			    err == WOLFSSL_ERROR_ZERO_RETURN) {
++				return -ENOTCONN;
++			}
++
++			if (ret == 0 && err == WOLFSSL_ERROR_NONE) {
++				/* Zero-length read with no error recorded:
++				 * an empty application datagram. Mirror the
++				 * mbedTLS path, which reports it to the
++				 * caller as a 0-byte receive.
++				 */
++				return 0;
++			}
++
++			/* Server BUFFER_ERROR: a prior peek absorbed a fatal
++			 * alert and reset the SSL object. Surface EAGAIN so
++			 * the server can wait for the next session.
++			 */
++			if (err == BUFFER_ERROR && is_server) {
++				return -EAGAIN;
++			}
++
++			return -EIO;
++		}
++
++		if (src_addr && addrlen) {
++			dtls_peer_address_get(ctx->active_session, src_addr, addrlen);
++		}
++
++		remaining = wolfSSL_pending(ctx->active_session->wssl);
++
++		/* No more data in the datagram, or dummy read. */
++		if ((remaining == 0) || (max_len == 0)) {
++			return ret;
++		}
++
++		if (flags & ZSOCK_MSG_TRUNC) {
++			ret += remaining;
++		}
++
++		/* Always drain remaining datagram data */
++		while (remaining > 0) {
++			byte dummy[128];
++			int to_read = MIN(remaining, sizeof(dummy));
++			int r = wolfSSL_read(ctx->active_session->wssl, dummy, to_read);
++
++			if (r <= 0) {
++				NET_ERR("Error while flushing the rest of the"
++					" datagram, err %d", r);
++				ret = -EIO;
++				break;
++			}
++			remaining -= r;
++		}
++
++		return ret;
++	} while (retry);
++
++	return -EAGAIN;
++}
++
++static ssize_t recvfrom_dtls_client_wolfssl(struct tls_context *ctx, void *buf,
++					    size_t max_len, int flags,
++					    struct net_sockaddr *src_addr,
++					    net_socklen_t *addrlen)
++{
++	int ret;
++
++	if (!is_handshake_complete(ctx->active_session)) {
++		ret = -ENOTCONN;
++		goto error;
++	}
++
++	ret = recvfrom_dtls_common_wolfssl(ctx, buf, max_len, flags,
++					   src_addr, addrlen);
++	if (ret >= 0) {
++		return ret;
++	}
++
++	if (ret == -ENOTCONN) {
++		/* Peer notified that it's closing the connection. */
++		if (tls_wolfssl_reset_session(ctx) == 0) {
++			ctx->error = ENOTCONN;
++		} else {
++			ctx->error = ENOMEM;
++			ret = -ENOMEM;
++		}
++		goto error;
++	}
++	if (ret == -EAGAIN) {
++		goto error;
++	}
++
++	NET_ERR("DTLS client recv error: %d", ret);
++
++	if (tls_wolfssl_reset_session(ctx) != 0) {
++		ctx->error = ENOMEM;
++		ret = -ENOMEM;
++	} else {
++		ctx->error = ECONNABORTED;
++		ret = -ECONNABORTED;
++	}
++
++error:
++	errno = -ret;
++	return -1;
++}
++
++static ssize_t recvfrom_dtls_server_wolfssl(struct tls_context *ctx, void *buf,
++					    size_t max_len, int flags,
++					    struct net_sockaddr *src_addr,
++					    net_socklen_t *addrlen)
++{
++	int ret;
++	bool repeat;
++	k_timeout_t timeout;
++
++	if (!ctx->is_initialized) {
++		ret = tls_wolfssl_init(ctx, true);
++		if (ret < 0) {
++			goto error;
++		}
++	}
++
++	if (is_blocking(ctx->sock, flags)) {
++		timeout = ctx->options.timeout_rx;
++	} else {
++		timeout = K_NO_WAIT;
++	}
++
++	/* Loop to enable DTLS reconnection for servers without closing
++	 * a socket.
++	 */
++	do {
++		struct net_sockaddr_storage peer_addr;
++		net_socklen_t peer_addrlen = sizeof(peer_addr);
++
++		repeat = false;
++
++		(void)dtls_server_check_expired_sessions(ctx);
++
++		if (!is_handshake_complete(ctx->active_session)) {
++			ret = tls_wolfssl_handshake(ctx, timeout);
++			if (ret < 0) {
++				/* In case of EAGAIN, check if it's needed to swap
++				 * sessions, otherwise just exit.
++				 */
++				if (ret == -EAGAIN) {
++					int err = dtls_server_switch_session_on_rx(ctx);
+ 
+-			if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+-			    ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
+-			    ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS ||
+-			    ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS ||
+-			    ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+-				int timeout_ms;
++					if (err == 0) {
++						/* Switched the session, repeat the loop. */
++						continue;
++					}
+ 
+-				if (!is_block) {
+-					ret = -EAGAIN;
+-					goto err;
++					break;
+ 				}
+ 
+-				/* Blocking timeout. */
+-				timeout = sys_timepoint_timeout(end);
+-				if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+-					ret = -EAGAIN;
+-					goto err;
++				ret = dtls_server_free_active_session(ctx);
++				if (ret == 0) {
++					repeat = true;
++				} else {
++					ret = -ENOMEM;
+ 				}
+ 
+-				timeout_ms = timeout_to_ms(&timeout);
++				continue;
++			}
+ 
+-				/* Block. */
+-				k_mutex_unlock(ctx->lock);
+-				ret = wait_for_reason(ctx->sock, timeout_ms, ret);
+-				k_mutex_lock(ctx->lock, K_FOREVER);
++			/* Server socket ready to use again. */
++			ctx->error = 0;
++		}
+ 
+-				if (ret == 0) {
+-					/* Retry. */
+-					continue;
+-				}
++		/* Backup peer address (to verify later if it changed). */
++		dtls_peer_address_get(ctx->active_session, net_sad(&peer_addr), &peer_addrlen);
++
++		ret = recvfrom_dtls_common_wolfssl(ctx, buf, max_len, flags,
++						   src_addr, addrlen);
++		if (ret >= 0) {
++			return ret;
++		}
++
++		switch (ret) {
++		case -ENOTCONN:
++			/* Peer closed the session (close-notify or reconnect),
++			 * free it so a new client can connect.
++			 */
++			ret = dtls_server_free_active_session(ctx);
++			if (ret == 0) {
++				repeat = true;
+ 			} else {
+-				NET_ERR("TLS recv error: -%x", -ret);
+-				ret = -EIO;
++				ctx->error = ENOMEM;
++				ret = -ENOMEM;
+ 			}
++			break;
+ 
+-err:
+-			errno = -ret;
+-			return -1;
+-		}
++		case -EAGAIN:
++			if (peer_addrlen > 0 &&
++			    !dtls_is_peer_addr_valid(ctx->active_session, net_sad(&peer_addr),
++						     peer_addrlen)) {
++				/* Current peer changed, repeat the loop. */
++				repeat = true;
++			} else {
++				(void)dtls_server_check_expired_sessions(ctx);
++				/* Otherwise, just return the error. */
++				ret = -EAGAIN;
++			}
+ 
+-		if (ret == 0) {
+ 			break;
+-		}
+ 
+-		recv_len += ret;
+-	} while ((recv_len == 0) || (waitall && (recv_len < max_len)));
++		default:
++			NET_ERR("DTLS server recv error: %d", ret);
+ 
+-	return recv_len;
++			ret = dtls_server_free_active_session(ctx);
++			if (ret == 0) {
++				repeat = true;
++			} else {
++				ctx->error = ENOMEM;
++				ret = -ENOMEM;
++			}
++
++			break;
++		}
++	} while (repeat);
++
++error:
++	errno = -ret;
++	return -1;
+ }
++#endif /* CONFIG_WOLFSSL && CONFIG_NET_SOCKETS_ENABLE_DTLS */
+ 
+-#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(CONFIG_MBEDTLS)
+ static ssize_t recvfrom_dtls_common(struct tls_context *ctx, void *buf,
+ 				    size_t max_len, int flags,
+ 				    struct net_sockaddr *src_addr,
+@@ -3691,7 +6678,7 @@ error:
+ 	errno = -ret;
+ 	return -1;
+ }
+-#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && CONFIG_MBEDTLS */
+ 
+ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+ 			  int flags, struct net_sockaddr *src_addr,
+@@ -3707,6 +6694,26 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+ 
+ 	ctx->flags = flags;
+ 
++#if defined(CONFIG_WOLFSSL)
++	/* TLS */
++	if (ctx->type == NET_SOCK_STREAM) {
++		return recv_tls_wolfssl(ctx, buf, max_len, flags);
++	}
++
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	/* DTLS */
++	if (ctx->options.role == ZTLS_IS_SERVER) {
++		return recvfrom_dtls_server_wolfssl(ctx, buf, max_len, flags,
++						    src_addr, addrlen);
++	}
++
++	return recvfrom_dtls_client_wolfssl(ctx, buf, max_len, flags,
++					    src_addr, addrlen);
++#else
++	errno = ENOTSUP;
++	return -1;
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#else
+ 	/* TLS */
+ 	if (ctx->type == NET_SOCK_STREAM) {
+ 		return recv_tls(ctx, buf, max_len, flags);
+@@ -3725,18 +6732,26 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+ 	errno = ENOTSUP;
+ 	return -1;
+ #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++#endif /* CONFIG_WOLFSSL */
+ }
+ 
+ static int ztls_poll_prepare_pollin(struct tls_context *ctx)
+ {
+-	/* If there already is mbedTLS data to read, there is no
++	/* If there already is TLS data to read, there is no
+ 	 * need to set the k_poll_event object. Return EALREADY
+ 	 * so we won't block in the k_poll.
+ 	 */
+ 	if (!ctx->is_listening) {
++#if defined(CONFIG_WOLFSSL)
++		if (ctx->active_session->wssl != NULL &&
++		    wolfSSL_pending(ctx->active_session->wssl) > 0) {
++			return -EALREADY;
++		}
++#else
+ 		if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
+ 			return -EALREADY;
+ 		}
++#endif /* CONFIG_WOLFSSL */
+ 	}
+ 
+ 	return 0;
+@@ -3757,7 +6772,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
+ 	 * it actually starts to poll for data.
+ 	 */
+ 	if ((pfd->events & ZSOCK_POLLIN) && (ctx->type == NET_SOCK_DGRAM) &&
+-	    (ctx->options.role == MBEDTLS_SSL_IS_CLIENT) &&
++	    (ctx->options.role == ZTLS_IS_CLIENT) &&
+ 	    !is_handshake_complete(ctx->active_session)) {
+ 		(*pev)->obj = &ctx->active_session->tls_established;
+ 		(*pev)->type = K_POLL_TYPE_SEM_AVAILABLE;
+@@ -3811,6 +6826,44 @@ static int tls_data_check(struct tls_context *ctx)
+ 
+ 	ctx->flags = ZSOCK_MSG_DONTWAIT;
+ 
++#if defined(CONFIG_WOLFSSL)
++	{
++		byte dummy[1];
++
++		ret = wolfSSL_peek(ctx->active_session->wssl, dummy, sizeof(dummy));
++		if (ret < 0) {
++			int err = wolfSSL_get_error(ctx->active_session->wssl, ret);
++
++			if (err == SOCKET_PEER_CLOSED_E ||
++			    err == WOLFSSL_ERROR_ZERO_RETURN) {
++				/* Don't reset the session for STREAM socket -
++				 * the application needs to reopen the socket
++				 * anyway, and resetting the session would
++				 * result in an error instead of 0 in a
++				 * consecutive recv() call.
++				 */
++				ctx->active_session->session_closed = true;
++
++				return -ENOTCONN;
++			}
++
++			if (wolfSSL_want_read(ctx->active_session->wssl) ||
++			    wolfSSL_want_write(ctx->active_session->wssl)) {
++				return 0;
++			}
++
++			NET_ERR("%s data check error: %d", "TLS", err);
++
++			if (tls_wolfssl_reset_session(ctx) != 0) {
++				return -ENOMEM;
++			}
++
++			return -ECONNABORTED;
++		}
++	}
++
++	return wolfSSL_pending(ctx->active_session->wssl);
++#else
+ 	ret = mbedtls_ssl_read(&ctx->active_session->ssl, NULL, 0);
+ 	if (ret < 0) {
+ 		if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+@@ -3842,6 +6895,7 @@ static int tls_data_check(struct tls_context *ctx)
+ 	}
+ 
+ 	return mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl);
++#endif /* CONFIG_WOLFSSL */
+ }
+ 
+ static int tls_update_pollin(int fd, struct tls_context *ctx,
+@@ -3851,10 +6905,18 @@ static int tls_update_pollin(int fd, struct tls_context *ctx,
+ 
+ 	if (!ctx->is_listening) {
+ 		/* Already had TLS data to read on socket. */
++#if defined(CONFIG_WOLFSSL)
++		if (ctx->active_session->wssl != NULL &&
++		    wolfSSL_pending(ctx->active_session->wssl) > 0) {
++			pfd->revents |= ZSOCK_POLLIN;
++			goto next;
++		}
++#else
+ 		if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
+ 			pfd->revents |= ZSOCK_POLLIN;
+ 			goto next;
+ 		}
++#endif /* CONFIG_WOLFSSL */
+ 	}
+ 
+ 	if ((pfd->revents & ZSOCK_POLLIN) == 0) {
+@@ -3892,6 +6954,119 @@ again:
+ }
+ 
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++#if defined(CONFIG_WOLFSSL)
++static int dtls_data_check(struct tls_context *ctx)
++{
++	bool is_server = ctx->options.role == ZTLS_IS_SERVER;
++	int ret;
++
++	if (!ctx->is_initialized) {
++		ret = tls_wolfssl_init(ctx, is_server);
++		if (ret < 0) {
++			return -ENOMEM;
++		}
++	}
++
++again:
++	if (is_server && dtls_server_check_expired_sessions(ctx)) {
++		return -ENOTCONN;
++	}
++
++	if (!is_handshake_complete(ctx->active_session)) {
++		ret = tls_wolfssl_handshake(ctx, K_NO_WAIT);
++		if (ret < 0) {
++			if (ret == -EAGAIN) {
++				if (is_server) {
++					ret = dtls_server_switch_session_on_rx(ctx);
++					if (ret == 0) {
++						goto again;
++					}
++				}
++
++				return 0;
++			}
++
++			if (is_server) {
++				ret = dtls_server_free_active_session(ctx);
++			} else {
++				ret = tls_wolfssl_reset_session(ctx);
++			}
++
++			if (ret != 0) {
++				return -ENOMEM;
++			}
++
++			return 0;
++		}
++
++		/* Socket ready to use again. */
++		ctx->error = 0;
++
++		return 0;
++	}
++
++	ctx->flags = ZSOCK_MSG_DONTWAIT;
++
++	{
++		byte dummy[1];
++
++		ret = wolfSSL_peek(ctx->active_session->wssl, dummy, sizeof(dummy));
++	}
++	if (ret < 0) {
++		int err = wolfSSL_get_error(ctx->active_session->wssl, ret);
++
++		if (err == SOCKET_PEER_CLOSED_E ||
++		    err == WOLFSSL_ERROR_ZERO_RETURN) {
++			/* Peer closed the session, free/reset so a new client
++			 * can connect.
++			 */
++			if (is_server) {
++				ret = dtls_server_free_active_session(ctx);
++			} else {
++				ret = tls_wolfssl_reset_session(ctx);
++			}
++
++			if (ret != 0) {
++				return -ENOMEM;
++			}
++
++			return -ENOTCONN;
++		}
++
++		if (wolfSSL_want_read(ctx->active_session->wssl) ||
++		    wolfSSL_want_write(ctx->active_session->wssl)) {
++			if (is_server) {
++				ret = dtls_server_switch_session_on_rx(ctx);
++				if (ret == 0) {
++					goto again;
++				}
++
++				if (dtls_server_check_expired_sessions(ctx)) {
++					return -ENOTCONN;
++				}
++			}
++
++			return 0;
++		}
++
++		NET_ERR("TLS data check error: %d", err);
++
++		if (is_server) {
++			if (dtls_server_free_active_session(ctx) != 0) {
++				return -ENOMEM;
++			}
++		} else {
++			if (tls_wolfssl_reset_session(ctx) != 0) {
++				return -ENOMEM;
++			}
++		}
++
++		return -ECONNABORTED;
++	}
++
++	return wolfSSL_pending(ctx->active_session->wssl);
++}
++#else /* CONFIG_WOLFSSL */
+ static int dtls_data_check(struct tls_context *ctx)
+ {
+ 	bool is_server = ctx->options.role == MBEDTLS_SSL_IS_SERVER;
+@@ -4012,6 +7187,7 @@ again:
+ 
+ 	return mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl);
+ }
++#endif /* CONFIG_WOLFSSL */
+ 
+ static int dtls_update_pollin(int fd, struct tls_context *ctx,
+ 			      struct zsock_pollfd *pfd)
+@@ -4019,10 +7195,18 @@ static int dtls_update_pollin(int fd, struct tls_context *ctx,
+ 	int ret;
+ 
+ 	/* Already had DTLS data to read on socket. */
++#if defined(CONFIG_WOLFSSL)
++	if (ctx->active_session->wssl != NULL &&
++	    wolfSSL_pending(ctx->active_session->wssl) > 0) {
++		pfd->revents |= ZSOCK_POLLIN;
++		goto next;
++	}
++#else
+ 	if (mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl) > 0) {
+ 		pfd->revents |= ZSOCK_POLLIN;
+ 		goto next;
+ 	}
++#endif /* CONFIG_WOLFSSL */
+ 
+ 	/* Perform data check without incoming data for completed DTLS connections.
+ 	 * This allows the connections to timeout with CONFIG_NET_SOCKETS_DTLS_TIMEOUT.
+@@ -4154,7 +7338,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+ 	 * reports that data is ready.
+ 	 */
+ 	if ((ctx->type != NET_SOCK_DGRAM) ||
+-	    (ctx->options.role != MBEDTLS_SSL_IS_CLIENT)) {
++	    (ctx->options.role != ZTLS_IS_CLIENT)) {
+ 		return false;
+ 	}
+ 
+@@ -4167,13 +7351,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+ 		pfd->revents &= ~ZSOCK_POLLIN;
+ 		return true;
+ 	} else if (!is_handshake_complete(ctx->active_session)) {
+-		uint8_t byte;
++		uint8_t b;
+ 		int ret;
+ 
+ 		/* Handshake didn't start yet - just drop the incoming data -
+ 		 * it's the client who should initiate the handshake.
+ 		 */
+-		ret = zsock_recv(ctx->sock, &byte, sizeof(byte),
++		ret = zsock_recv(ctx->sock, &b, sizeof(b),
+ 				 ZSOCK_MSG_DONTWAIT);
+ 		if (ret < 0) {
+ 			pfd->revents |= ZSOCK_POLLERR;
+@@ -4492,6 +7676,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
+ 		err = tls_opt_cert_verify_callback_set(ctx, optval, optlen);
+ 		break;
+ 
++#if defined(CONFIG_WOLFSSL)
++	case ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL:
++		err = tls_opt_cert_verify_callback_wolfssl_set(ctx, optval, optlen);
++		break;
++	/* Under mbedTLS the option number 21 is reserved but unhandled — it
++	 * falls through to the default case and surfaces as -ENOPROTOOPT,
++	 * which matches the upstream "unknown sockopt" contract.
++	 */
++#endif /* CONFIG_WOLFSSL */
++
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	case ZSOCK_TLS_DTLS_HANDSHAKE_TIMEOUT_MIN:
+ 		err = tls_opt_dtls_handshake_timeout_set(ctx, optval,
+@@ -4538,6 +7732,20 @@ out:
+ }
+ 
+ #if defined(CONFIG_NET_TEST)
++#if defined(CONFIG_WOLFSSL)
++WOLFSSL *ztls_get_wolfssl_context(int fd)
++{
++	struct tls_context *ctx;
++
++	ctx = zvfs_get_fd_obj(fd, (const struct fd_op_vtable *)
++					&tls_sock_fd_op_vtable, EBADF);
++	if (ctx == NULL) {
++		return NULL;
++	}
++
++	return ctx->active_session->wssl;
++}
++#elif defined(CONFIG_MBEDTLS)
+ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
+ {
+ 	struct tls_context *ctx;
+@@ -4550,6 +7758,7 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
+ 
+ 	return &ctx->active_session->ssl;
+ }
++#endif /* CONFIG_WOLFSSL */
+ 
+ uint32_t ztls_get_session_count(void)
+ {
+@@ -4558,15 +7767,15 @@ uint32_t ztls_get_session_count(void)
+ 
+ #endif /* CONFIG_NET_TEST */
+ 
+-static ssize_t tls_sock_read_vmeth(void *obj, void *buffer, size_t count)
++static ssize_t tls_sock_read_vmeth(void *obj, void *buf, size_t count)
+ {
+-	return ztls_recvfrom_ctx(obj, buffer, count, 0, NULL, 0);
++	return ztls_recvfrom_ctx(obj, buf, count, 0, NULL, 0);
+ }
+ 
+-static ssize_t tls_sock_write_vmeth(void *obj, const void *buffer,
++static ssize_t tls_sock_write_vmeth(void *obj, const void *buf,
+ 				    size_t count)
+ {
+-	return ztls_sendto_ctx(obj, buffer, count, 0, NULL, 0);
++	return ztls_sendto_ctx(obj, buf, count, 0, NULL, 0);
+ }
+ 
+ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+@@ -4652,8 +7861,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+ static int tls_sock_shutdown_vmeth(void *obj, int how)
+ {
+ 	struct tls_context *ctx = obj;
++	int ret;
++
++	ret = zsock_shutdown(ctx->sock, how);
++#if defined(CONFIG_WOLFSSL)
++	/* Mark the TLS layer's read side closed only after the underlying
++	 * socket accepted the shutdown — setting recv_eof before forwarding
++	 * would poison the recv path for an unsuccessful shutdown. mbedTLS
++	 * does not consult recv_eof, so the write is gated to the wolfSSL
++	 * backend to keep the mbedTLS contract byte-identical with upstream.
++	 */
++	if (ret == 0 && (how == ZSOCK_SHUT_RD || how == ZSOCK_SHUT_RDWR)) {
++		ctx->recv_eof = true;
++	}
++#endif
+ 
+-	return zsock_shutdown(ctx->sock, how);
++	return ret;
+ }
+ 
+ static int tls_sock_bind_vmeth(void *obj, const struct net_sockaddr *addr,
+diff --git a/subsys/random/CMakeLists.txt b/subsys/random/CMakeLists.txt
+index 4326b7142ad..d88246531ca 100644
+--- a/subsys/random/CMakeLists.txt
++++ b/subsys/random/CMakeLists.txt
+@@ -2,7 +2,8 @@
+ 
+ if(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR
+     CONFIG_TIMER_RANDOM_GENERATOR OR
+-    CONFIG_XOSHIRO_RANDOM_GENERATOR)
++    CONFIG_XOSHIRO_RANDOM_GENERATOR OR
++    CONFIG_WOLFSSL_CSPRNG_GENERATOR)
+ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/random/random.h)
+ zephyr_library()
+ zephyr_library_sources_ifdef(CONFIG_USERSPACE           random_handlers.c)
+@@ -27,3 +28,8 @@ if(CONFIG_CTR_DRBG_CSPRNG_GENERATOR OR CONFIG_PSA_CSPRNG_GENERATOR)
+ zephyr_library_sources(random_psa.c)
+ zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
+ endif()
++
++if(CONFIG_WOLFSSL_CSPRNG_GENERATOR)
++zephyr_library_sources(random_wolfssl.c)
++zephyr_library_link_libraries(wolfSSL)
++endif()
+diff --git a/subsys/random/Kconfig b/subsys/random/Kconfig
+index a759d7b88ed..93ffbef5abe 100644
+--- a/subsys/random/Kconfig
++++ b/subsys/random/Kconfig
+@@ -161,6 +161,17 @@ config PSA_CSPRNG_GENERATOR
+ 	  security-sensitive applications.
+ 
+ 
++config WOLFSSL_CSPRNG_GENERATOR
++	bool "Use wolfSSL Hash-DRBG CSPRNG"
++	depends on WOLFSSL
++	depends on ENTROPY_HAS_DRIVER
++	help
++	  Enables the wolfSSL DRBG cryptographically secure pseudo-random
++	  number generator (wc_RNG). The DRBG uses the entropy API for
++	  its initialization seed and reseeding. The wolfSSL Hash-DRBG is
++	  a NIST SP 800-90A compliant cryptographically secure random
++	  number generator.
++
+ config TEST_CSPRNG_GENERATOR
+ 	bool "Use insecure CSPRNG for testing purposes"
+ 	depends on TEST_RANDOM_GENERATOR
+@@ -170,6 +181,15 @@ config TEST_CSPRNG_GENERATOR
+ 
+ endchoice # CSPRNG_GENERATOR_CHOICE
+ 
++config WOLFSSL_CSPRNG_PERSONALIZATION
++	string "wolfSSL DRBG personalization string"
++	default "zephyr wolfssl-rng seed"
++	depends on WOLFSSL_CSPRNG_GENERATOR
++	help
++	  Personalization (nonce) string fed into the wolfSSL DRBG at
++	  instantiation, in addition to the entropy input from the
++	  entropy driver.
++
+ config CS_CTR_DRBG_PERSONALIZATION
+ 	string "CTR-DRBG Personalization string"
+ 	default "zephyr ctr-drbg seed"
+diff --git a/subsys/random/random_wolfssl.c b/subsys/random/random_wolfssl.c
+new file mode 100644
+index 00000000000..7bdaadef40d
+--- /dev/null
++++ b/subsys/random/random_wolfssl.c
+@@ -0,0 +1,96 @@
++/*
++ * Copyright (c) 2026 wolfSSL Inc.
++ *
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++#include <zephyr/init.h>
++#include <zephyr/device.h>
++#include <zephyr/drivers/entropy.h>
++#include <zephyr/kernel.h>
++#include <string.h>
++
++#ifndef WOLFSSL_USER_SETTINGS
++#include <user_settings.h>
++#endif
++#include <wolfssl/wolfcrypt/settings.h>
++#include <wolfssl/wolfcrypt/random.h>
++
++/*
++ * entropy_dev is initialized at runtime to allow first time initialization
++ * of the wolfSSL DRBG engine.
++ */
++static const struct device *entropy_dev;
++static const unsigned char drbg_seed[] = CONFIG_WOLFSSL_CSPRNG_PERSONALIZATION;
++static bool rng_initialised;
++static K_MUTEX_DEFINE(rng_lock);
++
++static WC_RNG rng_ctx;
++
++static int wolfssl_rng_entropy_cb(OS_Seed *os, byte *seed, word32 sz)
++{
++	return entropy_get_entropy(entropy_dev, (void *)seed, (size_t)sz);
++}
++
++static int wolfssl_rng_initialize(void)
++{
++	int ret;
++
++	entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
++
++	if (!device_is_ready(entropy_dev)) {
++		/* Recoverable error reported through the syscall return — not a
++		 * fatal __ASSERT, so the failure semantics are the same in
++		 * assert-enabled and assert-disabled builds.
++		 */
++		return -ENODEV;
++	}
++
++	ret = wc_SetSeed_Cb(wolfssl_rng_entropy_cb);
++	if (ret != 0) {
++		return -EIO;
++	}
++
++	/* sizeof() - 1 drops the string's NUL terminator so it is not fed into
++	 * the DRBG as personalization data (and an empty string means none).
++	 */
++	ret = wc_InitRngNonce_ex(&rng_ctx, (byte *)drbg_seed, sizeof(drbg_seed) - 1,
++				 NULL, 0);
++	if (ret != 0) {
++		(void)wc_FreeRng(&rng_ctx);
++		return -EIO;
++	}
++
++	rng_initialised = true;
++	return 0;
++}
++
++int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
++{
++	int ret;
++
++	k_mutex_lock(&rng_lock, K_FOREVER);
++
++	if (unlikely(!rng_initialised)) {
++		ret = wolfssl_rng_initialize();
++		if (ret != 0) {
++			/* Already a negative errno (-ENODEV / -EIO); preserve it
++			 * rather than collapsing every init failure to -EIO.
++			 */
++			goto end;
++		}
++	}
++
++	ret = wc_RNG_GenerateBlock(&rng_ctx, (byte *)dst, (word32)outlen);
++	if (ret != 0) {
++		/* Do not leak wolfSSL error codes through the syscall
++		 * contract (0 or negative errno).
++		 */
++		ret = -EIO;
++	}
++
++end:
++	k_mutex_unlock(&rng_lock);
++
++	return ret;
++}

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -8,6 +8,7 @@ Zephyr release.
 |----------------|--------------------------------------------|
 | 3.7            | [3.7/README.md](3.7/README.md)             |
 | 4.3            | [4.3/README.md](4.3/README.md)             |
+| 4.4            | [4.4/README.md](4.4/README.md)             |
 
 For general information on wolfSSL as a Zephyr module, see
 https://github.com/wolfSSL/wolfssl/tree/master/zephyr.


### PR DESCRIPTION
Add a patch for Zephyr `secure_socket` API  support for the latest 4.4.1 Zephyr version. This also splits the patch in a core patch and an optional additional testing patch.

The 4.3 patch is also split into the new core + testing patches.

Latest wolfssl master is required for the 4.4 patches.