### PR TITLE
wolfProvider/libcryptsetup: add version-independent wolfprov routing patch

### DIFF
--- a/wolfProvider/libcryptsetup/README.md
+++ b/wolfProvider/libcryptsetup/README.md
@@ -1,5 +1,28 @@
-`libcryptsetup-v2.6.1-wolfprov.patch` adds FIPS and non FIPS wolfProvider 
-support for libcryptsetup `v2.6.1`. It disables various tests that use out 
-of bounds or not supported crypto. examples include: `ripemd160`, `whirlpool`, 
-`blake2b-512`, `blake2s-256`, `stribog512`, `kuznyechik`, `argon2i`, `argon2id`, 
-and `pbkdf2`.
+`wolfProvider/libcryptsetup/libcryptsetup-wolfprov-routing.patch` routes
+libcryptsetup's crypto through wolfProvider. It points the provider load in
+`lib/crypto_backend/crypto_openssl.c` at `libwolfprov`, aliases the legacy
+provider handle to it so stock OpenSSL crypto is not pulled back into the
+context, and reports `[libwolfprov]` in place of `[default]` in the backend
+version string (`cryptsetup --debug benchmark 2>&1 | grep 'Crypto backend'`).
+libcryptsetup builds a private `OSSL_LIB_CTX`, so this cannot be done with
+`OPENSSL_CONF` or any environment variable — the source change is the only
+mechanism. The patch contains no test or build-system changes.
+
+It is intentionally version-independent: both hunks carry only context that is
+identical across releases. Verified to apply with no fuzz against every upstream
+tag from 2.4.1 through 2.8.7, and against the Debian source packages for
+bookworm, trixie and sid. It does not apply to 2.4.0 or earlier, which loaded
+providers into the OpenSSL default library context.
+
+Build patched packages with `DEB_BUILD_OPTIONS=nocheck`. Two gaps to expect
+afterwards: wolfProvider serves no Argon2, so a `luksFormat` using LUKS2's
+default Argon2id KDF fails outright rather than writing a non-approved header
+(pass `--pbkdf pbkdf2`); and on cryptsetup before 2.7.0 the compiled-in plain
+mode hash is still `ripemd160`, so plain mode needs `--hash sha256`.
+
+`libcryptsetup-v2.6.1-wolfprov.patch` adds FIPS and non FIPS wolfProvider
+support for libcryptsetup `v2.6.1`. It disables various tests that use out
+of bounds or not supported crypto. examples include: `ripemd160`, `whirlpool`,
+`blake2b-512`, `blake2s-256`, `stribog512`, `kuznyechik`, `argon2i`, `argon2id`,
+and `pbkdf2`. It is pinned to `v2.6.1` and will not apply to 2.7.x or later, so
+use the routing patch above for deployments.

--- a/wolfProvider/libcryptsetup/libcryptsetup-wolfprov-routing.patch
+++ b/wolfProvider/libcryptsetup/libcryptsetup-wolfprov-routing.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/crypto_backend/crypto_openssl.c b/lib/crypto_backend/crypto_openssl.c
+--- a/lib/crypto_backend/crypto_openssl.c
++++ b/lib/crypto_backend/crypto_openssl.c
+@@ -163,12 +163,11 @@ static int openssl_backend_init(bool fips)
+ 			return -EINVAL;
+ 
+-		ossl_default = OSSL_PROVIDER_try_load(ossl_ctx, "default", 0);
++		ossl_default = OSSL_PROVIDER_try_load(ossl_ctx, "libwolfprov", 0);
+ 		if (!ossl_default) {
+ 			OSSL_LIB_CTX_free(ossl_ctx);
+ 			return -EINVAL;
+ 		}
+ 
+-		/* Optional */
+-		ossl_legacy = OSSL_PROVIDER_try_load(ossl_ctx, "legacy", 0);
++		ossl_legacy = ossl_default;
+ 	}
+ 
+@@ -180,3 +179,3 @@ static int openssl_backend_init(bool fips)
+ 		OpenSSL_version(OPENSSL_VERSION),
+-		ossl_default ? "[default]" : "",
++		ossl_default ? "[libwolfprov]" : "",
+ 		ossl_legacy  ? "[legacy]" : "",


### PR DESCRIPTION
Adds `wolfProvider/libcryptsetup/libcryptsetup-wolfprov-routing.patch` — routing only, no test or build-system changes.

libcryptsetup builds a private `OSSL_LIB_CTX` in `openssl_backend_init()` and loads the `default` provider into it by name, so `OPENSSL_CONF` cannot redirect it. The patch repoints that load at `libwolfprov`, aliases the legacy handle to it so stock OpenSSL crypto is not pulled back into the context, and reports `[libwolfprov]` in the backend version string.

No version in the filename: both hunks carry only context that is byte-identical across releases. Verified with no fuzz (`patch --fuzz=0` and `git apply --check`) against every upstream tag from 2.4.1 through 2.8.7, and against the bookworm, trixie and sid source packages. Does not apply to 2.4.0 or earlier, which used the OpenSSL default library context.

The existing `libcryptsetup-v2.6.1-wolfprov.patch` is untouched — it stays for test-suite work on 2.6.1, and its `configure.ac` hunk is upstream as of 2.7.0. README now distinguishes the two so a 2.7.x user does not pick the pinned one.