### PR TITLE
Removes the wolfSSL-specific QSKIP hunk for Qt certificate unit test

### DIFF
--- a/qt/wolfssl-qt-51518-full.patch
+++ b/qt/wolfssl-qt-51518-full.patch
@@ -515,19 +515,7 @@ index fb268228943..7db754c42d7 100644
  class tst_QSslCertificate : public QObject
  {
      Q_OBJECT
-@@ -992,6 +996,11 @@ void tst_QSslCertificate::nulInSan()
- #endif
-     QList<QSslCertificate> certList =
-         QSslCertificate::fromPath(testDataDir + "more-certificates/badguy-nul-san.crt", QSsl::Pem, QSslCertificate::PatternSyntax::FixedString);
-+#ifndef QT_NO_WOLFSSL
-+    // wolfSSL (PR#10279) rejects certificates with embedded NUL bytes in SAN DNS entries at parse time
-+    if (certList.isEmpty())
-+        QSKIP("wolfSSL rejects certificates with embedded NUL bytes in SAN DNS entries");
-+#endif
-     QCOMPARE(certList.size(), 1);
-
-     const QSslCertificate &cert = certList.at(0);
-@@ -1081,7 +1090,9 @@ void tst_QSslCertificate::multipleCommonNames()
+@@ -1081,7 +1085,9 @@ void tst_QSslCertificate::multipleCommonNames()
      QList<QSslCertificate> certList =
          QSslCertificate::fromPath(testDataDir + "more-certificates/test-cn-two-cns-cert.pem", QSsl::Pem, QSslCertificate::PatternSyntax::FixedString);
      QVERIFY(certList.count() > 0);


### PR DESCRIPTION
## Summary

Removes the wolfSSL-specific `QSKIP` hunk for `tst_QSslCertificate::nulInSan()` from `qt/wolfssl-qt-51518-full.patch`. It is no longer needed and causes the test to be skipped instead of passed.

## Background

`nulInSan()` loads a certificate with a NUL byte embedded in a SAN `dNSName` entry and verifies it parses to a non-empty `certList`.

- wolfSSL PR#10279 added `DecodeGeneralNameCheckChars()` in `wolfcrypt/src/asn.c`, which rejects SAN entries containing NUL bytes at parse time (`ASN_PARSE_E`). This made `certList` empty, so the Qt patch added a `QSKIP` guard to avoid a hard failure.
- wolfSSL PR#10793 ("Restore error code from DecodeGeneralName", `e1a2ba3b` / merged as `7dd269f`) removed `DecodeGeneralNameCheckChars()`, explicitly stopping the rejection of embedded-NUL IA5String SAN values at parse time. Certificates with embedded NUL bytes now parse successfully again, `certList` is no longer empty, and the `QSKIP` guard never triggers — the test now runs and passes on its own.

Keeping the guard is harmless functionally, but it's dead code carried over from a wolfSSL behavior that no longer exists, and its presence is misleading when reading the patch.

## Change

Drop the following hunk from `qt/wolfssl-qt-51518-full.patch`:

```diff
@@ -992,6 +996,11 @@ void tst_QSslCertificate::nulInSan()
 #endif
     QList<QSslCertificate> certList =
         QSslCertificate::fromPath(testDataDir + "more-certificates/badguy-nul-san.crt", QSsl::Pem, QSslCertificate::PatternSyntax::FixedString);
+#ifndef QT_NO_WOLFSSL
+    // wolfSSL (PR#10279) rejects certificates with embedded NUL bytes in SAN DNS entries at parse time
+    if (certList.isEmpty())
+        QSKIP("wolfSSL rejects certificates with embedded NUL bytes in SAN DNS entries");
+#endif
     QCOMPARE(certList.size(), 1);
```

## Testing

Built Qt 5.15.18 with `-wolfssl-linked` against current wolfSSL master (`a4aab71ff`, post-PR#10793) and ran the test directly:

```
PASS   : tst_QSslCertificate::nulInSan()
Totals: 3 passed, 0 failed, 0 skipped, 0 blacklisted
```
