### PR TITLE
zephyr: update the 4.3 and 4.4 wolfSSL TLS socket patches

### DIFF
--- a/zephyr/4.3/README.md
+++ b/zephyr/4.3/README.md
@@ -6,24 +6,41 @@ for all TLS operations. This will also enable wolfSSL as the default RNG impleme
 feature, first ensure wolfSSL has been added to the west manifest using the instructions from the
 README.md here: https://github.com/wolfSSL/wolfssl/tree/master/zephyr
 
-This integration depends on new Kconfig options added to the wolfSSL Zephyr module; use a wolfSSL
-revision that includes the PR adding Zephyr 4.3 default TLS support (`WOLFSSL_SESSION_EXPORT`,
-`WOLFSSL_KEEP_PEER_CERT`, `WOLFSSL_ALWAYS_VERIFY_CB`, and the `native_sim` timer gate extension).
+This integration depends on Kconfig options added to the wolfSSL Zephyr module for Zephyr default
+TLS support (`WOLFSSL_SESSION_EXPORT`, `WOLFSSL_OPENSSL_EXTRA_X509_SMALL`,
+`WOLFSSL_ALWAYS_VERIFY_CB`, and the `native_sim` timer gate extension). They are all in
+**wolfSSL >= 5.9.2**, so a released wolfSSL is enough.
+
+One later improvement needs **wolfSSL > 5.9.2** (master, or any newer release) - pull request
+[wolfSSL/wolfssl#10983](https://github.com/wolfSSL/wolfssl/pull/10983), merged after
+`v5.9.2-stable`: `wc_port.c`'s `z_time()` now reads the `native_sim`/`native_posix` simulator RTC
+regardless of the selected C library, instead of only under picolibc/newlib. Without it, a
+`native_sim` build on the host libc validates ASN.1 dates against uptime-since-boot. Real targets
+are unaffected.
 
 Once the west manifest has been updated, run west update, then patch the Zephyr tree (run inside the
-`zephyr` directory). The integration ships as two patches:
+`zephyr` directory). The integration ships as three patches:
 
-- **`zephyr-tls-4.3.0.patch`** — the core wolfSSL backend (the BSD-sockets TLS layer and the
+- **`zephyr-tls-4.3.1.patch`** - the core wolfSSL backend (the BSD-sockets TLS layer and the
   RNG/CSPRNG). This is all that is required to use wolfSSL for TLS sockets.
-- **`zephyr-tls-4.3.0-tests.patch`** — the wolfSSL twister test scenarios and the echo_server
+- **`zephyr-tls-4.3.1-tests.patch`** - the wolfSSL twister test scenarios and the echo_server
   sample overlay. Apply it only if you want to run the test suite yourself; it is not needed to
   use the integration. It depends on the core patch, so apply the core patch first.
+- **`zephyr-tls-4.3.1-mbedtls-decoupling.patch`** - optional. Removes the remaining hard mbedTLS
+  dependencies from subsystems whose crypto already runs through the PSA API or the TLS socket
+  layer (mcumgr/UpdateHub DTLS, LwM2M, and uuid v5), so an image using wolfSSL plus the wolfPSA
+  PSA provider can drop `CONFIG_MBEDTLS` entirely. Apply on top of the core patch. The provider
+  side is not part of this patch set: it ships in wolfPSA itself, which is a Zephyr module of its
+  own (`zephyr/` subdirectory, `CONFIG_WOLFPSA=y`) - see
+  https://github.com/wolfSSL/wolfPSA/tree/master/zephyr.
 
 ```
 # required:
-patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.0.patch
+patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.1.patch
 # optional, only to run the tests:
-patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.0-tests.patch
+patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.1-tests.patch
+# optional, to drop mbedTLS entirely (needs wolfSSL + the wolfPSA PSA provider):
+patch -p1 < /path/to/your/osp/zephyr/4.3/zephyr-tls-4.3.1-mbedtls-decoupling.patch
 ```
 
 ### Minimum prj.conf
@@ -43,19 +60,36 @@ Options added by this integration:
 
 | Kconfig | Purpose |
 |---|---|
-| `WOLFSSL_SESSION_EXPORT` | External session cache (serialize sessions across connections) |
-| `WOLFSSL_KEEP_PEER_CERT` | Retain peer certificate after handshake |
-| `WOLFSSL_ALWAYS_VERIFY_CB` | Invoke verify callback on success in addition to failure |
 | `WOLFSSL_VERIFY_CALLBACK` | Enable wolfSSL-native per-cert verify callback via the `TLS_CERT_VERIFY_CALLBACK_WOLFSSL` socket option |
 
-Existing wolfSSL module options (`WOLFSSL_DTLS`, `WOLFSSL_ALPN`, `WOLFSSL_PSK`,
-`WOLFSSL_TLS_VERSION_1_3`, `WOLFSSL_MAX_FRAGMENT_LEN`) are opt-in as usual.
+`CONFIG_NET_SOCKETS_SOCKOPT_TLS` force-selects the wolfSSL module options the backend cannot
+work without, so an application config does not have to set them:
+
+| Kconfig | Purpose |
+|---|---|
+| `WOLFSSL_OPENSSL_EXTRA_X509_SMALL` | Exposes `WOLFSSL_X509_STORE_CTX::current_cert`, which the verify callback reads for the leaf CN/SAN match |
+| `WOLFSSL_ALWAYS_VERIFY_CB` | Invoke verify callback on success in addition to failure - without it the CN/SAN match is silently bypassed |
+| `WOLFSSL_SESSION_CACHE` | wolfSSL compiles the session API out under `NO_SESSION_CACHE`, which the TLS layer needs to link |
+
+`CONFIG_WOLFSSL_SNI` is optional: with it disabled the Server Name Indication extension is not
+sent, but a configured `TLS_HOSTNAME` still drives the certificate CN/SAN match that
+`TLS_PEER_VERIFY` relies on. `CONFIG_WOLFSSL_CRYPTO_ONLY` is incompatible with TLS sockets and
+is rejected with a build error.
+
+Session resumption is a deliberate opt-in: set `CONFIG_WOLFSSL_SESSION_EXPORT=y` (external session
+cache) if you want it - the integration's session store/restore are no-ops without it. Existing
+wolfSSL module options (`WOLFSSL_DTLS`, `WOLFSSL_ALPN`, `WOLFSSL_PSK`, `WOLFSSL_TLS_VERSION_1_3`,
+`WOLFSSL_MAX_FRAGMENT_LEN`) are opt-in as usual.
 
 ### Limitations
 
+- A client that never sets `TLS_HOSTNAME` is rejected under `TLS_PEER_VERIFY_REQUIRED`, because
+  there is no name to check the peer certificate against. This matches the mbedTLS backend, which
+  sets an empty hostname for that case so no certificate can match. Set `TLS_HOSTNAME`, or use
+  `TLS_PEER_VERIFY_OPTIONAL` and read `TLS_CERT_VERIFY_RESULT`, or `TLS_PEER_VERIFY_NONE`.
 - TLS 1.0 and 1.1 disabled (`NO_OLD_TLS`).
 - The mbedTLS-style `TLS_CERT_VERIFY_CALLBACK` socket option is not supported on the wolfSSL backend.
-- `TLS_CERT_NOCOPY` has no effect — certificates are always copied.
+- `TLS_CERT_NOCOPY` has no effect - certificates are always copied.
 - TLS 1.3 0-RTT not wired on the wolfSSL path.
 - OCSP and CRL handling is library-internal on both backends; there is no Zephyr socket-option API for it.
 

--- a/zephyr/4.3/zephyr-tls-4.3.1-mbedtls-decoupling.patch
+++ b/zephyr/4.3/zephyr-tls-4.3.1-mbedtls-decoupling.patch
@@ -1,0 +1,80 @@
+diff --git a/lib/uuid/Kconfig b/lib/uuid/Kconfig
+index 8e1be8ff511..e3feb6d53ac 100644
+--- a/lib/uuid/Kconfig
++++ b/lib/uuid/Kconfig
+@@ -22,8 +22,7 @@ config UUID_V5
+ 	bool "UUID version 5 generation support [EXPERIMENTAL]"
+ 	select EXPERIMENTAL
+ 	depends on UUID
+-	depends on MBEDTLS
+-	depends on MBEDTLS_PSA_CRYPTO_C
++	depends on PSA_CRYPTO_CLIENT
+ 	depends on PSA_WANT_ALG_SHA_1
+ 	# When TF-M is enabled, Mbed TLS's MD module (which is used to generate
+ 	# v5 UUIDs) will dispacth hash operations to TF-M. Unfortunately TF-M
+diff --git a/subsys/mgmt/mcumgr/transport/Kconfig.udp b/subsys/mgmt/mcumgr/transport/Kconfig.udp
+index 19de5cf3ce5..51f3ba474f2 100644
+--- a/subsys/mgmt/mcumgr/transport/Kconfig.udp
++++ b/subsys/mgmt/mcumgr/transport/Kconfig.udp
+@@ -64,8 +64,8 @@ config MCUMGR_TRANSPORT_UDP_MTU
+ 
+ config MCUMGR_TRANSPORT_UDP_DTLS
+ 	bool "DTLS"
+-	select MBEDTLS
+-	select MBEDTLS_ENABLE_HEAP
++	select MBEDTLS if !WOLFSSL
++	select MBEDTLS_ENABLE_HEAP if !WOLFSSL
+ 	select NET_SOCKETS_SOCKOPT_TLS
+ 	select NET_SOCKETS_ENABLE_DTLS
+ 	select TLS_CREDENTIALS
+diff --git a/subsys/mgmt/updatehub/Kconfig b/subsys/mgmt/updatehub/Kconfig
+index dca7aa44936..2dc89ae75fb 100644
+--- a/subsys/mgmt/updatehub/Kconfig
++++ b/subsys/mgmt/updatehub/Kconfig
+@@ -72,8 +72,8 @@ config UPDATEHUB_SHELL
+ 
+ config UPDATEHUB_DTLS
+ 	bool "Activate communication CoAPS/DTLS"
+-	select MBEDTLS
+-	select MBEDTLS_ENABLE_HEAP
++	select MBEDTLS if !WOLFSSL
++	select MBEDTLS_ENABLE_HEAP if !WOLFSSL
+ 	select NET_SOCKETS_SOCKOPT_TLS
+ 	select NET_SOCKETS_ENABLE_DTLS
+ 	help
+diff --git a/subsys/net/lib/lwm2m/lwm2m_engine.c b/subsys/net/lib/lwm2m/lwm2m_engine.c
+index b4dc1d7f536..44dfbbbc4e9 100644
+--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
++++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
+@@ -37,7 +37,14 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+ 
+ #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
+ #include <zephyr/net/tls_credentials.h>
+-#include <mbedtls/ssl_ciphersuites.h>
++
++/* IANA TLS cipher-suite identifiers, defined locally so the LwM2M ciphersuite
++ * list does not pull in an mbedTLS header. The DTLS handshake itself runs
++ * through the TLS socket layer, which may be backed by mbedTLS or wolfSSL.
++ */
++#define LWM2M_TLS_PSK_WITH_AES_128_CCM_8              0xC0A8
++#define LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8      0xC0AE
++#define LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 0xC02B
+ #endif
+ #if defined(CONFIG_DNS_RESOLVER)
+ #include <zephyr/net/dns_resolve.h>
+@@ -1061,12 +1068,12 @@ static int lwm2m_load_tls_credentials(struct lwm2m_ctx *ctx)
+ }
+ 
+ static const int cipher_list_psk[] = {
+-	MBEDTLS_TLS_PSK_WITH_AES_128_CCM_8,
++	LWM2M_TLS_PSK_WITH_AES_128_CCM_8,
+ };
+ 
+ static const int cipher_list_cert[] = {
+-	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
+-	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
++	LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
++	LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+ };
+ 
+ #endif /* CONFIG_LWM2M_DTLS_SUPPORT */

--- a/zephyr/4.3/zephyr-tls-4.3.1-tests.patch
+++ b/zephyr/4.3/zephyr-tls-4.3.1-tests.patch
@@ -1,9 +1,9 @@
 diff --git a/samples/net/sockets/echo_server/overlay-wolfssl.conf b/samples/net/sockets/echo_server/overlay-wolfssl.conf
 new file mode 100644
-index 00000000000..b3a539a5e0a
+index 00000000000..43870a21619
 --- /dev/null
 +++ b/samples/net/sockets/echo_server/overlay-wolfssl.conf
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,24 @@
 +# Copyright (c) 2026 wolfSSL Inc.
 +# SPDX-License-Identifier: Apache-2.0
 +
@@ -28,8 +28,6 @@ index 00000000000..b3a539a5e0a
 +CONFIG_WOLFSSL=y
 +CONFIG_WOLFSSL_DTLS=y
 +CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-+
-+
 diff --git a/samples/net/sockets/echo_server/sample.yaml b/samples/net/sockets/echo_server/sample.yaml
 index 5c075eacc0a..a31d22e0e8d 100644
 --- a/samples/net/sockets/echo_server/sample.yaml
@@ -120,7 +118,7 @@ index 00000000000..9a24eb7a931
 +CONFIG_WOLFSSL=y
 +CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
 diff --git a/tests/net/lib/http_server/tls/src/main.c b/tests/net/lib/http_server/tls/src/main.c
-index 6d710eb350e..ec076b4e4c7 100644
+index 6d710eb350e..39ae4a560c2 100644
 --- a/tests/net/lib/http_server/tls/src/main.c
 +++ b/tests/net/lib/http_server/tls/src/main.c
 @@ -160,7 +160,12 @@ static void test_tls(void)
@@ -129,7 +127,7 @@ index 6d710eb350e..ec076b4e4c7 100644
  
 -		sec_tag_list_size = sizeof(sec_tag_list);
 +		/* sizeof(sec_tag_list_verify_none), not sizeof(sec_tag_list)
-+		 * — the latter is sizeof(pointer), which on 64-bit hosts
++		 * - the latter is sizeof(pointer), which on 64-bit hosts
 +		 * (e.g. native_sim/native/64) feeds an extra garbage sec_tag
 +		 * into setsockopt and breaks credential lookup.
 +		 */
@@ -257,7 +255,7 @@ index 24058c31dd7..9e87ecf9e64 100644
 +CONFIG_MBEDTLS_SSL_ALPN=y
 +CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS=3
 diff --git a/tests/net/socket/tls/src/main.c b/tests/net/socket/tls/src/main.c
-index 8186ba7dbe9..4375fd04c5e 100644
+index 8186ba7dbe9..6b534025ba6 100644
 --- a/tests/net/socket/tls/src/main.c
 +++ b/tests/net/socket/tls/src/main.c
 @@ -12,15 +12,54 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -266,7 +264,7 @@ index 8186ba7dbe9..4375fd04c5e 100644
  #include <zephyr/net/tls_credentials.h>
 +/* IANA TLS ciphersuite IDs used by this file's set_ciphersuites tests.
 + * Names match RFC 4279. Don't introduce a public Zephyr-wide header just
-+ * for these two — both backends accept IANA IDs verbatim via the byte-
++ * for these two - both backends accept IANA IDs verbatim via the byte-
 + * list cipher API.
 + */
 +#define TLS_PSK_WITH_AES_128_CBC_SHA  0x008C
@@ -525,7 +523,7 @@ index 8186ba7dbe9..4375fd04c5e 100644
 + * GCM), measured by running the suite with an oversized buffer and printing
 + * the inbound record length. Different values per backend reflect different
 + * implementation choices for the record-layer framing (header layout, IV
-+ * placement, padding) — they are not part of any wire-format ABI. If a
++ * placement, padding) - they are not part of any wire-format ABI. If a
 + * test starts failing here after a backend or ciphersuite change, re-measure
 + * with an oversized buffer and update.
 + */
@@ -626,11 +624,11 @@ index 8186ba7dbe9..4375fd04c5e 100644
 +	test_prepare_dtls_connection(AF_INET6);
 +
 +	/* Schedule reception shutdown from workqueue while recv() is blocked
-+	 * — exercises the recv_eof check inside the wolfSSL DTLS recv loop
++	 * - exercises the recv_eof check inside the wolfSSL DTLS recv loop
 +	 * (recvfrom_dtls_common_wolfssl). The TCP/TLS variant lives in
 +	 * test_shutdown_rd_while_recv. 50ms margin guards against slow CI
 +	 * runners where recv() hasn't reached its blocking point yet at the
-+	 * 10ms mark — short enough to keep the test fast.
++	 * 10ms mark - short enough to keep the test fast.
 +	 */
 +	k_work_init_delayable(&test_data.work, shutdown_work);
 +	test_data.sock = c_sock;
@@ -857,7 +855,7 @@ index 8186ba7dbe9..4375fd04c5e 100644
 +
 +/* Sets up a TLS client/server connection on a FIXED server port so two
 + * consecutive connections present the same peer address (which is the key
-+ * into client_cache). Used by test_session_cache_client_resume — the
++ * into client_cache). Used by test_session_cache_client_resume - the
 + * main test_prepare_* helpers use ANY_PORT, which prevents resumption
 + * lookup from matching across connections.
 + */
@@ -927,7 +925,7 @@ index 8186ba7dbe9..4375fd04c5e 100644
 +		zsock_close(dummy);
 +	}
 +
-+	/* First connection — should perform full handshake, then store. */
++	/* First connection - should perform full handshake, then store. */
 +	prepare_tls_session_resume_connection(SERVER_PORT);
 +
 +#if defined(CONFIG_WOLFSSL)
@@ -952,7 +950,7 @@ index 8186ba7dbe9..4375fd04c5e 100644
 +	test_sockets_close();
 +	k_sleep(TCP_TEARDOWN_TIMEOUT);
 +
-+	/* Second connection to the SAME server port — should restore the
++	/* Second connection to the SAME server port - should restore the
 +	 * stored session and resume.
 +	 */
 +	prepare_tls_session_resume_connection(SERVER_PORT);
@@ -1338,7 +1336,7 @@ index 00000000000..ca2568bb15d
 +CONFIG_WOLFSSL_SESSION_EXPORT=y
 +CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
 diff --git a/tests/net/socket/tls_ext/src/main.c b/tests/net/socket/tls_ext/src/main.c
-index ffc4c5630fd..e2f5d8a780d 100644
+index ffc4c5630fd..39e2ef58ff2 100644
 --- a/tests/net/socket/tls_ext/src/main.c
 +++ b/tests/net/socket/tls_ext/src/main.c
 @@ -10,11 +10,17 @@
@@ -1359,7 +1357,25 @@ index ffc4c5630fd..e2f5d8a780d 100644
  
  LOG_MODULE_REGISTER(tls_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
  
-@@ -434,9 +440,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
+@@ -336,9 +342,14 @@ static int test_configure_client(struct sockaddr_in *sa, bool own_cert,
+ 		       sec_tag_list, sec_tag_list_size);
+ 	zassert_not_equal(r, -1, "failed to set TLS_SEC_TAG_LIST (%d)", errno);
+ 
+-	r = setsockopt(client_fd, SOL_TLS, TLS_HOSTNAME, hostname,
+-		       strlen(hostname) + 1);
+-	zassert_not_equal(r, -1, "failed to set TLS_HOSTNAME (%d)", errno);
++	/* A NULL hostname leaves TLS_HOSTNAME unset, which both backends treat
++	 * as a peer identity that cannot be verified.
++	 */
++	if (hostname != NULL) {
++		r = setsockopt(client_fd, SOL_TLS, TLS_HOSTNAME, hostname,
++			       strlen(hostname) + 1);
++		zassert_not_equal(r, -1, "failed to set TLS_HOSTNAME (%d)", errno);
++	}
+ 
+ 	sa->sin_family = AF_INET;
+ 	sa->sin_port = htons(PORT);
+@@ -434,9 +445,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
  
  ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_required)
  {
@@ -1377,10 +1393,61 @@ index ffc4c5630fd..e2f5d8a780d 100644
  static void test_tls_cert_verify_result_opt_common(uint32_t expect)
  {
  	int server_fd, client_fd, ret;
-@@ -481,13 +495,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
+@@ -481,13 +500,68 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
  	test_tls_cert_verify_result_opt_common(MBEDTLS_X509_BADCERT_CN_MISMATCH);
  }
  
++/* A client that never sets TLS_HOSTNAME has no name to check the peer
++ * certificate against, so TLS_PEER_VERIFY_REQUIRED must reject it rather
++ * than accept a certificate issued for any name.
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_no_hostname_required_rejected)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct sockaddr_in sa;
++	int peer_verify = TLS_PEER_VERIFY_REQUIRED;
++
++	server_fd = test_configure_server(&server_thread_id, TLS_PEER_VERIFY_NONE,
++					  false, true);
++	client_fd = test_configure_client(&sa, false, NULL);
++
++	ret = setsockopt(client_fd, SOL_TLS, TLS_PEER_VERIFY,
++			 &peer_verify, sizeof(peer_verify));
++	zassert_ok(ret, "failed to set TLS_PEER_VERIFY (%d)", errno);
++
++	ret = connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, -1, "connect succeeded without a hostname to verify");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++/* TLS_PEER_VERIFY_NONE means no peer verification at all, so a hostname
++ * that cannot match must not fail the handshake. Guards against the name
++ * check making NONE stricter than OPTIONAL.
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_verify_none_ignores_hostname)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct sockaddr_in sa;
++	int peer_verify = TLS_PEER_VERIFY_NONE;
++
++	server_fd = test_configure_server(&server_thread_id, TLS_PEER_VERIFY_NONE,
++					  false, false);
++	client_fd = test_configure_client(&sa, false, "dummy");
++
++	ret = setsockopt(client_fd, SOL_TLS, TLS_PEER_VERIFY,
++			 &peer_verify, sizeof(peer_verify));
++	zassert_ok(ret, "failed to set TLS_PEER_VERIFY (%d)", errno);
++
++	ret = connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
++	zassert_not_equal(ret, -1, "TLS_PEER_VERIFY_NONE rejected a hostname mismatch (%d)",
++			  errno);
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
 +/* --- Unified cert verify callback tests (mbedTLS backend only) --- */
 +
 +#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK) && !defined(CONFIG_WOLFSSL)
@@ -1396,7 +1463,7 @@ index ffc4c5630fd..e2f5d8a780d 100644
  {
  	struct test_cert_verify_ctx *test_ctx = (struct test_cert_verify_ctx *)ctx;
  
-@@ -507,6 +525,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
+@@ -507,6 +581,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
  	int server_fd, client_fd, ret;
  	k_tid_t server_thread_id;
  	struct sockaddr_in sa;
@@ -1404,7 +1471,7 @@ index ffc4c5630fd..e2f5d8a780d 100644
  	struct test_cert_verify_ctx ctx = {
  		.cb_called = false,
  		.result = result,
-@@ -546,10 +565,49 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
+@@ -546,10 +621,49 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
  	test_tls_cert_verify_cb_opt_common(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED);
  }
  
@@ -1454,7 +1521,7 @@ index ffc4c5630fd..e2f5d8a780d 100644
  	/*
  	 * Load both client & server credentials
  	 *
-@@ -599,4 +657,328 @@ static void *setup(void)
+@@ -599,4 +713,328 @@ static void *setup(void)
  	return NULL;
  }
  

--- a/zephyr/4.3/zephyr-tls-4.3.1.patch
+++ b/zephyr/4.3/zephyr-tls-4.3.1.patch
@@ -73,7 +73,7 @@ index 7bad851f238..39f97bc86d8 100644
  
 diff --git a/include/zephyr/net/tls_verify.h b/include/zephyr/net/tls_verify.h
 new file mode 100644
-index 00000000000..92ac4f1dd22
+index 00000000000..f33f007d5aa
 --- /dev/null
 +++ b/include/zephyr/net/tls_verify.h
 @@ -0,0 +1,139 @@
@@ -88,7 +88,7 @@ index 00000000000..92ac4f1dd22
 + *
 + * The wolfSSL backend accumulates certificate verification errors into the
 + * TLS_CERT_VERIFY_RESULT getsockopt bitmask using the same hex values as
-+ * mbedtls/x509.h's MBEDTLS_X509_BADCERT_* macros — the layout is part of
++ * mbedtls/x509.h's MBEDTLS_X509_BADCERT_* macros - the layout is part of
 + * the TLS_CERT_VERIFY_RESULT public contract and predates the wolfSSL
 + * backend. Applications that already include mbedtls/x509.h are
 + * automatically protected from redefinition by the #ifndef guards below.
@@ -226,10 +226,10 @@ index 7e32b540ce4..a51a9a3b74d 100644
  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
 +zephyr_library_link_libraries_ifdef(CONFIG_WOLFSSL wolfSSL)
 diff --git a/subsys/net/lib/sockets/Kconfig b/subsys/net/lib/sockets/Kconfig
-index c676c32ddf1..bd23d0f3375 100644
+index c676c32ddf1..88d827d86a0 100644
 --- a/subsys/net/lib/sockets/Kconfig
 +++ b/subsys/net/lib/sockets/Kconfig
-@@ -128,7 +128,32 @@ config NET_SOCKETS_SERVICE_STACK_SIZE
+@@ -128,7 +128,33 @@ config NET_SOCKETS_SERVICE_STACK_SIZE
  config NET_SOCKETS_SOCKOPT_TLS
  	bool "TCP TLS socket option support"
  	imply TLS_CREDENTIALS
@@ -238,7 +238,6 @@ index c676c32ddf1..bd23d0f3375 100644
 +	# wolfSSL backend requirements. The integration calls a narrow set of
 +	# non-base wolfSSL APIs; only the strict minimum is force-selected
 +	# here to keep flash/RAM cost on constrained targets low:
-+	#   SET_CIPHER_BYTES - wolfSSL_set_cipher_list_bytes (small)
 +	#   OPENSSL_EXTRA_X509_SMALL - exposes WOLFSSL_X509_STORE_CTX::current_cert
 +	#                      which the verify callback reads to perform the
 +	#                      leaf CN/SAN match. wolfSSL gates the whole
@@ -253,17 +252,19 @@ index c676c32ddf1..bd23d0f3375 100644
 +	# HAVE_EXT_CACHE is undefined, so enabling it is an explicit opt-in.
 +	# (wolfSSL_clear, wolfSSL_X509_check_host and wolfSSL_set_verify are
 +	# always available in src/ssl.c / src/x509.c / src/ssl_api_cert.c.)
++	# WOLFSSL_SET_CIPHER_BYTES (wolfSSL_set_cipher_list_bytes) needs no
++	# select: the module's user_settings.h defines it from this symbol.
 +	# Gated on `WOLFSSL && !MBEDTLS` because the backends are mutually
 +	# exclusive: pulling these wolfSSL knobs in on an mbedTLS build (e.g.
 +	# when CONFIG_WOLFSSL=y is enabled for the random subsystem only) is
 +	# pure bloat and risks user confusion.
-+	select WOLFSSL_SET_CIPHER_BYTES if WOLFSSL && !MBEDTLS
 +	select WOLFSSL_OPENSSL_EXTRA_X509_SMALL if WOLFSSL && !MBEDTLS
 +	select WOLFSSL_ALWAYS_VERIFY_CB if WOLFSSL && !MBEDTLS
++	select WOLFSSL_SESSION_CACHE if WOLFSSL && !MBEDTLS
  	imply MBEDTLS_SSL_PROTO_TLS1_2 if !NET_L2_OPENTHREAD
  	imply MBEDTLS_MD_C if !NET_L2_OPENTHREAD
  	imply MBEDTLS_RSA_C if !NET_L2_OPENTHREAD
-@@ -142,6 +167,45 @@ config NET_SOCKETS_SOCKOPT_TLS
+@@ -142,6 +168,45 @@ config NET_SOCKETS_SOCKOPT_TLS
  	  Enable TLS socket option support which automatically establishes
  	  a TLS connection to the remote host.
  
@@ -309,7 +310,7 @@ index c676c32ddf1..bd23d0f3375 100644
  config NET_SOCKETS_TLS_PRIORITY
  	int "Default processing priority for TLS sockets"
  	default 45
-@@ -153,15 +217,18 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+@@ -153,15 +218,18 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
  	bool "Set Maximum Fragment Length (MFL)"
  	default y
  	help
@@ -336,7 +337,7 @@ index c676c32ddf1..bd23d0f3375 100644
  
  	  This is mostly useful for TLS client side to tell TLS server what is
  	  the maximum supported receive record length.
-@@ -169,7 +236,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+@@ -169,7 +237,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
  config NET_SOCKETS_ENABLE_DTLS
  	bool "DTLS socket support"
  	depends on NET_SOCKETS_SOCKOPT_TLS
@@ -345,7 +346,7 @@ index c676c32ddf1..bd23d0f3375 100644
  	help
  	  Enable DTLS socket support. By default only TLS over TCP is supported.
  
-@@ -248,7 +315,7 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
+@@ -248,7 +316,7 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
  config NET_SOCKETS_TLS_MAX_APP_PROTOCOLS
  	int "Maximum number of supported application layer protocols"
  	default 2
@@ -354,7 +355,7 @@ index c676c32ddf1..bd23d0f3375 100644
  	help
  	  This variable sets maximum number of supported application layer
  	  protocols over TLS/DTLS that can be set explicitly by a socket option.
-@@ -263,12 +330,41 @@ config NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT
+@@ -263,12 +331,41 @@ config NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT
  	  used for TLS/DTLS session resumption.
  
  config NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK
@@ -401,7 +402,7 @@ index c676c32ddf1..bd23d0f3375 100644
  config NET_SOCKETS_OFFLOAD
  	bool "Offload Socket APIs"
 diff --git a/subsys/net/lib/sockets/sockets_tls.c b/subsys/net/lib/sockets/sockets_tls.c
-index 0a0b360291d..5cc70f1545e 100644
+index 0a0b360291d..bb5c99b5f5e 100644
 --- a/subsys/net/lib/sockets/sockets_tls.c
 +++ b/subsys/net/lib/sockets/sockets_tls.c
 @@ -47,6 +47,12 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -417,10 +418,19 @@ index 0a0b360291d..5cc70f1545e 100644
  #endif /* CONFIG_MBEDTLS */
  
  #include "sockets_internal.h"
-@@ -56,6 +62,93 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
+@@ -56,6 +62,118 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
  #include <zephyr_mbedtls_priv.h>
  #endif
  
++#if defined(CONFIG_WOLFSSL) && defined(CONFIG_MBEDTLS)
++/* The two TLS-socket backends are mutually exclusive: their function blocks
++ * define the same ZTLS_* macros and IO callbacks. Fail early with an actionable
++ * message instead of a downstream macro-redefinition / VERIFY_CB #error.
++ */
++#error "wolfSSL and mbedTLS TLS-socket backends are mutually exclusive; " \
++       "enable exactly one of CONFIG_WOLFSSL / CONFIG_MBEDTLS."
++#endif
++
 +#if defined(CONFIG_WOLFSSL)
 +/* wolfssl/wolfcrypt/settings.h's WOLFSSL_ZEPHYR block #defines POSIX
 + * socket names (socket, bind, connect, ..., getsockname) to their
@@ -432,11 +442,11 @@ index 0a0b360291d..5cc70f1545e 100644
 + * Suppress with a hard #undef right before each wolfSSL header include
 + * rather than save-and-restore via #pragma push_macro/pop_macro: the
 + * push form would silently capture (and later reinstall) whatever
-+ * upstream header had previously defined these names as macros — a
++ * upstream header had previously defined these names as macros - a
 + * future addition would be invisible at review time and break the
 + * vtable. The #undef form makes it a build error instead.
 + *
-+ * List mirrors the WOLFSSL_ZEPHYR remappings as of wolfSSL master —
++ * List mirrors the WOLFSSL_ZEPHYR remappings as of wolfSSL master -
 + * revisit on uprev.
 + */
 +#undef socket
@@ -492,7 +502,23 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && !defined(WOLFSSL_DTLS)
 +#error "DTLS sockets enabled but wolfssl DTLS not enabled"
-+#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && !WOLFSSL_DTLS */
++#endif
++
++/* WOLFCRYPT_ONLY compiles the whole wolfSSL TLS layer out, so every
++ * wolfSSL_* call below would fail to link.
++ */
++#if defined(WOLFCRYPT_ONLY)
++#error "Zephyr TLS sockets need the wolfSSL TLS layer " \
++       "(disable CONFIG_WOLFSSL_CRYPTO_ONLY)"
++#endif /* WOLFCRYPT_ONLY */
++
++/* The session-cache paths below call wolfSSL_CTX_set_session_cache_mode(),
++ * wolfSSL_get1_session() and friends, all compiled out by NO_SESSION_CACHE.
++ */
++#if defined(NO_SESSION_CACHE)
++#error "Zephyr TLS sockets with wolfSSL require the session cache " \
++       "(enable CONFIG_WOLFSSL_SESSION_CACHE)"
++#endif /* NO_SESSION_CACHE */ /* CONFIG_NET_SOCKETS_ENABLE_DTLS && !WOLFSSL_DTLS */
 +
 +#define ZTLS_IS_CLIENT        0
 +#define ZTLS_IS_SERVER        1
@@ -511,7 +537,7 @@ index 0a0b360291d..5cc70f1545e 100644
  #if defined(CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS)
  #define ALPN_MAX_PROTOCOLS (CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS + 1)
  #else
-@@ -114,14 +207,14 @@ struct tls_session_cache {
+@@ -114,14 +232,14 @@ struct tls_session_cache {
  	size_t session_len;
  };
  
@@ -528,7 +554,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  /** TLS context information. */
  __net_socket struct tls_context {
-@@ -143,6 +236,21 @@ __net_socket struct tls_context {
+@@ -143,6 +261,26 @@ __net_socket struct tls_context {
  	/** Session ended at the TLS/DTLS level. */
  	bool session_closed : 1;
  
@@ -545,12 +571,17 @@ index 0a0b360291d..5cc70f1545e 100644
 +	 *  to upstream.
 +	 */
 +	bool recv_eof : 1;
++
++	/* Set once the application configured TLS_DTLS_ROLE explicitly, so
++	 * tls_wolfssl_init() derives the role only when it was left to us.
++	 */
++	bool role_set : 1;
 +#endif /* CONFIG_WOLFSSL */
 +
  	/** Socket type. */
  	enum net_sock_type type;
  
-@@ -203,22 +311,30 @@ __net_socket struct tls_context {
+@@ -203,22 +341,30 @@ __net_socket struct tls_context {
  		uint32_t dtls_handshake_timeout_min;
  		uint32_t dtls_handshake_timeout_max;
  
@@ -583,7 +614,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	/** DTLS peer address. */
  	struct sockaddr dtls_peer_addr;
-@@ -227,7 +343,36 @@ __net_socket struct tls_context {
+@@ -227,7 +373,36 @@ __net_socket struct tls_context {
  	socklen_t dtls_peer_addrlen;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
  
@@ -621,14 +652,14 @@ index 0a0b360291d..5cc70f1545e 100644
  	/** mbedTLS context. */
  	mbedtls_ssl_context ssl;
  
-@@ -252,7 +397,31 @@ __net_socket struct tls_context {
+@@ -252,7 +427,31 @@ __net_socket struct tls_context {
  /* A global pool of TLS contexts. */
  static struct tls_context tls_contexts[CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS];
  
 +/* Client-side session cache. mbedTLS uses it unconditionally. wolfSSL only
 + * uses it when HAVE_EXT_CACHE is defined (CONFIG_WOLFSSL_SESSION_EXPORT)
 + * because session import/export requires the wolfSSL_d2i/i2d APIs gated
-+ * on that macro — without it tls_session_store/restore are no-ops and
++ * on that macro - without it tls_session_store/restore are no-ops and
 + * the cache stays empty, so leave it (and its mutex / reset helper) out
 + * of .bss entirely.
 + */
@@ -653,7 +684,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  #if defined(MBEDTLS_SSL_CACHE_C)
  static mbedtls_ssl_cache_context server_cache;
-@@ -266,6 +435,14 @@ static struct k_mutex context_lock;
+@@ -266,6 +465,14 @@ static struct k_mutex context_lock;
   */
  #define TLS_WAIT_MS 100
  
@@ -668,7 +699,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static void tls_session_cache_reset(void)
  {
  	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
-@@ -276,12 +453,23 @@ static void tls_session_cache_reset(void)
+@@ -276,12 +483,28 @@ static void tls_session_cache_reset(void)
  
  	(void)memset(client_cache, 0, sizeof(client_cache));
  }
@@ -681,6 +712,11 @@ index 0a0b360291d..5cc70f1545e 100644
 +	k_mutex_lock(&client_cache_lock, K_FOREVER);
 +	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
 +		if (client_cache[i].session != NULL) {
++			/* Serialized session holds the TLS master/resumption
++			 * secret; scrub before releasing to the heap.
++			 */
++			wc_ForceZero(client_cache[i].session,
++				     client_cache[i].session_len);
 +			XFREE(client_cache[i].session, NULL,
 +			      DYNAMIC_TYPE_TMP_BUFFER);
 +		}
@@ -695,7 +731,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int tls_ctr_drbg_random(void *ctx, unsigned char *buf, size_t len)
  {
  	ARG_UNUSED(ctx);
-@@ -294,8 +482,25 @@ static int tls_ctr_drbg_random(void *ctx, unsigned char *buf, size_t len)
+@@ -294,8 +517,25 @@ static int tls_ctr_drbg_random(void *ctx, unsigned char *buf, size_t len)
  	return 0;
  #endif
  }
@@ -722,7 +758,7 @@ index 0a0b360291d..5cc70f1545e 100644
  /* mbedTLS-defined function for setting timer. */
  static void dtls_timing_set_delay(void *data, uint32_t int_ms, uint32_t fin_ms)
  {
-@@ -357,7 +562,7 @@ static int dtls_get_remaining_timeout(struct tls_context *ctx)
+@@ -357,7 +597,7 @@ static int dtls_get_remaining_timeout(struct tls_context *ctx)
  
  	return timing->fin_ms - elapsed_ms;
  }
@@ -731,7 +767,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  /* Initialize TLS internals. */
  static int tls_init(void)
-@@ -369,7 +574,9 @@ static int tls_init(void)
+@@ -369,7 +609,9 @@ static int tls_init(void)
  #endif
  
  	(void)memset(tls_contexts, 0, sizeof(tls_contexts));
@@ -741,7 +777,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	k_mutex_init(&context_lock);
  
-@@ -377,6 +584,34 @@ static int tls_init(void)
+@@ -377,6 +619,34 @@ static int tls_init(void)
  	mbedtls_ssl_cache_init(&server_cache);
  #endif
  
@@ -776,7 +812,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	return 0;
  }
  
-@@ -437,8 +672,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
+@@ -437,8 +707,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
  	mbedtls_ssl_conf_max_frag_len(config, mfl_code);
  }
  #else
@@ -787,7 +823,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  /* Allocate TLS context. */
  static struct tls_context *tls_alloc(void)
-@@ -468,6 +705,15 @@ static struct tls_context *tls_alloc(void)
+@@ -468,6 +740,15 @@ static struct tls_context *tls_alloc(void)
  	if (tls) {
  		k_sem_init(&tls->tls_established, 0, 1);
  
@@ -803,7 +839,7 @@ index 0a0b360291d..5cc70f1545e 100644
  		mbedtls_ssl_init(&tls->ssl);
  		mbedtls_ssl_config_init(&tls->config);
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-@@ -489,6 +735,7 @@ static struct tls_context *tls_alloc(void)
+@@ -489,6 +770,7 @@ static struct tls_context *tls_alloc(void)
  #if defined(CONFIG_MBEDTLS_DEBUG)
  		mbedtls_ssl_conf_dbg(&tls->config, zephyr_mbedtls_debug, NULL);
  #endif
@@ -811,7 +847,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	} else {
  		NET_WARN("Failed to allocate TLS context");
  	}
-@@ -512,12 +759,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
+@@ -512,12 +794,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
  	memcpy(&target_tls->options, &source_tls->options,
  	       sizeof(target_tls->options));
  
@@ -839,7 +875,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	return target_tls;
  }
-@@ -535,6 +795,39 @@ static int tls_release(struct tls_context *tls)
+@@ -535,6 +830,39 @@ static int tls_release(struct tls_context *tls)
  		return -EBADF;
  	}
  
@@ -879,7 +915,7 @@ index 0a0b360291d..5cc70f1545e 100644
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  	mbedtls_ssl_cookie_free(&tls->cookie);
  #endif
-@@ -545,12 +838,19 @@ static int tls_release(struct tls_context *tls)
+@@ -545,12 +873,19 @@ static int tls_release(struct tls_context *tls)
  	mbedtls_x509_crt_free(&tls->own_cert);
  	mbedtls_pk_free(&tls->priv_key);
  #endif
@@ -899,7 +935,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static bool peer_addr_cmp(const struct sockaddr *addr,
  			  const struct sockaddr *peer_addr)
  {
-@@ -574,7 +874,9 @@ static bool peer_addr_cmp(const struct sockaddr *addr,
+@@ -574,7 +909,9 @@ static bool peer_addr_cmp(const struct sockaddr *addr,
  
  	return false;
  }
@@ -909,7 +945,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int tls_session_save(const struct sockaddr *peer_addr,
  			    mbedtls_ssl_session *session)
  {
-@@ -743,6 +1045,226 @@ static void tls_session_purge(void)
+@@ -743,6 +1080,243 @@ static void tls_session_purge(void)
  	mbedtls_ssl_cache_init(&server_cache);
  #endif
  }
@@ -937,9 +973,13 @@ index 0a0b360291d..5cc70f1545e 100644
 +				break;
 +			}
 +
++			/* No free slot and no peer match yet: keep the
++			 * least-recently-used (oldest, i.e. smallest timestamp)
++			 * used slot as the eviction candidate.
++			 */
 +			if (entry == NULL ||
 +			    (entry->session != NULL &&
-+			     entry->timestamp < client_cache[i].timestamp)) {
++			     entry->timestamp > client_cache[i].timestamp)) {
 +				entry = &client_cache[i];
 +			}
 +		}
@@ -950,6 +990,8 @@ index 0a0b360291d..5cc70f1545e 100644
 +	}
 +
 +	if (entry->session != NULL) {
++		/* Evicted blob holds session secret material; scrub it. */
++		wc_ForceZero(entry->session, entry->session_len);
 +		XFREE(entry->session, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +		entry->session = NULL;
 +		entry->session_len = 0;
@@ -1035,6 +1077,13 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +exit:
 +	if (serialized != NULL) {
++		/* On the reserve-failure path this still holds the fully
++		 * serialized session (secret); scrub the written bytes. size is
++		 * the i2d length (>0 only once serialization succeeded).
++		 */
++		if (size > 0) {
++			wc_ForceZero(serialized, (size_t)size);
++		}
 +		XFREE(serialized, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +	}
 +	wolfSSL_SESSION_free(session);
@@ -1105,6 +1154,8 @@ index 0a0b360291d..5cc70f1545e 100644
 +			if (client_cache[i].session != NULL &&
 +			    peer_addr_cmp(&client_cache[i].peer_addr,
 +					  &peer_addr)) {
++				wc_ForceZero(client_cache[i].session,
++					     client_cache[i].session_len);
 +				XFREE(client_cache[i].session, NULL,
 +				      DYNAMIC_TYPE_TMP_BUFFER);
 +				client_cache[i].session = NULL;
@@ -1113,6 +1164,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +			}
 +		}
 +		k_mutex_unlock(&client_cache_lock);
++		wc_ForceZero(serialized_copy, serialized_len);
 +		XFREE(serialized_copy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +		return;
 +	}
@@ -1122,6 +1174,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +	}
 +
 +	wolfSSL_SESSION_free(session);
++	wc_ForceZero(serialized_copy, serialized_len);
 +	XFREE(serialized_copy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +#endif /* HAVE_EXT_CACHE */
 +}
@@ -1136,7 +1189,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  static inline int time_left(uint32_t start, uint32_t timeout)
  {
-@@ -751,6 +1273,7 @@ static inline int time_left(uint32_t start, uint32_t timeout)
+@@ -751,6 +1325,7 @@ static inline int time_left(uint32_t start, uint32_t timeout)
  	return timeout - elapsed;
  }
  
@@ -1144,7 +1197,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int wait(int sock, int timeout, int event)
  {
  	struct zsock_pollfd fds = {
-@@ -789,11 +1312,11 @@ static int wait(int sock, int timeout, int event)
+@@ -789,11 +1364,11 @@ static int wait(int sock, int timeout, int event)
  
  static int wait_for_reason(int sock, int timeout, int reason)
  {
@@ -1158,7 +1211,7 @@ index 0a0b360291d..5cc70f1545e 100644
  		return wait(sock, timeout, ZSOCK_POLLOUT);
  	}
  
-@@ -862,7 +1385,8 @@ static void dtls_peer_address_get(struct tls_context *context,
+@@ -862,7 +1437,8 @@ static void dtls_peer_address_get(struct tls_context *context,
  	*addrlen = len;
  }
  
@@ -1168,7 +1221,7 @@ index 0a0b360291d..5cc70f1545e 100644
  {
  	struct tls_context *tls_ctx = ctx;
  	ssize_t sent;
-@@ -870,67 +1394,80 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
+@@ -870,60 +1446,136 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
  	sent = zsock_sendto(tls_ctx->sock, buf, len, ZSOCK_MSG_DONTWAIT,
  			    &tls_ctx->dtls_peer_addr,
  			    tls_ctx->dtls_peer_addrlen);
@@ -1211,7 +1264,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +	if (received == 0) {
 +		/* The underlying datagram socket reports EOF (typically
 +		 * because the local read side was shut down). Signal it as
-+		 * CBIO_ERR_CONN_CLOSE — symmetry with the TCP tls_wolf_rx
++		 * CBIO_ERR_CONN_CLOSE - symmetry with the TCP tls_wolf_rx
 +		 * callback. Without this wolfSSL treats the 0-byte read as
 +		 * an incomplete record and loops back via WANT_READ.
 +		 */
@@ -1251,32 +1304,29 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	return received;
  }
--#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
--
--static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
 +#else
 +static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
- {
- 	struct tls_context *tls_ctx = ctx;
- 	ssize_t sent;
- 
--	sent = zsock_sendto(tls_ctx->sock, buf, len,
--			    ZSOCK_MSG_DONTWAIT, NULL, 0);
++{
++	struct tls_context *tls_ctx = ctx;
++	ssize_t sent;
++
 +	sent = zsock_sendto(tls_ctx->sock, buf, len, ZSOCK_MSG_DONTWAIT,
 +			    &tls_ctx->dtls_peer_addr,
 +			    tls_ctx->dtls_peer_addrlen);
- 	if (sent < 0) {
- 		if (errno == EAGAIN) {
- 			return MBEDTLS_ERR_SSL_WANT_WRITE;
-@@ -942,10 +1479,73 @@ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
- 	return sent;
- }
- 
--static int tls_rx(void *ctx, unsigned char *buf, size_t len)
++	if (sent < 0) {
++		if (errno == EAGAIN) {
++			return MBEDTLS_ERR_SSL_WANT_WRITE;
++		}
++
++		return MBEDTLS_ERR_NET_SEND_FAILED;
++	}
++
++	return sent;
++}
++
 +static int dtls_rx(void *ctx, unsigned char *buf, size_t len)
- {
- 	struct tls_context *tls_ctx = ctx;
--	ssize_t received;
++{
++	struct tls_context *tls_ctx = ctx;
 +	socklen_t addrlen = sizeof(struct sockaddr);
 +	struct sockaddr addr;
 +	int err;
@@ -1316,35 +1366,13 @@ index 0a0b360291d..5cc70f1545e 100644
 +	return received;
 +}
 +#endif /* CONFIG_WOLFSSL */
-+#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
-+
-+#if defined(CONFIG_MBEDTLS)
-+static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
-+{
-+	struct tls_context *tls_ctx = ctx;
-+	ssize_t sent;
-+
-+	sent = zsock_sendto(tls_ctx->sock, buf, len,
-+			    ZSOCK_MSG_DONTWAIT, NULL, 0);
-+	if (sent < 0) {
-+		if (errno == EAGAIN) {
-+			return MBEDTLS_ERR_SSL_WANT_WRITE;
-+		}
-+
-+		return MBEDTLS_ERR_NET_SEND_FAILED;
-+	}
-+
-+	return sent;
-+}
-+
-+static int tls_rx(void *ctx, unsigned char *buf, size_t len)
-+{
-+	struct tls_context *tls_ctx = ctx;
-+	ssize_t received;
+ #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
  
- 	received = zsock_recvfrom(tls_ctx->sock, buf, len,
- 				  ZSOCK_MSG_DONTWAIT, NULL, 0);
-@@ -959,6 +1559,85 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
++#if defined(CONFIG_MBEDTLS)
+ static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
+ {
+ 	struct tls_context *tls_ctx = ctx;
+@@ -959,6 +1611,85 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
  
  	return received;
  }
@@ -1430,7 +1458,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
  static bool crt_is_pem(const unsigned char *buf, size_t buflen)
-@@ -971,7 +1650,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
+@@ -971,7 +1702,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
  static int tls_add_ca_certificate(struct tls_context *tls,
  				  struct tls_credential *ca_cert)
  {
@@ -1456,7 +1484,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	int err;
  
  	if (tls->options.cert_nocopy == TLS_CERT_NOCOPY_NONE ||
-@@ -995,6 +1691,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
+@@ -995,6 +1743,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
  	return -ENOTSUP;
  }
  
@@ -1464,7 +1492,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static void tls_set_ca_chain(struct tls_context *tls)
  {
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
-@@ -1003,11 +1700,27 @@ static void tls_set_ca_chain(struct tls_context *tls)
+@@ -1003,11 +1752,32 @@ static void tls_set_ca_chain(struct tls_context *tls)
  				      &mbedtls_x509_crt_profile_default);
  #endif /* MBEDTLS_X509_CRT_PARSE_C */
  }
@@ -1481,7 +1509,12 @@ index 0a0b360291d..5cc70f1545e 100644
 +	if (crt_is_pem(own_cert->buf, own_cert->len)) {
 +		format = WOLFSSL_FILETYPE_PEM;
 +	}
-+	ret = wolfSSL_CTX_use_certificate_buffer(tls->ctx, own_cert->buf,
++	/* Chain variant, not the single-certificate one: applications ship the
++	 * leaf and its intermediates as one concatenated credential, and
++	 * mbedtls_x509_crt_parse() on the other backend loads all of them.
++	 * Loading only the leaf sends an incomplete chain to the peer.
++	 */
++	ret = wolfSSL_CTX_use_certificate_chain_buffer_format(tls->ctx, own_cert->buf,
 +						 own_cert->len, format);
 +	if (ret != WOLFSSL_SUCCESS) {
 +		NET_ERR("Failed to parse certificate");
@@ -1493,7 +1526,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	int err;
  
  	if (tls->options.cert_nocopy == TLS_CERT_NOCOPY_NONE ||
-@@ -1030,6 +1743,7 @@ static int tls_add_own_cert(struct tls_context *tls,
+@@ -1030,6 +1800,7 @@ static int tls_add_own_cert(struct tls_context *tls,
  	return -ENOTSUP;
  }
  
@@ -1501,7 +1534,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int tls_set_own_cert(struct tls_context *tls)
  {
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
-@@ -1044,11 +1758,27 @@ static int tls_set_own_cert(struct tls_context *tls)
+@@ -1044,11 +1815,27 @@ static int tls_set_own_cert(struct tls_context *tls)
  
  	return -ENOTSUP;
  }
@@ -1530,7 +1563,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	int err;
  
  	err = mbedtls_pk_parse_key(&tls->priv_key, priv_key->buf,
-@@ -1068,6 +1798,47 @@ static int tls_set_psk(struct tls_context *tls,
+@@ -1068,6 +1855,47 @@ static int tls_set_psk(struct tls_context *tls,
  		       struct tls_credential *psk,
  		       struct tls_credential *psk_id)
  {
@@ -1578,7 +1611,7 @@ index 0a0b360291d..5cc70f1545e 100644
  #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
  	int err = mbedtls_ssl_conf_psk(&tls->config,
  				       psk->buf, psk->len,
-@@ -1079,6 +1850,7 @@ static int tls_set_psk(struct tls_context *tls,
+@@ -1079,6 +1907,7 @@ static int tls_set_psk(struct tls_context *tls,
  
  	return 0;
  #endif
@@ -1586,7 +1619,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	return -ENOTSUP;
  }
-@@ -1121,6 +1893,7 @@ static int tls_set_credential(struct tls_context *tls,
+@@ -1121,6 +1950,7 @@ static int tls_set_credential(struct tls_context *tls,
  	return 0;
  }
  
@@ -1594,7 +1627,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int tls_mbedtls_set_credentials(struct tls_context *tls)
  {
  	struct tls_credential *cred;
-@@ -1471,10 +2244,57 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
+@@ -1471,10 +2301,57 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
  
  	return 0;
  }
@@ -1607,7 +1640,7 @@ index 0a0b360291d..5cc70f1545e 100644
 + *   KEEP_PEER_CERT || SESSION_CERTS
 + * (the OPENSSL_EXTRA_X509_SMALL arm is our downstream patch). The Zephyr
 + * TLS sockets backend force-selects WOLFSSL_OPENSSL_EXTRA_X509_SMALL, so
-+ * the function is normally available — but if a wolfSSL uprev drops the
++ * the function is normally available - but if a wolfSSL uprev drops the
 + * downstream patch and no user-supplied flag fills the gap, the build
 + * would fail with an obscure linker error. Fail loudly here instead.
 + */
@@ -1628,7 +1661,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +	/* Parse the cert here so setsockopt(TLS_SEC_TAG_LIST) returns EINVAL
 +	 * on malformed credentials (mbedTLS-parity contract exercised by
 +	 * test_tls_bad_cred). The X509 is freed immediately so no peer-cert
-+	 * retention is needed — the OPENSSL_EXTRA_X509_SMALL arm of the gate
++	 * retention is needed - the OPENSSL_EXTRA_X509_SMALL arm of the gate
 +	 * (see modules/crypto/wolfssl/src/x509.c:6055) is our downstream
 +	 * relaxation so KEEP_PEER_CERT isn't forced just for validation.
 +	 */
@@ -1653,7 +1686,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	mbedtls_x509_crt cert_ctx;
  	int err;
  
-@@ -1509,7 +2329,31 @@ static int tls_check_cert(struct tls_credential *cert)
+@@ -1509,7 +2386,39 @@ static int tls_check_cert(struct tls_credential *cert)
  
  static int tls_check_priv_key(struct tls_credential *priv_key)
  {
@@ -1663,7 +1696,15 @@ index 0a0b360291d..5cc70f1545e 100644
 +	int fmt;
 +	int ret;
 +
++	/* wolfSSL has no CTX-free private key parser without OPENSSL_EXTRA, so
++	 * validation borrows a throwaway CTX. Pick a method that exists in this
++	 * build: wolfSSLv23_client_method() is compiled out by NO_WOLFSSL_CLIENT.
++	 */
++#ifndef NO_WOLFSSL_CLIENT
 +	tmp_ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
++#else
++	tmp_ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
++#endif
 +	if (tmp_ctx == NULL) {
 +		return -ENOMEM;
 +	}
@@ -1686,7 +1727,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	mbedtls_pk_context key_ctx;
  	int err;
  
-@@ -1537,7 +2381,22 @@ static int tls_check_priv_key(struct tls_credential *priv_key)
+@@ -1537,7 +2446,22 @@ static int tls_check_priv_key(struct tls_credential *priv_key)
  
  static int tls_check_psk(struct tls_credential *psk)
  {
@@ -1710,7 +1751,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	struct tls_credential *psk_id;
  
  	psk_id = credential_get(psk->tag, TLS_CREDENTIAL_PSK_ID);
-@@ -1557,7 +2416,7 @@ static int tls_check_psk(struct tls_credential *psk)
+@@ -1557,7 +2481,7 @@ static int tls_check_psk(struct tls_credential *psk)
  		"Reconfigure mbed TLS to support PSK based key exchange.");
  
  	return -ENOTSUP;
@@ -1719,7 +1760,7 @@ index 0a0b360291d..5cc70f1545e 100644
  }
  
  static int tls_check_credentials(const sec_tag_t *sec_tags, int sec_tag_count)
-@@ -1622,55 +2481,1167 @@ exit:
+@@ -1622,53 +2546,1259 @@ exit:
  	return err;
  }
  
@@ -1814,8 +1855,6 @@ index 0a0b360291d..5cc70f1545e 100644
  
 -static int tls_opt_sec_tag_list_get(struct tls_context *context,
 -				    void *optval, socklen_t *optlen)
--{
--	int len;
 +	end = sys_timepoint_calc(timeout);
 +
 +	do {
@@ -1825,6 +1864,14 @@ index 0a0b360291d..5cc70f1545e 100644
 +		}
 +
 +		err = wolfSSL_get_error(ctx->wssl, ret);
++
++		/* A zero-length write is legal and wolfSSL reports it as 0 with
++		 * no error latched. Treat it as the no-op the mbedTLS backend
++		 * does, otherwise the catch-all below tears down the session.
++		 */
++		if (ret == 0 && err == WOLFSSL_ERROR_NONE) {
++			return 0;
++		}
 +
 +		if (err == WOLFSSL_ERROR_WANT_READ ||
 +		    err == WOLFSSL_ERROR_WANT_WRITE) {
@@ -1851,9 +1898,17 @@ index 0a0b360291d..5cc70f1545e 100644
 +			}
 +		} else {
 +			NET_ERR("TLS send error: %x", err);
-+			tls_wolfssl_reset(ctx);
-+			ctx->error = ECONNABORTED;
-+			errno = ECONNABORTED;
++			/* Distinguish a failed session reset from a plain abort,
++			 * as the mbedTLS arm does: the SSL object is unusable in
++			 * that case, not merely disconnected.
++			 */
++			if (tls_wolfssl_reset(ctx) != 0) {
++				ctx->error = ENOMEM;
++				errno = ENOMEM;
++			} else {
++				ctx->error = ECONNABORTED;
++				errno = ECONNABORTED;
++			}
 +			break;
 +		}
 +	} while (true);
@@ -1903,7 +1958,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +			 * below would land us in the EIO arm.
 +			 *
 +			 * Return what's been drained across earlier iterations
-+			 * (recv_len) — POSIX semantics: a partial recv followed
++			 * (recv_len) - POSIX semantics: a partial recv followed
 +			 * by EOF reports the partial. recv_len may be 0 on the
 +			 * first iteration, in which case the caller sees clean
 +			 * EOF immediately. The DTLS sibling
@@ -1958,6 +2013,16 @@ index 0a0b360291d..5cc70f1545e 100644
 +		}
 +
 +		if (ret == 0) {
++			/* wolfSSL reports a clean TLS-level closure as 0 with the
++			 * reason latched in ssl->error. Mark the session closed so
++			 * a later send() fails like the mbedTLS backend instead of
++			 * writing to a shut-down session.
++			 */
++			err = wolfSSL_get_error(ctx->wssl, ret);
++			if (err == WOLFSSL_ERROR_ZERO_RETURN ||
++			    err == SOCKET_PEER_CLOSED_E) {
++				ctx->session_closed = true;
++			}
 +			break;
 +		}
 +
@@ -1995,8 +2060,12 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
 +			if (context->type == SOCK_DGRAM) {
++				/* wolfSSL reports the DTLS retransmit timeout in
++				 * seconds; convert to ms.
++				 */
 +				int timeout_dtls =
-+					wolfSSL_dtls_get_current_timeout(context->wssl);
++					wolfSSL_dtls_get_current_timeout(context->wssl)
++						* MSEC_PER_SEC;
 +
 +				if (timeout_ms == SYS_FOREVER_MS) {
 +					timeout_ms = timeout_dtls;
@@ -2074,8 +2143,12 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
 +			if (context->type == SOCK_DGRAM) {
++				/* wolfSSL reports the DTLS retransmit timeout in
++				 * seconds; convert to ms.
++				 */
 +				int timeout_dtls =
-+					wolfSSL_dtls_get_current_timeout(context->wssl);
++					wolfSSL_dtls_get_current_timeout(context->wssl)
++						* MSEC_PER_SEC;
 +
 +				if (timeout_ms == SYS_FOREVER_MS) {
 +					timeout_ms = timeout_dtls;
@@ -2145,7 +2218,12 @@ index 0a0b360291d..5cc70f1545e 100644
 +		return 0;
 +	}
 +
-+	if (XSTRCMP(identity, context->psk_id) != 0) {
++	/* TLS_CREDENTIAL_PSK_ID is length-delimited, so compare the full
++	 * registered length. XSTRCMP would stop at an embedded NUL and accept
++	 * a shorter identity that is a prefix of the registered one.
++	 */
++	if (XSTRLEN(identity) != context->psk_id_len ||
++	    XMEMCMP(identity, context->psk_id, context->psk_id_len) != 0) {
 +		return 0;
 +	}
 +
@@ -2303,6 +2381,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +		return 0;
 +	}
 +
++#if defined(HAVE_SNI)
 +	if (context->options.is_hostname_set) {
 +		if (wolfSSL_UseSNI(context->wssl, WOLFSSL_SNI_HOST_NAME,
 +				   (const char *)context->host_name,
@@ -2310,13 +2389,19 @@ index 0a0b360291d..5cc70f1545e 100644
 +			return -EINVAL;
 +		}
 +	}
++#endif /* HAVE_SNI */
++
++	/* Without HAVE_SNI the extension is simply not sent. The hostname is
++	 * still recorded and still drives the CN/SAN match in the verify
++	 * callback, which is what TLS_PEER_VERIFY depends on.
++	 */
 +
 +	return 0;
 +}
 +
 +/* Returns true only when a leaf cert is present and its CN/SAN matches
 + * the hostname configured on this client context. NULL cert and "no
-+ * hostname configured" both report mismatch — the latter is the MITM
++ * hostname configured" both report mismatch - the latter is the MITM
 + * protection path (parity with mbedtls_ssl_set_hostname(ssl, "")).
 + */
 +static bool tls_wolfssl_leaf_hostname_matches(struct tls_context *context,
@@ -2351,6 +2436,14 @@ index 0a0b360291d..5cc70f1545e 100644
 +		return;
 +	}
 +	if (context->options.role != ZTLS_IS_CLIENT) {
++		return;
++	}
++	/* TLS_PEER_VERIFY_NONE means the application opted out of peer
++	 * verification entirely, so no name check applies. Without this the
++	 * mismatch below would fail a handshake that OPTIONAL lets through,
++	 * making NONE stricter than OPTIONAL.
++	 */
++	if (context->options.verify_level == TLS_PEER_VERIFY_NONE) {
 +		return;
 +	}
 +	if (tls_wolfssl_leaf_hostname_matches(context, store->current_cert)) {
@@ -2426,7 +2519,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +	/* OPTIONAL: return 1 so handshake continues after recording flags.
 +	 * Surface a warning when we're about to silently let an invalid
-+	 * chain through — applications that set OPTIONAL but never read
++	 * chain through - applications that set OPTIONAL but never read
 +	 * TLS_CERT_VERIFY_RESULT will otherwise accept bad certs with no
 +	 * trace. mbedTLS prints similar info at debug verbosity.
 +	 */
@@ -2638,12 +2731,32 @@ index 0a0b360291d..5cc70f1545e 100644
 +static int tls_wolfssl_set_dtls_timeouts(struct tls_context *context)
 +{
 +	if (context->type == SOCK_DGRAM) {
-+		if (wolfSSL_dtls_set_timeout_max(context->wssl,
-+				(int)context->options.dtls_handshake_timeout_max) != WOLFSSL_SUCCESS) {
++		int init_s;
++		int max_s;
++
++		/* wolfSSL's DTLS retransmit timeout API takes whole seconds, but
++		 * dtls_handshake_timeout_min/max are stored in milliseconds (the
++		 * socket-option and mbedTLS-shared unit). Convert here, rounding
++		 * up so a sub-second value never collapses to 0, and keep
++		 * init <= max.
++		 */
++		init_s = (int)((context->options.dtls_handshake_timeout_min +
++				MSEC_PER_SEC - 1) / MSEC_PER_SEC);
++		if (init_s < 1) {
++			init_s = 1;
++		}
++		max_s = (int)((context->options.dtls_handshake_timeout_max +
++			       MSEC_PER_SEC - 1) / MSEC_PER_SEC);
++		if (max_s < init_s) {
++			max_s = init_s;
++		}
++
++		if (wolfSSL_dtls_set_timeout_max(context->wssl, max_s)
++				!= WOLFSSL_SUCCESS) {
 +			return -EINVAL;
 +		}
-+		if (wolfSSL_dtls_set_timeout_init(context->wssl,
-+				(int)context->options.dtls_handshake_timeout_min) != WOLFSSL_SUCCESS) {
++		if (wolfSSL_dtls_set_timeout_init(context->wssl, init_s)
++				!= WOLFSSL_SUCCESS) {
 +			return -EINVAL;
 +		}
 +
@@ -2749,7 +2862,14 @@ index 0a0b360291d..5cc70f1545e 100644
 +	WOLFSSL_METHOD *method;
 +	int ret;
 +
-+	context->options.role = is_server ? ZTLS_IS_SERVER : ZTLS_IS_CLIENT;
++	/* Do not clobber an explicitly configured TLS_DTLS_ROLE: connect() on a
++	 * DTLS socket would otherwise demote a socket the application set up as
++	 * a server, and options.role drives verify level, BIO callbacks and the
++	 * session-reset path.
++	 */
++	if (!context->role_set) {
++		context->options.role = is_server ? ZTLS_IS_SERVER : ZTLS_IS_CLIENT;
++	}
 +
 +#if defined(CONFIG_WOLFSSL_DEBUG)
 +	wolfSSL_Debugging_ON();
@@ -2759,6 +2879,15 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +	if (method == NULL) {
 +		return -ENOTSUP;
++	}
++
++	/* wolfSSL_CTX_new() takes ownership of the method, so an already
++	 * initialized context (a DTLS client re-connecting) must release it
++	 * rather than allocate one per call.
++	 */
++	if (context->ctx != NULL) {
++		XFREE(method, NULL, DYNAMIC_TYPE_METHOD);
++		method = NULL;
 +	}
 +
 +	if (context->ctx == NULL) {
@@ -2807,13 +2936,17 @@ index 0a0b360291d..5cc70f1545e 100644
 +	}
 +#endif /* !NO_PSK */
 +
-+#if defined(CONFIG_WOLFSSL_MAX_FRAGMENT_LEN)
++#if defined(CONFIG_WOLFSSL_MAX_FRAGMENT_LEN) && \
++	defined(CONFIG_NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH)
++	/* Gate on the socket-layer MFL toggle too, so setting it n disables
++	 * max_fragment_length negotiation on wolfSSL as the option advertises.
++	 */
 +	if (wolfSSL_CTX_UseMaxFragment(context->ctx,
 +				       CONFIG_WOLFSSL_MAX_FRAGMENT_LEN) != WOLFSSL_SUCCESS) {
 +		ret = -EINVAL;
 +		goto err_cleanup;
 +	}
-+#endif /* CONFIG_WOLFSSL_MAX_FRAGMENT_LEN */
++#endif /* WOLFSSL_MAX_FRAGMENT_LEN && NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH */
 +
 +	if (NULL == context->wssl) {
 +		if ((context->wssl = wolfSSL_new(context->ctx)) == NULL) {
@@ -2915,25 +3048,39 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +static int tls_opt_sec_tag_list_get(struct tls_context *context,
 +				    void *optval, socklen_t *optlen)
-+{
-+	int len;
+ {
+ 	int len;
  
- 	if (*optlen % sizeof(sec_tag_t) != 0 || *optlen == 0) {
- 		return -EINVAL;
-@@ -1688,6 +3659,44 @@ static int tls_opt_sec_tag_list_get(struct tls_context *context,
+@@ -1688,6 +3818,70 @@ static int tls_opt_sec_tag_list_get(struct tls_context *context,
  static int tls_opt_hostname_set(struct tls_context *context,
  				const void *optval, socklen_t optlen)
  {
 +#if defined(CONFIG_WOLFSSL)
-+	if (NULL != context->host_name) {
-+		XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-+		context->host_name = NULL;
-+		context->host_len = 0;
-+	}
++	char *host_name;
 +
 +	if (optval == NULL) {
++		if (context->host_name != NULL) {
++			XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++			context->host_name = NULL;
++			context->host_len = 0;
++		}
 +		context->options.is_hostname_set = false;
 +		return 0;
++	}
++
++	/* The mbedTLS backend treats optval as a C string and ignores optlen
++	 * entirely, so trim any trailing NUL padding rather than carrying it
++	 * into the SNI extension and the certificate name match.
++	 */
++	while (optlen > 0 && ((const char *)optval)[optlen - 1] == '\0') {
++		optlen--;
++	}
++
++	/* An empty hostname cannot match any certificate and would silently
++	 * disable the name check, so reject it instead.
++	 */
++	if (optlen == 0) {
++		return -EINVAL;
 +	}
 +
 +	/* RFC 6066 SNI HostName is at most 2^16 - 1; reject anything larger
@@ -2944,15 +3091,25 @@ index 0a0b360291d..5cc70f1545e 100644
 +		return -EINVAL;
 +	}
 +
-+	/* +1 for NUL — wolfSSL APIs require C strings. */
-+	context->host_name = XMALLOC(optlen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-+	if (context->host_name == NULL) {
-+		context->options.is_hostname_set = false;
++	/* mbedTLS validates before touching the configured hostname. Keep the
++	 * old one until the new one is committed, otherwise a rejected
++	 * setsockopt leaves the socket with no name check at all.
++	 */
++
++	/* +1 for NUL - wolfSSL APIs require C strings. */
++	host_name = XMALLOC(optlen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	if (host_name == NULL) {
 +		return -ENOMEM;
 +	}
 +
-+	XMEMCPY(context->host_name, optval, optlen);
-+	context->host_name[optlen] = '\0';
++	XMEMCPY(host_name, optval, optlen);
++	host_name[optlen] = '\0';
++
++	if (context->host_name != NULL) {
++		XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	}
++
++	context->host_name = host_name;
 +	context->host_len = optlen;
 +	context->options.is_hostname_set = true;
 +
@@ -2965,7 +3122,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	ARG_UNUSED(optlen);
  
  #if defined(MBEDTLS_X509_CRT_PARSE_C)
-@@ -1701,6 +3710,7 @@ static int tls_opt_hostname_set(struct tls_context *context,
+@@ -1701,6 +3895,7 @@ static int tls_opt_hostname_set(struct tls_context *context,
  	context->options.is_hostname_set = true;
  
  	return 0;
@@ -2973,7 +3130,7 @@ index 0a0b360291d..5cc70f1545e 100644
  }
  
  static int tls_opt_ciphersuite_list_set(struct tls_context *context,
-@@ -1723,12 +3733,23 @@ static int tls_opt_ciphersuite_list_set(struct tls_context *context,
+@@ -1723,12 +3918,23 @@ static int tls_opt_ciphersuite_list_set(struct tls_context *context,
  		return -EINVAL;
  	}
  
@@ -2997,7 +3154,7 @@ index 0a0b360291d..5cc70f1545e 100644
  }
  
  static int tls_opt_ciphersuite_list_get(struct tls_context *context,
-@@ -1742,6 +3763,49 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
+@@ -1742,6 +3948,49 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
  		return -EINVAL;
  	}
  
@@ -3047,7 +3204,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	if (context->options.ciphersuites[0] == 0) {
  		/* No specific ciphersuites configured, return all available. */
  		selected_ciphers = mbedtls_ssl_list_ciphersuites();
-@@ -1761,23 +3825,54 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
+@@ -1761,23 +4010,54 @@ static int tls_opt_ciphersuite_list_get(struct tls_context *context,
  	*optlen = i * sizeof(int);
  
  	return 0;
@@ -3108,7 +3265,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	return 0;
  }
-@@ -1808,6 +3903,12 @@ static int tls_opt_alpn_list_set(struct tls_context *context,
+@@ -1808,6 +4088,12 @@ static int tls_opt_alpn_list_set(struct tls_context *context,
  	memcpy(context->options.alpn_list, optval, optlen);
  	context->options.alpn_list[alpn_cnt] = NULL;
  
@@ -3121,7 +3278,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	return 0;
  }
  
-@@ -1854,12 +3955,18 @@ static int tls_opt_dtls_handshake_timeout_set(struct tls_context *context,
+@@ -1854,12 +4140,18 @@ static int tls_opt_dtls_handshake_timeout_set(struct tls_context *context,
  		context->options.dtls_handshake_timeout_min = *val;
  	}
  
@@ -3142,7 +3299,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	return 0;
  }
-@@ -2131,18 +4238,44 @@ static int tls_opt_cert_verify_result_get(struct tls_context *context,
+@@ -2131,18 +4423,44 @@ static int tls_opt_cert_verify_result_get(struct tls_context *context,
  		return -EINVAL;
  	}
  
@@ -3188,7 +3345,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	tls_session_purge();
  
  	return 0;
-@@ -2163,9 +4296,9 @@ static int tls_opt_peer_verify_set(struct tls_context *context,
+@@ -2163,9 +4481,9 @@ static int tls_opt_peer_verify_set(struct tls_context *context,
  
  	peer_verify = (int *)optval;
  
@@ -3201,7 +3358,7 @@ index 0a0b360291d..5cc70f1545e 100644
  		return -EINVAL;
  	}
  
-@@ -2213,8 +4346,8 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
+@@ -2213,17 +4531,36 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
  	}
  
  	role = (int *)optval;
@@ -3212,7 +3369,12 @@ index 0a0b360291d..5cc70f1545e 100644
  		return -EINVAL;
  	}
  
-@@ -2224,6 +4357,22 @@ static int tls_opt_dtls_role_set(struct tls_context *context,
+ 	context->options.role = *role;
++#if defined(CONFIG_WOLFSSL)
++	context->role_set = true;
++#endif
+ 
+ 	return 0;
  }
  
  #if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
@@ -3235,7 +3397,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int tls_opt_cert_verify_callback_set(struct tls_context *context,
  					    const void *optval,
  					    socklen_t optlen)
-@@ -2247,18 +4396,68 @@ static int tls_opt_cert_verify_callback_set(struct tls_context *context,
+@@ -2247,18 +4584,72 @@ static int tls_opt_cert_verify_callback_set(struct tls_context *context,
  
  	return 0;
  }
@@ -3296,6 +3458,10 @@ index 0a0b360291d..5cc70f1545e 100644
 +						    const void *optval,
 +						    socklen_t optlen)
 +{
++	ARG_UNUSED(context);
++	ARG_UNUSED(optval);
++	ARG_UNUSED(optlen);
++
 +	return -ENOPROTOOPT;
 +}
 +#endif /* CONFIG_WOLFSSL_VERIFY_CALLBACK */
@@ -3304,7 +3470,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static int protocol_check(int family, int type, int *proto)
  {
  	if (family != AF_INET && family != AF_INET6) {
-@@ -2342,7 +4541,11 @@ int ztls_close_ctx(struct tls_context *ctx, int sock)
+@@ -2342,7 +4733,11 @@ int ztls_close_ctx(struct tls_context *ctx, int sock)
  	/* Try to send close notification. */
  	ctx->flags = 0;
  
@@ -3316,7 +3482,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  	err = tls_release(ctx);
  	ret = zsock_close(ctx->sock);
-@@ -2401,6 +4604,32 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
+@@ -2401,6 +4796,32 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
  	    || (ctx->type == SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
  #endif
  	    ) {
@@ -3349,7 +3515,7 @@ index 0a0b360291d..5cc70f1545e 100644
  		ret = tls_mbedtls_init(ctx, false);
  		if (ret < 0) {
  			goto error;
-@@ -2425,6 +4654,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
+@@ -2425,6 +4846,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct sockaddr *addr,
  		}
  
  		tls_session_store(ctx, addr, addrlen);
@@ -3357,7 +3523,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	}
  
  	return 0;
-@@ -2465,6 +4695,25 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
+@@ -2465,6 +4887,25 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
  
  	child->sock = sock;
  
@@ -3383,7 +3549,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	ret = tls_mbedtls_init(child, true);
  	if (ret < 0) {
  		goto error;
-@@ -2483,6 +4732,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
+@@ -2483,6 +4924,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
  	}
  
  	return fd;
@@ -3391,7 +3557,7 @@ index 0a0b360291d..5cc70f1545e 100644
  
  error:
  	if (child != NULL) {
-@@ -2501,6 +4751,7 @@ error:
+@@ -2501,6 +4943,7 @@ error:
  	return -1;
  }
  
@@ -3399,7 +3565,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static ssize_t send_tls(struct tls_context *ctx, const void *buf,
  			size_t len, int flags)
  {
-@@ -2579,8 +4830,85 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
+@@ -2579,8 +5022,85 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
  
  	return -1;
  }
@@ -3486,7 +3652,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static ssize_t sendto_dtls_client(struct tls_context *ctx, const void *buf,
  				  size_t len, int flags,
  				  const struct sockaddr *dest_addr,
-@@ -2672,6 +5000,24 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+@@ -2672,6 +5192,24 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  	ctx->flags = flags;
  
  	/* TLS */
@@ -3511,7 +3677,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	if (ctx->type == SOCK_STREAM) {
  		return send_tls(ctx, buf, len, flags);
  	}
-@@ -2688,6 +5034,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+@@ -2688,6 +5226,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  	errno = ENOTSUP;
  	return -1;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
@@ -3519,7 +3685,7 @@ index 0a0b360291d..5cc70f1545e 100644
  }
  
  static ssize_t dtls_sendmsg_merge_and_send(struct tls_context *ctx,
-@@ -2793,6 +5140,7 @@ send_loop:
+@@ -2793,6 +5332,7 @@ send_loop:
  	return tls_sendmsg_loop_and_send(ctx, msg, flags);
  }
  
@@ -3527,11 +3693,16 @@ index 0a0b360291d..5cc70f1545e 100644
  static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  			size_t max_len, int flags)
  {
-@@ -2808,7 +5156,110 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
- 		return -1;
- 	}
+@@ -2804,11 +5344,114 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+ 	int ret;
  
--	if (ctx->session_closed) {
+ 	if (ctx->error != 0) {
+-		errno = ctx->error;
+-		return -1;
++		errno = ctx->error;
++		return -1;
++	}
++
 +	if (ctx->session_closed) {
 +		return 0;
 +	}
@@ -3633,13 +3804,14 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +	if (ctx->error != 0) {
 +		return -ctx->error;
-+	}
-+
+ 	}
+ 
+-	if (ctx->session_closed) {
 +	if (ctx->recv_eof) {
  		return 0;
  	}
  
-@@ -2821,79 +5272,235 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+@@ -2821,79 +5464,243 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  	end = sys_timepoint_calc(timeout);
  
  	do {
@@ -3669,7 +3841,7 @@ index 0a0b360291d..5cc70f1545e 100644
 -				break;
 +			/* Local shutdown(SHUT_RD/RDWR) racing with a blocked
 +			 * recv(): same hazard as the TCP/TLS path, just
-+			 * surfaced differently — dtls_wolf_rx now maps a
++			 * surfaced differently - dtls_wolf_rx now maps a
 +			 * 0-byte recvfrom to CBIO_ERR_CONN_CLOSE (added
 +			 * symmetry with tls_wolf_rx); without this shortcut
 +			 * the next iteration would still re-block.
@@ -3677,7 +3849,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +			 * Return 0 unconditionally here (unlike the TCP/TLS
 +			 * sibling recv_tls_wolfssl which returns its
 +			 * accumulated recv_len). That's not a wolfSSL quirk
-+			 * — DTLS recv reads at most one datagram per call,
++			 * - DTLS recv reads at most one datagram per call,
 +			 * with no cross-iteration accumulation, exactly
 +			 * matching the mbedTLS DTLS path (recvfrom_dtls_common
 +			 * above). The asymmetry between TCP and DTLS is
@@ -3713,9 +3885,12 @@ index 0a0b360291d..5cc70f1545e 100644
  
 -				timeout_ms = timeout_to_ms(&timeout);
 +				{
++					/* wolfSSL reports the DTLS timeout in
++					 * seconds; convert to ms.
++					 */
 +					int timeout_dtls =
 +						wolfSSL_dtls_get_current_timeout(
-+							ctx->wssl);
++							ctx->wssl) * MSEC_PER_SEC;
 +					int timeout_sock =
 +						timeout_to_ms(&timeout);
 +
@@ -3793,12 +3968,17 @@ index 0a0b360291d..5cc70f1545e 100644
 +			int r = wolfSSL_read(ctx->wssl, dummy, to_read);
 +
 +			if (r <= 0) {
++				wc_ForceZero(dummy, sizeof(dummy));
 +				NET_ERR("Error while flushing the rest of the"
 +					" datagram, err %d", r);
 +				ret = -EIO;
 +				break;
 +			}
 +			remaining -= r;
++			/* Scrub the decrypted plaintext drained into the
++			 * discard buffer before it leaves scope.
++			 */
++			wc_ForceZero(dummy, sizeof(dummy));
 +		}
 +
 +		return ret;
@@ -3918,7 +4098,7 @@ index 0a0b360291d..5cc70f1545e 100644
  static ssize_t recvfrom_dtls_common(struct tls_context *ctx, void *buf,
  				    size_t max_len, int flags,
  				    struct sockaddr *src_addr,
-@@ -3183,6 +5790,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+@@ -3183,6 +5990,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  
  	ctx->flags = flags;
  
@@ -3944,7 +4124,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	/* TLS */
  	if (ctx->type == SOCK_STREAM) {
  		return recv_tls(ctx, buf, max_len, flags);
-@@ -3201,18 +5827,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+@@ -3201,18 +6027,25 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  	errno = ENOTSUP;
  	return -1;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
@@ -3971,7 +4151,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	}
  
  	return 0;
-@@ -3233,7 +5866,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
+@@ -3233,7 +6066,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
  	 * it actually starts to poll for data.
  	 */
  	if ((pfd->events & ZSOCK_POLLIN) && (ctx->type == SOCK_DGRAM) &&
@@ -3980,7 +4160,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	    !is_handshake_complete(ctx)) {
  		(*pev)->obj = &ctx->tls_established;
  		(*pev)->type = K_POLL_TYPE_SEM_AVAILABLE;
-@@ -3281,6 +5914,79 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3281,6 +6114,83 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  {
  	int ret;
  
@@ -3997,7 +4177,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +
 +			ret = tls_wolfssl_init(ctx, is_server);
 +			if (ret < 0) {
-+				/* Match mbedTLS arm — collapse to -ENOMEM. */
++				/* Match mbedTLS arm - collapse to -ENOMEM. */
 +				return -ENOMEM;
 +			}
 +		}
@@ -4030,8 +4210,12 @@ index 0a0b360291d..5cc70f1545e 100644
 +	{
 +		byte dummy[1];
 +
++		/* <= 0, not < 0 - wolfSSL_peek returns 0 for a clean TLS-level
++		 * closure and latches the reason in ssl->error.
++		 */
 +		ret = wolfSSL_peek(ctx->wssl, dummy, sizeof(dummy));
-+		if (ret < 0) {
++		wc_ForceZero(dummy, sizeof(dummy));
++		if (ret <= 0) {
 +			int err = wolfSSL_get_error(ctx->wssl, ret);
 +
 +			if (err == SOCKET_PEER_CLOSED_E ||
@@ -4060,7 +4244,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	if (ctx->type == SOCK_STREAM) {
  		if (!ctx->is_initialized) {
  			return -ENOTCONN;
-@@ -3325,11 +6031,6 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3325,11 +6235,6 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  	ret = mbedtls_ssl_read(&ctx->ssl, NULL, 0);
  	if (ret < 0) {
  		if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
@@ -4072,7 +4256,7 @@ index 0a0b360291d..5cc70f1545e 100644
  			if (ctx->type == SOCK_DGRAM) {
  				ret = tls_mbedtls_reset(ctx);
  				if (ret != 0) {
-@@ -3349,16 +6050,12 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3349,16 +6254,12 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  
  		NET_ERR("TLS data check error: -%x", -ret);
  
@@ -4089,7 +4273,7 @@ index 0a0b360291d..5cc70f1545e 100644
  			return -ENOTCONN;
  		}
  #endif
-@@ -3366,6 +6063,7 @@ static int ztls_socket_data_check(struct tls_context *ctx)
+@@ -3366,6 +6267,7 @@ static int ztls_socket_data_check(struct tls_context *ctx)
  	}
  
  	return mbedtls_ssl_get_bytes_avail(&ctx->ssl);
@@ -4097,7 +4281,7 @@ index 0a0b360291d..5cc70f1545e 100644
  }
  
  static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
-@@ -3375,10 +6073,17 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
+@@ -3375,10 +6277,17 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
  
  	if (!ctx->is_listening) {
  		/* Already had TLS data to read on socket. */
@@ -4115,7 +4299,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	}
  
  	if (ctx->type == SOCK_STREAM) {
-@@ -3402,6 +6107,7 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
+@@ -3402,6 +6311,7 @@ static int ztls_poll_update_pollin(int fd, struct tls_context *ctx,
  	}
  #endif
  	ret = ztls_socket_data_check(ctx);
@@ -4123,7 +4307,7 @@ index 0a0b360291d..5cc70f1545e 100644
  	if (ret == -ENOTCONN || (pfd->revents & ZSOCK_POLLHUP)) {
  		/* Datagram does not return 0 on consecutive recv, but an error
  		 * code, hence clear POLLIN.
-@@ -3512,7 +6218,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+@@ -3512,7 +6422,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
  	 * reports that data is ready.
  	 */
  	if ((ctx->type != SOCK_DGRAM) ||
@@ -4132,7 +4316,7 @@ index 0a0b360291d..5cc70f1545e 100644
  		return false;
  	}
  
-@@ -3525,13 +6231,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+@@ -3525,13 +6435,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
  		pfd->revents &= ~ZSOCK_POLLIN;
  		return true;
  	} else if (!is_handshake_complete(ctx)) {
@@ -4148,7 +4332,7 @@ index 0a0b360291d..5cc70f1545e 100644
  				 ZSOCK_MSG_DONTWAIT);
  		if (ret < 0) {
  			pfd->revents |= ZSOCK_POLLERR;
-@@ -3850,6 +6556,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
+@@ -3850,6 +6760,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
  		err = tls_opt_cert_verify_callback_set(ctx, optval, optlen);
  		break;
  
@@ -4156,7 +4340,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +	case TLS_CERT_VERIFY_CALLBACK_WOLFSSL:
 +		err = tls_opt_cert_verify_callback_wolfssl_set(ctx, optval, optlen);
 +		break;
-+	/* Under mbedTLS the option number 21 is reserved but unhandled — it
++	/* Under mbedTLS the option number 21 is reserved but unhandled - it
 +	 * falls through to the default case and surfaces as -ENOPROTOOPT,
 +	 * which matches the upstream "unknown sockopt" contract.
 +	 */
@@ -4165,7 +4349,7 @@ index 0a0b360291d..5cc70f1545e 100644
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  	case TLS_DTLS_HANDSHAKE_TIMEOUT_MIN:
  		err = tls_opt_dtls_handshake_timeout_set(ctx, optval,
-@@ -3896,6 +6612,21 @@ out:
+@@ -3896,6 +6816,21 @@ out:
  }
  
  #if defined(CONFIG_NET_TEST)
@@ -4187,7 +4371,7 @@ index 0a0b360291d..5cc70f1545e 100644
  mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
  {
  	struct tls_context *ctx;
-@@ -3908,17 +6639,18 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
+@@ -3908,17 +6843,18 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
  
  	return &ctx->ssl;
  }
@@ -4210,7 +4394,7 @@ index 0a0b360291d..5cc70f1545e 100644
  }
  
  static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
-@@ -4004,8 +6736,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+@@ -4004,8 +6940,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
  static int tls_sock_shutdown_vmeth(void *obj, int how)
  {
  	struct tls_context *ctx = obj;
@@ -4219,7 +4403,7 @@ index 0a0b360291d..5cc70f1545e 100644
 +	ret = zsock_shutdown(ctx->sock, how);
 +#if defined(CONFIG_WOLFSSL)
 +	/* Mark the TLS layer's read side closed only after the underlying
-+	 * socket accepted the shutdown — setting recv_eof before forwarding
++	 * socket accepted the shutdown - setting recv_eof before forwarding
 +	 * would poison the recv path for an unsuccessful shutdown. mbedTLS
 +	 * does not consult recv_eof, so the write is gated to the wolfSSL
 +	 * backend to keep the mbedTLS contract byte-identical with upstream.
@@ -4261,7 +4445,7 @@ index 0e455630471..6331218e713 100644
  	  Enables the CTR-DRBG pseudo-random number generator. This CSPRNG
  	  shall use the entropy API for an initialization seed. The CTR-DRBG
 diff --git a/subsys/random/random_ctr_drbg.c b/subsys/random/random_ctr_drbg.c
-index 25f563e3040..2e2f648d445 100644
+index 25f563e3040..8b9fc9deac8 100644
 --- a/subsys/random/random_ctr_drbg.c
 +++ b/subsys/random/random_ctr_drbg.c
 @@ -10,6 +10,7 @@
@@ -4272,7 +4456,7 @@ index 25f563e3040..2e2f648d445 100644
  #if !defined(CONFIG_MBEDTLS_CFG_FILE)
  #include "mbedtls/config.h"
  #else
-@@ -17,6 +18,15 @@
+@@ -17,15 +18,27 @@
  #endif /* CONFIG_MBEDTLS_CFG_FILE */
  #include <mbedtls/ctr_drbg.h>
  
@@ -4288,7 +4472,11 @@ index 25f563e3040..2e2f648d445 100644
  /*
   * entropy_dev is initialized at runtime to allow first time initialization
   * of the ctr_drbg engine.
-@@ -26,6 +36,7 @@ static const unsigned char drbg_seed[] = CONFIG_CS_CTR_DRBG_PERSONALIZATION;
+  */
+ static const struct device *entropy_dev;
++#if defined(CONFIG_MBEDTLS)
+ static const unsigned char drbg_seed[] = CONFIG_CS_CTR_DRBG_PERSONALIZATION;
++#endif
  static bool ctr_initialised;
  static K_MUTEX_DEFINE(ctr_lock);
  
@@ -4296,7 +4484,7 @@ index 25f563e3040..2e2f648d445 100644
  static mbedtls_ctr_drbg_context ctr_ctx;
  
  static int ctr_drbg_entropy_func(void *ctx, unsigned char *buf, size_t len)
-@@ -33,6 +44,17 @@ static int ctr_drbg_entropy_func(void *ctx, unsigned char *buf, size_t len)
+@@ -33,6 +46,17 @@ static int ctr_drbg_entropy_func(void *ctx, unsigned char *buf, size_t len)
  	return entropy_get_entropy(entropy_dev, (void *)buf, len);
  }
  
@@ -4314,7 +4502,7 @@ index 25f563e3040..2e2f648d445 100644
  static int ctr_drbg_initialize(void)
  {
  	int ret;
-@@ -44,6 +66,7 @@ static int ctr_drbg_initialize(void)
+@@ -44,6 +68,7 @@ static int ctr_drbg_initialize(void)
  		return -ENODEV;
  	}
  
@@ -4322,7 +4510,7 @@ index 25f563e3040..2e2f648d445 100644
  	mbedtls_ctr_drbg_init(&ctr_ctx);
  
  	ret = mbedtls_ctr_drbg_seed(&ctr_ctx,
-@@ -57,6 +80,18 @@ static int ctr_drbg_initialize(void)
+@@ -57,6 +82,24 @@ static int ctr_drbg_initialize(void)
  		return -EIO;
  	}
  
@@ -4332,7 +4520,13 @@ index 25f563e3040..2e2f648d445 100644
 +		return -EIO;
 +	}
 +
-+	ret = wc_InitRngNonce_ex(&ctr_ctx, (byte *)drbg_seed, sizeof(drbg_seed), NULL, 0);
++	/* No nonce: _InitRng() then requests MAX_SEED_SZ from the entropy
++	 * source and derives the SP 800-90A nonce from it, instead of
++	 * shortening the seed by SEED_SZ/2 to make room for a caller-provided
++	 * one. CONFIG_CS_CTR_DRBG_PERSONALIZATION never reached the DRBG's
++	 * personalization input in any case; that slot is hardwired to NULL.
++	 */
++	ret = wc_InitRng_ex(&ctr_ctx, NULL, 0);
 +	if (ret != 0) {
 +		(void)wc_FreeRng(&ctr_ctx);
 +		return -EIO;
@@ -4341,7 +4535,7 @@ index 25f563e3040..2e2f648d445 100644
  	ctr_initialised = true;
  	return 0;
  }
-@@ -76,8 +111,15 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
+@@ -76,8 +119,15 @@ int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
  		}
  	}
  

--- a/zephyr/4.4/README.md
+++ b/zephyr/4.4/README.md
@@ -6,36 +6,61 @@ for all TLS operations. This will also enable wolfSSL as an alternative RNG impl
 this feature, first ensure wolfSSL has been added to the west manifest using the instructions from the
 README.md here: https://github.com/wolfSSL/wolfssl/tree/master/zephyr
 
-This integration depends on Kconfig options and a few small fixes in the wolfSSL Zephyr module:
-Zephyr default TLS support (`WOLFSSL_SESSION_EXPORT`, `WOLFSSL_KEEP_PEER_CERT`,
-`WOLFSSL_ALWAYS_VERIFY_CB`, and the `native_sim` timer gate extension) plus three Zephyr 4.4 fixes
-(a `wolfio.h` include guard for the retyped 4.4 zsock prototypes, an `arpa/inet.h` include in
-`test.h`, and a malloc-arena bump in the `wolfssl_tls_sock` sample). These are all in wolfSSL
-upstream (master), so a recent wolfSSL revision needs no extra module patching.
+This integration requires **wolfSSL > 5.9.2** (master, or any newer release). 5.9.2 itself is the
+baseline for the socket backend: earlier revisions gate `wolfSSL_clear()` - used by the
+per-session reset path in `sockets_tls.c` - behind `OPENSSL_EXTRA`/`WOLFSSL_WPAS_SMALL`, and lack
+the upstream `OPENSSL_EXTRA_X509_SMALL` gate arm that lets the backend validate credentials
+without forcing `KEEP_PEER_CERT`. Zephyr 4.4 support then needs a few changes that landed just
+after that tag, detailed below.
 
-Then patch the Zephyr tree (run inside the `zephyr` directory). The integration ships as two
-patches, both generated against the Zephyr **4.4.1** release:
+The Kconfig options the backend builds on - `WOLFSSL_SESSION_EXPORT`,
+`WOLFSSL_OPENSSL_EXTRA_X509_SMALL` and `WOLFSSL_ALWAYS_VERIFY_CB` in the wolfSSL Zephyr module -
+are part of that 5.9.2 baseline.
 
-- **`zephyr-tls-4.4.1.patch`** — the core wolfSSL backend (the BSD-sockets TLS layer and the
+Those post-5.9.2 changes are: a `wolfio.h` include guard for the retyped 4.4 zsock prototypes, an
+`arpa/inet.h` include in `test.h`, a malloc-arena bump in the `wolfssl_tls_sock` sample, and a
+`native_sim` simulation fix - `wc_port.c`'s `z_time()` used to
+consult the simulator RTC only when `CONFIG_RTC` *and* picolibc/newlib were selected, so under the
+host libc ASN.1 date validation fell back to uptime-since-boot; it now reads the simulator RTC on
+native boards regardless of the selected libc (native simulation only, real targets unchanged).
+
+Those are merged in pull request
+[wolfSSL/wolfssl#10983](https://github.com/wolfSSL/wolfssl/pull/10983), which landed after the
+`v5.9.2-stable` tag. Any wolfSSL newer than 5.9.2 therefore works: a released version once the
+next one ships, or a master revision containing that pull request in the meantime.
+
+Then patch the Zephyr tree (run inside the `zephyr` directory). The integration ships as three
+patches, all generated against the Zephyr **4.4.1** release:
+
+- **`zephyr-tls-4.4.1.patch`** - the core wolfSSL backend (the BSD-sockets TLS layer and the
   RNG/CSPRNG). This is all that is required to use wolfSSL for TLS sockets.
-- **`zephyr-tls-4.4.1-tests.patch`** — the wolfSSL twister test scenarios and the echo_server
+- **`zephyr-tls-4.4.1-tests.patch`** - the wolfSSL twister test scenarios and the echo_server
   sample overlay. Apply it only if you want to run the test suite yourself; it is not needed to
   use the integration. It depends on the core patch, so apply the core patch first.
+- **`zephyr-tls-4.4.1-mbedtls-decoupling.patch`** - optional. Removes the remaining hard mbedTLS
+  dependencies from subsystems whose crypto already runs through the PSA API or the TLS socket
+  layer (mcumgr/UpdateHub DTLS, LwM2M, WireGuard, and uuid v5), so an image using wolfSSL plus the
+  wolfPSA PSA provider can drop `CONFIG_MBEDTLS` entirely. Apply on top of the core patch. The
+  provider side is not part of this patch set: it ships in wolfPSA itself, which is a Zephyr
+  module of its own (`zephyr/` subdirectory, `CONFIG_WOLFPSA=y`) - see
+  https://github.com/wolfSSL/wolfPSA/tree/master/zephyr.
 
 ```
 # required:
 patch -p1 < /path/to/your/osp/zephyr/4.4/zephyr-tls-4.4.1.patch
 # optional, only to run the tests:
 patch -p1 < /path/to/your/osp/zephyr/4.4/zephyr-tls-4.4.1-tests.patch
+# optional, to drop mbedTLS entirely (needs wolfSSL + the wolfPSA PSA provider):
+patch -p1 < /path/to/your/osp/zephyr/4.4/zephyr-tls-4.4.1-mbedtls-decoupling.patch
 ```
 
-The tests patch also includes one small, wolfSSL-independent test fix —
+The tests patch also includes one small, wolfSSL-independent test fix -
 `sizeof(sec_tag_list_verify_none)` in `tests/net/lib/http_server/tls/src/main.c`, which the
 `net.http.server.tls` scenario needs on 64-bit builds. That fix is being submitted upstream
 separately and is expected to land in Zephyr 4.4.2; if you apply the tests patch to a tree that
 already contains it, drop the corresponding one-line hunk.
 
-The 4.4 mbedTLS module also requires the `tf-psa-crypto` west project — make sure it is in
+The 4.4 mbedTLS module also requires the `tf-psa-crypto` west project - make sure it is in
 your manifest's allowlist before `west update`.
 
 ### Minimum prj.conf
@@ -43,7 +68,7 @@ your manifest's allowlist before `west update`.
 Use `tests/net/socket/tls/prj_wolfssl.conf` as a template. At minimum the application needs
 `CONFIG_MBEDTLS=n`, `CONFIG_WOLFSSL=y`, and Zephyr POSIX support (`CONFIG_POSIX_API=y`,
 `CONFIG_POSIX_TIMERS=y`, `CONFIG_POSIX_THREADS=y`; without `CONFIG_POSIX_API` also set
-`CONFIG_POSIX_SYSTEM_INTERFACES=y` — Zephyr 4.4 gates the POSIX option groups on it).
+`CONFIG_POSIX_SYSTEM_INTERFACES=y` - Zephyr 4.4 gates the POSIX option groups on it).
 Size `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` to the application footprint.
 
 ### What changed compared to the Zephyr 4.3 integration
@@ -68,9 +93,9 @@ Zephyr 4.4 restructured the TLS socket layer and the random subsystem; the integ
   upstream `CONFIG_NET_SOCKETS_TLS_CONNECT_TIMEOUT` (default 10 s) on both backends.
 - **RNG.** Zephyr 4.4 removed `random_ctr_drbg.c` (the CSPRNG is PSA-based now). The wolfSSL
   RNG integration is therefore a new CSPRNG choice option `CONFIG_WOLFSSL_CSPRNG_GENERATOR`
-  (file `subsys/random/random_wolfssl.c`, wolfSSL Hash-DRBG seeded from the entropy driver,
-  personalization string via `CONFIG_WOLFSSL_CSPRNG_PERSONALIZATION`). Select it inside
-  `choice CSPRNG_GENERATOR_CHOICE` instead of the deprecated `CTR_DRBG_CSPRNG_GENERATOR`.
+  (file `subsys/random/random_wolfssl.c`, wolfSSL Hash-DRBG seeded from the entropy driver).
+  Select it inside `choice CSPRNG_GENERATOR_CHOICE` instead of the deprecated
+  `CTR_DRBG_CSPRNG_GENERATOR`.
 - **Minimum TLS version.** Upstream 4.4 enforces a minimum TLS version derived from the socket
   protocol. The wolfSSL backend keeps the 4.3 exact-version method selection
   (`wolfTLSv1_2/1_3_*_method`), which is stricter: an `IPPROTO_TLS_1_2` socket negotiates
@@ -80,7 +105,7 @@ Zephyr 4.4 restructured the TLS socket layer and the random subsystem; the integ
   `CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK` (the old name risked colliding with the
   wolfSSL module's own Kconfig namespace). A 4.3-era `prj.conf` still setting the old name
   fails the build with `error: Aborting due to Kconfig warnings` /
-  `attempt to assign the value 'y' to the undefined symbol WOLFSSL_VERIFY_CALLBACK` —
+  `attempt to assign the value 'y' to the undefined symbol WOLFSSL_VERIFY_CALLBACK` -
   rename the option in your application config.
 
 ### Configuration options
@@ -93,21 +118,37 @@ Options added by this integration:
 
 | Kconfig | Purpose |
 |---|---|
-| `WOLFSSL_SESSION_EXPORT` | External session cache (serialize sessions across connections) |
-| `WOLFSSL_KEEP_PEER_CERT` | Retain peer certificate after handshake |
-| `WOLFSSL_ALWAYS_VERIFY_CB` | Invoke verify callback on success in addition to failure |
 | `NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK` | Enable wolfSSL-native per-cert verify callback via the `TLS_CERT_VERIFY_CALLBACK_WOLFSSL` socket option (named `WOLFSSL_VERIFY_CALLBACK` in the 4.3 integration) |
 | `WOLFSSL_CSPRNG_GENERATOR` | Use the wolfSSL DRBG as the system CSPRNG (`sys_csrand_get`) |
-| `WOLFSSL_CSPRNG_PERSONALIZATION` | Personalization string for the wolfSSL DRBG |
 
-Existing wolfSSL module options (`WOLFSSL_DTLS`, `WOLFSSL_ALPN`, `WOLFSSL_PSK`,
-`WOLFSSL_TLS_VERSION_1_3`, `WOLFSSL_MAX_FRAGMENT_LEN`) are opt-in as usual.
+`CONFIG_NET_SOCKETS_SOCKOPT_TLS` force-selects the wolfSSL module options the backend cannot
+work without, so an application config does not have to set them:
+
+| Kconfig | Purpose |
+|---|---|
+| `WOLFSSL_OPENSSL_EXTRA_X509_SMALL` | Exposes `WOLFSSL_X509_STORE_CTX::current_cert`, which the verify callback reads for the leaf CN/SAN match |
+| `WOLFSSL_ALWAYS_VERIFY_CB` | Invoke verify callback on success in addition to failure - without it the CN/SAN match is silently bypassed |
+| `WOLFSSL_SESSION_CACHE` | wolfSSL compiles the session API out under `NO_SESSION_CACHE`, which the TLS layer needs to link |
+
+`CONFIG_WOLFSSL_SNI` is optional: with it disabled the Server Name Indication extension is not
+sent, but a configured `TLS_HOSTNAME` still drives the certificate CN/SAN match that
+`TLS_PEER_VERIFY` relies on. `CONFIG_WOLFSSL_CRYPTO_ONLY` is incompatible with TLS sockets and
+is rejected with a build error.
+
+Session resumption is a deliberate opt-in: set `CONFIG_WOLFSSL_SESSION_EXPORT=y` (external session
+cache) if you want it - the integration's session store/restore are no-ops without it. Existing
+wolfSSL module options (`WOLFSSL_DTLS`, `WOLFSSL_ALPN`, `WOLFSSL_PSK`, `WOLFSSL_TLS_VERSION_1_3`,
+`WOLFSSL_MAX_FRAGMENT_LEN`) are opt-in as usual.
 
 ### Limitations
 
+- A client that never sets `TLS_HOSTNAME` is rejected under `TLS_PEER_VERIFY_REQUIRED`, because
+  there is no name to check the peer certificate against. This matches the mbedTLS backend, which
+  sets an empty hostname for that case so no certificate can match. Set `TLS_HOSTNAME`, or use
+  `TLS_PEER_VERIFY_OPTIONAL` and read `TLS_CERT_VERIFY_RESULT`, or `TLS_PEER_VERIFY_NONE`.
 - TLS 1.0 and 1.1 disabled (`NO_OLD_TLS`).
 - The mbedTLS-style `TLS_CERT_VERIFY_CALLBACK` socket option is not supported on the wolfSSL backend.
-- `TLS_CERT_NOCOPY` has no effect — certificates are always copied.
+- `TLS_CERT_NOCOPY` has no effect - certificates are always copied.
 - TLS 1.3 0-RTT not wired on the wolfSSL path.
 - DTLS Connection ID (`TLS_DTLS_CID*`) is not supported; DTLS server sessions are matched by
   peer address only.

--- a/zephyr/4.4/zephyr-tls-4.4.1-mbedtls-decoupling.patch
+++ b/zephyr/4.4/zephyr-tls-4.4.1-mbedtls-decoupling.patch
@@ -1,0 +1,129 @@
+diff --git a/lib/uuid/Kconfig b/lib/uuid/Kconfig
+index 040b7c7768c..8b36580f360 100644
+--- a/lib/uuid/Kconfig
++++ b/lib/uuid/Kconfig
+@@ -19,8 +19,7 @@ config UUID_V4
+ config UUID_V5
+ 	bool "UUID version 5 generation support"
+ 	depends on UUID
+-	depends on MBEDTLS
+-	depends on MBEDTLS_PSA_CRYPTO_C
++	depends on PSA_CRYPTO_CLIENT
+ 	depends on PSA_WANT_ALG_SHA_1
+ 	# When TF-M is enabled, Mbed TLS's MD module (which is used to generate
+ 	# v5 UUIDs) will dispacth hash operations to TF-M. Unfortunately TF-M
+diff --git a/subsys/mgmt/mcumgr/transport/Kconfig.udp b/subsys/mgmt/mcumgr/transport/Kconfig.udp
+index 4d93f47aaba..194ab493255 100644
+--- a/subsys/mgmt/mcumgr/transport/Kconfig.udp
++++ b/subsys/mgmt/mcumgr/transport/Kconfig.udp
+@@ -64,8 +64,8 @@ config MCUMGR_TRANSPORT_UDP_MTU
+ 
+ config MCUMGR_TRANSPORT_UDP_DTLS
+ 	bool "DTLS"
+-	select MBEDTLS
+-	select MBEDTLS_ENABLE_HEAP
++	select MBEDTLS if !WOLFSSL
++	select MBEDTLS_ENABLE_HEAP if !WOLFSSL
+ 	select NET_SOCKETS_SOCKOPT_TLS
+ 	select NET_SOCKETS_ENABLE_DTLS
+ 	select TLS_CREDENTIALS
+diff --git a/subsys/mgmt/updatehub/Kconfig b/subsys/mgmt/updatehub/Kconfig
+index dca7aa44936..2dc89ae75fb 100644
+--- a/subsys/mgmt/updatehub/Kconfig
++++ b/subsys/mgmt/updatehub/Kconfig
+@@ -72,8 +72,8 @@ config UPDATEHUB_SHELL
+ 
+ config UPDATEHUB_DTLS
+ 	bool "Activate communication CoAPS/DTLS"
+-	select MBEDTLS
+-	select MBEDTLS_ENABLE_HEAP
++	select MBEDTLS if !WOLFSSL
++	select MBEDTLS_ENABLE_HEAP if !WOLFSSL
+ 	select NET_SOCKETS_SOCKOPT_TLS
+ 	select NET_SOCKETS_ENABLE_DTLS
+ 	help
+diff --git a/subsys/net/lib/lwm2m/lwm2m_engine.c b/subsys/net/lib/lwm2m/lwm2m_engine.c
+index 5ab89498c07..de9ddd98536 100644
+--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
++++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
+@@ -36,7 +36,14 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+ 
+ #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
+ #include <zephyr/net/tls_credentials.h>
+-#include <mbedtls/ssl_ciphersuites.h>
++
++/* IANA TLS cipher-suite identifiers, defined locally so the LwM2M ciphersuite
++ * list does not pull in an mbedTLS header. The DTLS handshake itself runs
++ * through the TLS socket layer, which may be backed by mbedTLS or wolfSSL.
++ */
++#define LWM2M_TLS_PSK_WITH_AES_128_CCM_8              0xC0A8
++#define LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8      0xC0AE
++#define LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 0xC02B
+ #endif
+ #if defined(CONFIG_DNS_RESOLVER)
+ #include <zephyr/net/dns_resolve.h>
+@@ -1060,12 +1067,12 @@ static int lwm2m_load_tls_credentials(struct lwm2m_ctx *ctx)
+ }
+ 
+ static const int cipher_list_psk[] = {
+-	MBEDTLS_TLS_PSK_WITH_AES_128_CCM_8,
++	LWM2M_TLS_PSK_WITH_AES_128_CCM_8,
+ };
+ 
+ static const int cipher_list_cert[] = {
+-	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
+-	MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
++	LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
++	LWM2M_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+ };
+ 
+ #endif /* CONFIG_LWM2M_DTLS_SUPPORT */
+diff --git a/subsys/net/lib/wireguard/crypto/crypto.h b/subsys/net/lib/wireguard/crypto/crypto.h
+index c81d8e74cc0..9a142dc5875 100644
+--- a/subsys/net/lib/wireguard/crypto/crypto.h
++++ b/subsys/net/lib/wireguard/crypto/crypto.h
+@@ -11,8 +11,6 @@
+ #include <stdint.h>
+ #include <stdbool.h>
+ 
+-#include <mbedtls/constant_time.h>
+-
+ /*
+  * BLAKE2S IMPLEMENTATION
+  * Note: BLAKE2s is not available in PSA Crypto API, so we always use
+@@ -82,7 +80,33 @@
+ 		(p)[0] = U8V((v) >> 56);                                                           \
+ 	} while (0)
+ 
+-#define crypto_zero(dest, len) mbedtls_platform_zeroize(dest, len)
+-#define crypto_equal(a, b, n) (mbedtls_ct_memcmp(a, b, n) == 0 ? true : false)
++/*
++ * Constant-time helpers, provided locally so WireGuard does not depend on
++ * mbedTLS. crypto_equal MUST run in constant time - it compares message
++ * authentication tags, where a data-dependent early exit would leak timing.
++ * crypto_zero clears secrets through a volatile pointer so the stores are not
++ * optimized away.
++ */
++static inline void crypto_zero(void *dest, size_t len)
++{
++	volatile uint8_t *p = (volatile uint8_t *)dest;
++
++	while (len--) {
++		*p++ = 0U;
++	}
++}
++
++static inline bool crypto_equal(const void *a, const void *b, size_t n)
++{
++	const volatile uint8_t *pa = (const volatile uint8_t *)a;
++	const volatile uint8_t *pb = (const volatile uint8_t *)b;
++	uint8_t diff = 0U;
++
++	while (n--) {
++		diff |= (uint8_t)(*pa++ ^ *pb++);
++	}
++
++	return diff == 0U;
++}
+ 
+ #endif /* _CRYPTO_H_ */

--- a/zephyr/4.4/zephyr-tls-4.4.1-tests.patch
+++ b/zephyr/4.4/zephyr-tls-4.4.1-tests.patch
@@ -1,9 +1,9 @@
 diff --git a/samples/net/sockets/echo_server/overlay-wolfssl.conf b/samples/net/sockets/echo_server/overlay-wolfssl.conf
 new file mode 100644
-index 00000000000..b3a539a5e0a
+index 00000000000..43870a21619
 --- /dev/null
 +++ b/samples/net/sockets/echo_server/overlay-wolfssl.conf
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,24 @@
 +# Copyright (c) 2026 wolfSSL Inc.
 +# SPDX-License-Identifier: Apache-2.0
 +
@@ -28,8 +28,6 @@ index 00000000000..b3a539a5e0a
 +CONFIG_WOLFSSL=y
 +CONFIG_WOLFSSL_DTLS=y
 +CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
-+
-+
 diff --git a/samples/net/sockets/echo_server/sample.yaml b/samples/net/sockets/echo_server/sample.yaml
 index c67d92b6334..5f7ce98b3e3 100644
 --- a/samples/net/sockets/echo_server/sample.yaml
@@ -117,7 +115,7 @@ index 00000000000..73f459c0974
 +CONFIG_WOLFSSL=y
 +CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
 diff --git a/tests/net/lib/http_server/tls/src/main.c b/tests/net/lib/http_server/tls/src/main.c
-index 2a26ff77377..35e2f61d22a 100644
+index 2a26ff77377..e55a8b8d603 100644
 --- a/tests/net/lib/http_server/tls/src/main.c
 +++ b/tests/net/lib/http_server/tls/src/main.c
 @@ -14,6 +14,9 @@
@@ -130,21 +128,16 @@ index 2a26ff77377..35e2f61d22a 100644
  
  LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
  
-@@ -161,7 +164,12 @@ static void test_tls(void)
+@@ -161,7 +164,7 @@ static void test_tls(void)
  		const sec_tag_t *sec_tag_list;
  		size_t sec_tag_list_size;
  
 -		sec_tag_list_size = sizeof(sec_tag_list);
-+		/* sizeof(sec_tag_list_verify_none), not sizeof(sec_tag_list)
-+		 * — the latter is sizeof(pointer), which on 64-bit hosts
-+		 * (e.g. native_sim/native/64) feeds an extra garbage sec_tag
-+		 * into setsockopt and breaks credential lookup.
-+		 */
 +		sec_tag_list_size = sizeof(sec_tag_list_verify_none);
  		sec_tag_list = sec_tag_list_verify_none;
  
  		ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
-@@ -263,4 +271,37 @@ static void *setup(void)
+@@ -263,4 +266,37 @@ static void *setup(void)
  	return NULL;
  }
  
@@ -365,7 +358,7 @@ index 4b5a4a8d1a8..81d618309c3 100644
 +CONFIG_NET_CONTEXT_REUSEPORT=y
 diff --git a/tests/net/socket/tls/prj_wolfssl.conf b/tests/net/socket/tls/prj_wolfssl.conf
 new file mode 100644
-index 00000000000..c433e70a967
+index 00000000000..83f15457040
 --- /dev/null
 +++ b/tests/net/socket/tls/prj_wolfssl.conf
 @@ -0,0 +1,76 @@
@@ -378,7 +371,7 @@ index 00000000000..c433e70a967
 +# options that would have to be neutralized symbol-by-symbol here, and
 +# every upstream addition to prj.conf would break this scenario with a
 +# Kconfig warning. Keep the backend-neutral part below in sync with
-+# prj.conf when it changes — check_conf_sync.py in this directory
++# prj.conf when it changes - check_conf_sync.py in this directory
 +# verifies the two files and fails on drift.
 +
 +# Setup for self-contained net testing without requiring a SLIP driver
@@ -446,7 +439,7 @@ index 00000000000..c433e70a967
 +CONFIG_NET_SOCKETS_TLS_MAX_APP_PROTOCOLS=3
 +CONFIG_NET_CONTEXT_REUSEPORT=y
 diff --git a/tests/net/socket/tls/src/main.c b/tests/net/socket/tls/src/main.c
-index 5db92a18ff3..c1531aa1d1a 100644
+index 5db92a18ff3..1ec7fb73747 100644
 --- a/tests/net/socket/tls/src/main.c
 +++ b/tests/net/socket/tls/src/main.c
 @@ -11,23 +11,80 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -455,7 +448,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
  #include <zephyr/net/tls_credentials.h>
 +/* IANA TLS ciphersuite IDs used by this file's set_ciphersuites tests.
 + * Names match RFC 5487. Don't introduce a public Zephyr-wide header just
-+ * for these two — both backends accept IANA IDs verbatim via the byte-
++ * for these two - both backends accept IANA IDs verbatim via the byte-
 + * list cipher API. (The RFC 4279 SHA-1 CBC suites used previously are no
 + * longer selectable in the Zephyr 4.4 mbedTLS ciphersuite Kconfig.)
 + */
@@ -486,7 +479,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
  uint32_t ztls_get_session_count(void);
  
 +/* Server-side allow-list. Only TLS_PSK_WITH_AES_256_CBC_SHA384 is enabled
-+ * in prj.conf for the mbedTLS scenarios — the GCM suite entry is never
++ * in prj.conf for the mbedTLS scenarios - the GCM suite entry is never
 + * negotiated, it only exercises list handling and the mismatch case. Keep
 + * it that way: enabling extra suites globally in prj.conf would change the
 + * default cipher negotiated by the other tests in this file, which size
@@ -523,7 +516,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
  #define CLIENT_3_PORT 4245
 +/* Dedicated port for test_session_cache_client_resume: the client-side
 + * session cache is keyed by peer address, so the test needs a fixed
-+ * port — but it must not collide with SERVER_PORT used by the DTLS
++ * port - but it must not collide with SERVER_PORT used by the DTLS
 + * multi-client tests, to stay independent of suite ordering and
 + * TIME_WAIT teardown.
 + */
@@ -741,7 +734,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
 + * GCM), measured by running the suite with an oversized buffer and printing
 + * the inbound record length. Different values per backend reflect different
 + * implementation choices for the record-layer framing (header layout, IV
-+ * placement, padding) — they are not part of any wire-format ABI. If a
++ * placement, padding) - they are not part of any wire-format ABI. If a
 + * test starts failing here after a backend or ciphersuite change, re-measure
 + * with an oversized buffer and update.
 + */
@@ -844,11 +837,11 @@ index 5db92a18ff3..c1531aa1d1a 100644
 +	test_prepare_dtls_connection(NET_AF_INET6);
 +
 +	/* Schedule reception shutdown from workqueue while recv() is blocked
-+	 * — exercises the recv_eof check inside the wolfSSL DTLS recv loop
++	 * - exercises the recv_eof check inside the wolfSSL DTLS recv loop
 +	 * (recvfrom_dtls_common_wolfssl). The TCP/TLS variant lives in
 +	 * test_shutdown_rd_while_recv. 50ms margin guards against slow CI
 +	 * runners where recv() hasn't reached its blocking point yet at the
-+	 * 10ms mark — short enough to keep the test fast.
++	 * 10ms mark - short enough to keep the test fast.
 +	 */
 +	k_work_init_delayable(&test_data.work, shutdown_work);
 +	test_data.sock = c_sock;
@@ -1231,7 +1224,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
 +
 +/* Sets up a TLS client/server connection on a FIXED server port so two
 + * consecutive connections present the same peer address (which is the key
-+ * into client_cache). Used by test_session_cache_client_resume — the
++ * into client_cache). Used by test_session_cache_client_resume - the
 + * main test_prepare_* helpers use ANY_PORT, which prevents resumption
 + * lookup from matching across connections.
 + */
@@ -1301,7 +1294,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
 +		zsock_close(dummy);
 +	}
 +
-+	/* First connection — should perform full handshake, then store. */
++	/* First connection - should perform full handshake, then store. */
 +	prepare_tls_session_resume_connection(RESUME_SERVER_PORT);
 +
 +#if defined(CONFIG_WOLFSSL)
@@ -1326,7 +1319,7 @@ index 5db92a18ff3..c1531aa1d1a 100644
 +	test_sockets_close();
 +	k_sleep(TCP_TEARDOWN_TIMEOUT);
 +
-+	/* Second connection to the SAME server port — should restore the
++	/* Second connection to the SAME server port - should restore the
 +	 * stored session and resume.
 +	 */
 +	prepare_tls_session_resume_connection(RESUME_SERVER_PORT);
@@ -1863,7 +1856,7 @@ index 00000000000..ca2568bb15d
 +CONFIG_WOLFSSL_SESSION_EXPORT=y
 +CONFIG_WOLFSSL_ALWAYS_VERIFY_CB=y
 diff --git a/tests/net/socket/tls_ext/src/main.c b/tests/net/socket/tls_ext/src/main.c
-index 865a44993d7..cc79217a081 100644
+index 865a44993d7..727138eefbe 100644
 --- a/tests/net/socket/tls_ext/src/main.c
 +++ b/tests/net/socket/tls_ext/src/main.c
 @@ -13,8 +13,14 @@
@@ -1922,21 +1915,28 @@ index 865a44993d7..cc79217a081 100644
  
  	memset(&sa, 0, sizeof(sa));
  	/* The server listens on all network interfaces */
-@@ -334,11 +340,11 @@ static int test_configure_client(struct net_sockaddr_in *sa, bool own_cert,
+@@ -334,11 +340,16 @@ static int test_configure_client(struct net_sockaddr_in *sa, bool own_cert,
  
  	r = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SEC_TAG_LIST,
  			     sec_tag_list, sec_tag_list_size);
 -	zassert_not_equal(r, -1, "failed to set TLS_SEC_TAG_LIST (%d)", errno);
 +	zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_SEC_TAG_LIST (%d)", errno);
  
- 	r = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, hostname,
- 			     strlen(hostname) + 1);
+-	r = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, hostname,
+-			     strlen(hostname) + 1);
 -	zassert_not_equal(r, -1, "failed to set TLS_HOSTNAME (%d)", errno);
-+	zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_HOSTNAME (%d)", errno);
++	/* A NULL hostname leaves TLS_HOSTNAME unset, which both backends treat
++	 * as a peer identity that cannot be verified.
++	 */
++	if (hostname != NULL) {
++		r = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_HOSTNAME, hostname,
++				     strlen(hostname) + 1);
++		zassert_not_equal(r, -1, "failed to set ZSOCK_TLS_HOSTNAME (%d)", errno);
++	}
  
  	sa->sin_family = NET_PF_INET;
  	sa->sin_port = net_htons(PORT);
-@@ -434,9 +440,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
+@@ -434,9 +445,17 @@ ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_optional)
  
  ZTEST(net_socket_tls_api_extension, test_tls_peer_verify_required)
  {
@@ -1954,7 +1954,7 @@ index 865a44993d7..cc79217a081 100644
  static void test_tls_cert_verify_result_opt_common(uint32_t expect)
  {
  	int server_fd, client_fd, ret;
-@@ -457,7 +471,7 @@ static void test_tls_cert_verify_result_opt_common(uint32_t expect)
+@@ -457,7 +476,7 @@ static void test_tls_cert_verify_result_opt_common(uint32_t expect)
  
  	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
  			       &peer_verify, sizeof(peer_verify));
@@ -1963,15 +1963,66 @@ index 865a44993d7..cc79217a081 100644
  
  	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
  	zassert_not_equal(ret, -1, "failed to connect (%d)", errno);
-@@ -481,13 +495,60 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
+@@ -481,6 +500,104 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_result_opt_bad_cn)
  	test_tls_cert_verify_result_opt_common(MBEDTLS_X509_BADCERT_CN_MISMATCH);
  }
  
++/* A client that never sets TLS_HOSTNAME has no name to check the peer
++ * certificate against, so TLS_PEER_VERIFY_REQUIRED must reject it rather
++ * than accept a certificate issued for any name.
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_no_hostname_required_rejected)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++	int peer_verify = ZSOCK_TLS_PEER_VERIFY_REQUIRED;
++
++	server_fd = test_configure_server(&server_thread_id, ZSOCK_TLS_PEER_VERIFY_NONE,
++					  false, true);
++	client_fd = test_configure_client(&sa, false, NULL);
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
++			       &peer_verify, sizeof(peer_verify));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_PEER_VERIFY (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_equal(ret, -1, "connect succeeded without a hostname to verify");
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
++/* TLS_PEER_VERIFY_NONE means no peer verification at all, so a hostname
++ * that cannot match must not fail the handshake. Guards against the name
++ * check making NONE stricter than OPTIONAL.
++ */
++ZTEST(net_socket_tls_api_extension, test_tls_verify_none_ignores_hostname)
++{
++	int server_fd, client_fd, ret;
++	k_tid_t server_thread_id;
++	struct net_sockaddr_in sa;
++	int peer_verify = ZSOCK_TLS_PEER_VERIFY_NONE;
++
++	server_fd = test_configure_server(&server_thread_id, ZSOCK_TLS_PEER_VERIFY_NONE,
++					  false, false);
++	client_fd = test_configure_client(&sa, false, "dummy");
++
++	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_PEER_VERIFY,
++			       &peer_verify, sizeof(peer_verify));
++	zassert_ok(ret, "failed to set ZSOCK_TLS_PEER_VERIFY (%d)", errno);
++
++	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
++	zassert_not_equal(ret, -1, "TLS_PEER_VERIFY_NONE rejected a hostname mismatch (%d)",
++			  errno);
++
++	test_shutdown(client_fd, server_fd, server_thread_id);
++}
++
 +/* Applications commonly pass strlen(host) + 1 (or sizeof a literal) as
 + * optlen for TLS_HOSTNAME. The mbedTLS backend ignores optlen and reads a
 + * C string; the wolfSSL backend uses optlen as the hostname length and
 + * strips a trailing NUL. Both must accept the NUL-terminated form and
-+ * still match the certificate CN — pin that here.
++ * still match the certificate CN - pin that here.
 + */
 +ZTEST(net_socket_tls_api_extension, test_tls_hostname_trailing_nul)
 +{
@@ -2017,15 +2068,7 @@ index 865a44993d7..cc79217a081 100644
  struct test_cert_verify_ctx {
  	bool cb_called;
  	int result;
- };
- 
- static int cert_verify_cb(void *ctx, mbedtls_x509_crt *crt, int depth,
--			  uint32_t *flags)
-+			   uint32_t *flags)
- {
- 	struct test_cert_verify_ctx *test_ctx = (struct test_cert_verify_ctx *)ctx;
- 
-@@ -522,7 +583,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
+@@ -522,7 +639,7 @@ static void test_tls_cert_verify_cb_opt_common(int result)
  
  	ret = zsock_setsockopt(client_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_CERT_VERIFY_CALLBACK,
  			       &cb, sizeof(cb));
@@ -2034,7 +2077,7 @@ index 865a44993d7..cc79217a081 100644
  
  	ret = zsock_connect(client_fd, (struct net_sockaddr *)&sa, sizeof(sa));
  	zassert_true(ctx.cb_called, "callback not called");
-@@ -546,6 +607,37 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
+@@ -546,6 +663,37 @@ ZTEST(net_socket_tls_api_extension, test_tls_cert_verify_cb_opt_bad_cert)
  	test_tls_cert_verify_cb_opt_common(MBEDTLS_ERR_X509_CERT_VERIFY_FAILED);
  }
  
@@ -2072,7 +2115,7 @@ index 865a44993d7..cc79217a081 100644
  static void *setup(void)
  {
  	int r;
-@@ -599,4 +691,361 @@ static void *setup(void)
+@@ -599,4 +747,361 @@ static void *setup(void)
  	return NULL;
  }
  

--- a/zephyr/4.4/zephyr-tls-4.4.1.patch
+++ b/zephyr/4.4/zephyr-tls-4.4.1.patch
@@ -20,7 +20,7 @@ index 927c8d5087e..df4b2d5e180 100644
  #define AI_PASSIVE      ZSOCK_AI_PASSIVE
  #define AI_CANONNAME    ZSOCK_AI_CANONNAME
 diff --git a/include/zephyr/net/socket.h b/include/zephyr/net/socket.h
-index 322309c26f0..de832814d8e 100644
+index 322309c26f0..65c5562ba30 100644
 --- a/include/zephyr/net/socket.h
 +++ b/include/zephyr/net/socket.h
 @@ -173,7 +173,9 @@ extern "C" {
@@ -72,7 +72,7 @@ index 322309c26f0..de832814d8e 100644
 + *  int (*)(int preverify_ok, WOLFSSL_X509_STORE_CTX *ctx).
 + *
 + *  Constraints (the TLS layer wraps this callback): it is invoked
-+ *  synchronously per chain position and must return normally — it must NOT
++ *  synchronously per chain position and must return normally - it must NOT
 + *  longjmp/throw out of the call. The application context registered via
 + *  @ref zsock_tls_cert_verify_cb_wolfssl is presented through
 + *  store_ctx->userCtx for the duration of the call only; the callback must
@@ -103,7 +103,7 @@ index 322309c26f0..de832814d8e 100644
  
 diff --git a/include/zephyr/net/tls_verify.h b/include/zephyr/net/tls_verify.h
 new file mode 100644
-index 00000000000..92ac4f1dd22
+index 00000000000..f33f007d5aa
 --- /dev/null
 +++ b/include/zephyr/net/tls_verify.h
 @@ -0,0 +1,139 @@
@@ -118,7 +118,7 @@ index 00000000000..92ac4f1dd22
 + *
 + * The wolfSSL backend accumulates certificate verification errors into the
 + * TLS_CERT_VERIFY_RESULT getsockopt bitmask using the same hex values as
-+ * mbedtls/x509.h's MBEDTLS_X509_BADCERT_* macros — the layout is part of
++ * mbedtls/x509.h's MBEDTLS_X509_BADCERT_* macros - the layout is part of
 + * the TLS_CERT_VERIFY_RESULT public contract and predates the wolfSSL
 + * backend. Applications that already include mbedtls/x509.h are
 + * automatically protected from redefinition by the #ifndef guards below.
@@ -256,10 +256,10 @@ index 7e32b540ce4..a51a9a3b74d 100644
  zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
 +zephyr_library_link_libraries_ifdef(CONFIG_WOLFSSL wolfSSL)
 diff --git a/subsys/net/lib/sockets/Kconfig b/subsys/net/lib/sockets/Kconfig
-index 87fbe4c7bca..abf036a02f4 100644
+index 87fbe4c7bca..636216613f6 100644
 --- a/subsys/net/lib/sockets/Kconfig
 +++ b/subsys/net/lib/sockets/Kconfig
-@@ -129,12 +129,76 @@ config NET_SOCKETS_SERVICE_STACK_SIZE
+@@ -129,12 +129,80 @@ config NET_SOCKETS_SERVICE_STACK_SIZE
  config NET_SOCKETS_SOCKOPT_TLS
  	bool "TCP TLS socket option support"
  	imply TLS_CREDENTIALS
@@ -270,7 +270,6 @@ index 87fbe4c7bca..abf036a02f4 100644
 +	# wolfSSL backend requirements. The integration calls a narrow set of
 +	# non-base wolfSSL APIs; only the strict minimum is force-selected
 +	# here to keep flash/RAM cost on constrained targets low:
-+	#   SET_CIPHER_BYTES - wolfSSL_set_cipher_list_bytes (small)
 +	#   OPENSSL_EXTRA_X509_SMALL - exposes WOLFSSL_X509_STORE_CTX::current_cert
 +	#                      which the verify callback reads to perform the
 +	#                      leaf CN/SAN match. wolfSSL gates the whole
@@ -285,13 +284,18 @@ index 87fbe4c7bca..abf036a02f4 100644
 +	# HAVE_EXT_CACHE is undefined, so enabling it is an explicit opt-in.
 +	# (wolfSSL_clear, wolfSSL_X509_check_host and wolfSSL_set_verify are
 +	# always available in src/ssl.c / src/x509.c / src/ssl_api_cert.c.)
-+	# Gated on `WOLFSSL && !MBEDTLS` because the backends are mutually
-+	# exclusive: pulling these wolfSSL knobs in on an mbedTLS build (e.g.
-+	# when CONFIG_WOLFSSL=y is enabled for the random subsystem only) is
-+	# pure bloat and risks user confusion.
-+	select WOLFSSL_SET_CIPHER_BYTES if WOLFSSL && !MBEDTLS
++	#   SESSION_CACHE - wolfSSL compiles wolfSSL_CTX_set_session_cache_mode,
++	#                      wolfSSL_get1_session and the session
++	#                      serialization API out under NO_SESSION_CACHE,
++	#                      so the TLS layer would not link without it.
++	# WOLFSSL_SET_CIPHER_BYTES (wolfSSL_set_cipher_list_bytes) needs no
++	# select: the module's user_settings.h defines it from this symbol.
++	# The `!MBEDTLS` qualifier is belt and braces: sockets_tls.c refuses to
++	# build with both backends, so it only keeps the knobs out of a tree
++	# that was never going to compile.
 +	select WOLFSSL_OPENSSL_EXTRA_X509_SMALL if WOLFSSL && !MBEDTLS
 +	select WOLFSSL_ALWAYS_VERIFY_CB if WOLFSSL && !MBEDTLS
++	select WOLFSSL_SESSION_CACHE if WOLFSSL && !MBEDTLS
  	help
  	  Enable TLS socket option support which automatically establishes
  	  a TLS connection to the remote host.
@@ -338,7 +342,7 @@ index 87fbe4c7bca..abf036a02f4 100644
  config NET_SOCKETS_TLS_CONNECT_TIMEOUT
  	int "Timeout value in milliseconds for TLS handshake"
  	depends on NET_SOCKETS_SOCKOPT_TLS
-@@ -155,15 +219,18 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+@@ -155,15 +223,18 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
  	bool "Set Maximum Fragment Length (MFL)"
  	default y
  	help
@@ -365,7 +369,7 @@ index 87fbe4c7bca..abf036a02f4 100644
  
  	  This is mostly useful for TLS client side to tell TLS server what is
  	  the maximum supported receive record length.
-@@ -171,7 +238,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
+@@ -171,7 +242,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
  config NET_SOCKETS_ENABLE_DTLS
  	bool "DTLS socket support"
  	depends on NET_SOCKETS_SOCKOPT_TLS
@@ -374,7 +378,7 @@ index 87fbe4c7bca..abf036a02f4 100644
  	help
  	  Enable DTLS socket support. By default only TLS over TCP is supported.
  
-@@ -261,7 +328,7 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
+@@ -261,7 +332,7 @@ config NET_SOCKETS_TLS_MAX_CIPHERSUITES
  config NET_SOCKETS_TLS_MAX_APP_PROTOCOLS
  	int "Maximum number of supported application layer protocols"
  	default 2
@@ -383,7 +387,7 @@ index 87fbe4c7bca..abf036a02f4 100644
  	help
  	  This variable sets maximum number of supported application layer
  	  protocols over TLS/DTLS that can be set explicitly by a socket option.
-@@ -276,12 +343,41 @@ config NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT
+@@ -276,12 +347,41 @@ config NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT
  	  used for TLS/DTLS session resumption.
  
  config NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK
@@ -430,7 +434,7 @@ index 87fbe4c7bca..abf036a02f4 100644
  config NET_SOCKETS_OFFLOAD
  	bool "Offload Socket APIs"
 diff --git a/subsys/net/lib/sockets/sockets_tls.c b/subsys/net/lib/sockets/sockets_tls.c
-index 4c8bded0e47..7d5ed85aff3 100644
+index 4c8bded0e47..a7caf9f8404 100644
 --- a/subsys/net/lib/sockets/sockets_tls.c
 +++ b/subsys/net/lib/sockets/sockets_tls.c
 @@ -41,6 +41,12 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -446,10 +450,19 @@ index 4c8bded0e47..7d5ed85aff3 100644
  #endif /* CONFIG_MBEDTLS */
  
  #include "sockets_internal.h"
-@@ -51,6 +57,93 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
+@@ -51,6 +57,118 @@ LOG_MODULE_REGISTER(net_sock_tls, CONFIG_NET_SOCKETS_LOG_LEVEL);
  #include <zephyr_mbedtls_priv.h>
  #endif
  
++#if defined(CONFIG_WOLFSSL) && defined(CONFIG_MBEDTLS)
++/* The two TLS-socket backends are mutually exclusive: their function blocks
++ * define the same ZTLS_* macros and IO callbacks. Fail early with an actionable
++ * message instead of a downstream macro-redefinition / VERIFY_CB #error.
++ */
++#error "wolfSSL and mbedTLS TLS-socket backends are mutually exclusive; " \
++       "enable exactly one of CONFIG_WOLFSSL / CONFIG_MBEDTLS."
++#endif
++
 +#if defined(CONFIG_WOLFSSL)
 +/* wolfssl/wolfcrypt/settings.h's WOLFSSL_ZEPHYR block #defines POSIX
 + * socket names (socket, bind, connect, ..., getsockname) to their
@@ -461,11 +474,11 @@ index 4c8bded0e47..7d5ed85aff3 100644
 + * Suppress with a hard #undef right before each wolfSSL header include
 + * rather than save-and-restore via #pragma push_macro/pop_macro: the
 + * push form would silently capture (and later reinstall) whatever
-+ * upstream header had previously defined these names as macros — a
++ * upstream header had previously defined these names as macros - a
 + * future addition would be invisible at review time and break the
 + * vtable. The #undef form makes it a build error instead.
 + *
-+ * List mirrors the WOLFSSL_ZEPHYR remappings as of wolfSSL master —
++ * List mirrors the WOLFSSL_ZEPHYR remappings as of wolfSSL master -
 + * revisit on uprev.
 + */
 +#undef socket
@@ -523,6 +536,22 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +#error "DTLS sockets enabled but wolfssl DTLS not enabled"
 +#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && !WOLFSSL_DTLS */
 +
++/* WOLFCRYPT_ONLY compiles the whole wolfSSL TLS layer out, so every
++ * wolfSSL_* call below would fail to link.
++ */
++#if defined(WOLFCRYPT_ONLY)
++#error "Zephyr TLS sockets need the wolfSSL TLS layer " \
++       "(disable CONFIG_WOLFSSL_CRYPTO_ONLY)"
++#endif /* WOLFCRYPT_ONLY */
++
++/* The session-cache paths below call wolfSSL_CTX_set_session_cache_mode(),
++ * wolfSSL_get1_session() and friends, all compiled out by NO_SESSION_CACHE.
++ */
++#if defined(NO_SESSION_CACHE)
++#error "Zephyr TLS sockets with wolfSSL require the session cache " \
++       "(enable CONFIG_WOLFSSL_SESSION_CACHE)"
++#endif /* NO_SESSION_CACHE */
++
 +#define ZTLS_IS_CLIENT        0
 +#define ZTLS_IS_SERVER        1
 +#define ZTLS_ERROR_WANT_READ  WOLFSSL_ERROR_WANT_READ
@@ -540,7 +569,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  #define LOG_ADDR_PORT_HELPER(addr)                                \
  	(addr)->sa_family == NET_AF_INET ?                        \
  		net_sprint_ipv4_addr(&net_sin(addr)->sin_addr) :  \
-@@ -125,14 +218,14 @@ struct tls_session_cache {
+@@ -125,14 +243,14 @@ struct tls_session_cache {
  	size_t session_len;
  };
  
@@ -557,7 +586,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  struct tls_session_context {
  	sys_snode_t node;
-@@ -154,9 +247,30 @@ struct tls_session_context {
+@@ -154,9 +272,30 @@ struct tls_session_context {
  	mbedtls_ssl_context ssl;
  #endif /* CONFIG_MBEDTLS */
  
@@ -588,13 +617,17 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	/* DTLS peer address. */
  	struct net_sockaddr_storage dtls_peer_addr;
-@@ -183,6 +297,27 @@ __net_socket struct tls_context {
+@@ -183,6 +322,36 @@ __net_socket struct tls_context {
  	/** Information whether underlying socket is listening. */
  	bool is_listening : 1;
  
 +#if defined(CONFIG_WOLFSSL)
-+	/** Local read side was shut down via shutdown(SHUT_RD/SHUT_RDWR).
-+	 *  Distinct from session_closed: send() must keep working.
++	/** Local read side was shut down via shutdown(). Distinct from
++	 *  session_closed: send() must keep working.
++	 *
++	 *  Latched only when the underlying shutdown() succeeds, which on the
++	 *  native inet backend means SHUT_RD alone: SHUT_WR and SHUT_RDWR
++	 *  return -ENOTSUP there and leave this clear.
 +	 *
 +	 *  One-way flag: once set, it's cleared only when the slot is
 +	 *  recycled by tls_alloc() (which memsets the struct). There is no
@@ -611,12 +644,17 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	 * (not once per session, nor once globally). Cleared on tls_alloc().
 +	 */
 +	bool server_hostname_warned : 1;
++
++	/* Set once the application configured TLS_DTLS_ROLE explicitly, so
++	 * tls_wolfssl_init() derives the role only when it was left to us.
++	 */
++	bool role_set : 1;
 +#endif /* CONFIG_WOLFSSL */
 +
  	/* TLS sessions associated with this socket. In most cases there will
  	 * be one session allocated per TLS context. DTLS server is an exception,
  	 * which can have multiple TLS sessions allocated at the same time.
-@@ -251,20 +386,51 @@ __net_socket struct tls_context {
+@@ -251,20 +420,51 @@ __net_socket struct tls_context {
  		uint32_t dtls_handshake_timeout_min;
  		uint32_t dtls_handshake_timeout_max;
  
@@ -672,14 +710,14 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  #if defined(CONFIG_MBEDTLS)
  	/** mbedTLS configuration. */
-@@ -299,7 +465,31 @@ BUILD_ASSERT(CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS >= CONFIG_NET_SOCKETS_T
+@@ -299,7 +499,31 @@ BUILD_ASSERT(CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS >= CONFIG_NET_SOCKETS_T
  	     "CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS cannot be smaller than "
  	     "CONFIG_NET_SOCKETS_TLS_MAX_CONTEXTS");
  
 +/* Client-side session cache. mbedTLS uses it unconditionally. wolfSSL only
 + * uses it when HAVE_EXT_CACHE is defined (CONFIG_WOLFSSL_SESSION_EXPORT)
 + * because session import/export requires the wolfSSL_d2i/i2d APIs gated
-+ * on that macro — without it tls_session_store/restore are no-ops and
++ * on that macro - without it tls_session_store/restore are no-ops and
 + * the cache stays empty, so leave it (and its mutex / reset helper) out
 + * of .bss entirely.
 + */
@@ -704,7 +742,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  #if defined(MBEDTLS_SSL_CACHE_C)
  static mbedtls_ssl_cache_context server_cache;
-@@ -313,8 +503,15 @@ static struct k_mutex context_lock;
+@@ -313,8 +537,15 @@ static struct k_mutex context_lock;
   */
  #define TLS_WAIT_MS 100
  
@@ -720,7 +758,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static void tls_session_cache_reset(void)
  {
  	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
-@@ -325,6 +522,37 @@ static void tls_session_cache_reset(void)
+@@ -325,6 +556,42 @@ static void tls_session_cache_reset(void)
  
  	(void)memset(client_cache, 0, sizeof(client_cache));
  }
@@ -730,6 +768,11 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	k_mutex_lock(&client_cache_lock, K_FOREVER);
 +	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
 +		if (client_cache[i].session != NULL) {
++			/* Serialized session holds the TLS master/resumption
++			 * secret; scrub before releasing to the heap.
++			 */
++			wc_ForceZero(client_cache[i].session,
++				     client_cache[i].session_len);
 +			XFREE(client_cache[i].session, NULL,
 +			      DYNAMIC_TYPE_TMP_BUFFER);
 +		}
@@ -758,7 +801,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  bool net_socket_is_tls(void *obj)
  {
-@@ -332,6 +560,7 @@ bool net_socket_is_tls(void *obj)
+@@ -332,6 +599,7 @@ bool net_socket_is_tls(void *obj)
  }
  
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
@@ -766,7 +809,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  /* mbedTLS-defined function for setting timer. */
  static void dtls_timing_set_delay(void *data, uint32_t int_ms, uint32_t fin_ms)
  {
-@@ -393,6 +622,7 @@ static int dtls_get_remaining_timeout(struct tls_session_context *session_ctx)
+@@ -393,6 +661,7 @@ static int dtls_get_remaining_timeout(struct tls_session_context *session_ctx)
  
  	return timing->fin_ms - elapsed_ms;
  }
@@ -774,7 +817,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  static void dtls_server_init_session_timeout(struct tls_session_context *session_ctx)
  {
-@@ -416,7 +646,9 @@ static int tls_init(void)
+@@ -416,7 +685,9 @@ static int tls_init(void)
  #endif
  
  	(void)memset(tls_contexts, 0, sizeof(tls_contexts));
@@ -784,7 +827,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	k_mutex_init(&context_lock);
  
-@@ -424,6 +656,34 @@ static int tls_init(void)
+@@ -424,6 +695,35 @@ static int tls_init(void)
  	mbedtls_ssl_cache_init(&server_cache);
  #endif
  
@@ -792,9 +835,10 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	/* Validate the configured TLS 1.3 PSK ciphersuite at init: a typo in
 +	 * CONFIG_NET_SOCKETS_TLS_WOLFSSL_PSK_TLS13_CIPHERSUITE is a build-
 +	 * time bug, not a transient runtime issue, so fail loudly here
-+	 * rather than at first handshake. __ASSERT panics dev builds (CONFIG_
-+	 * ASSERT=y); returning non-zero from tls_init signals SYS_INIT
-+	 * failure so release builds also surface the misconfiguration.
++	 * rather than at first handshake. __ASSERT panics dev builds
++	 * (CONFIG_ASSERT=y). With asserts off this only logs: z_sys_init_run_level()
++	 * discards init_fn() return values, so boot continues and every TLS 1.3
++	 * PSK handshake then fails at runtime.
 +	 */
 +	{
 +		byte cs0, cs1;
@@ -819,7 +863,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	return 0;
  }
  
-@@ -484,8 +744,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
+@@ -484,8 +784,10 @@ static inline void tls_set_max_frag_len(mbedtls_ssl_config *config, enum net_soc
  	mbedtls_ssl_conf_max_frag_len(config, mfl_code);
  }
  #else
@@ -830,7 +874,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  static struct tls_session_context *tls_session_alloc(void)
  {
-@@ -499,14 +761,33 @@ static struct tls_session_context *tls_session_alloc(void)
+@@ -499,14 +801,33 @@ static struct tls_session_context *tls_session_alloc(void)
  
  	(void)memset(session_ctx, 0, sizeof(*session_ctx));
  	(void)k_sem_init(&session_ctx->tls_established, 0, 1);
@@ -864,7 +908,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	k_mem_slab_free(&tls_session_contexts, (void *)session_ctx);
  }
  
-@@ -548,6 +829,15 @@ static struct tls_context *tls_alloc(void)
+@@ -548,6 +869,15 @@ static struct tls_context *tls_alloc(void)
  	k_mutex_unlock(&context_lock);
  
  	if (tls) {
@@ -880,7 +924,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  		mbedtls_ssl_config_init(&tls->config);
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  		mbedtls_ssl_cookie_init(&tls->cookie);
-@@ -568,6 +858,7 @@ static struct tls_context *tls_alloc(void)
+@@ -568,6 +898,7 @@ static struct tls_context *tls_alloc(void)
  #if defined(CONFIG_MBEDTLS_DEBUG)
  		mbedtls_ssl_conf_dbg(&tls->config, zephyr_mbedtls_debug, NULL);
  #endif
@@ -888,7 +932,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	} else {
  		NET_WARN("Failed to allocate TLS context");
  	}
-@@ -591,12 +882,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
+@@ -591,12 +922,25 @@ static struct tls_context *tls_clone(struct tls_context *source_tls)
  	memcpy(&target_tls->options, &source_tls->options,
  	       sizeof(target_tls->options));
  
@@ -916,7 +960,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	return target_tls;
  }
-@@ -616,6 +920,25 @@ static int tls_release(struct tls_context *tls)
+@@ -616,6 +960,25 @@ static int tls_release(struct tls_context *tls)
  		return -EBADF;
  	}
  
@@ -942,7 +986,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  	mbedtls_ssl_cookie_free(&tls->cookie);
  #endif
-@@ -625,6 +948,7 @@ static int tls_release(struct tls_context *tls)
+@@ -625,19 +988,58 @@ static int tls_release(struct tls_context *tls)
  	mbedtls_x509_crt_free(&tls->own_cert);
  	mbedtls_pk_free(&tls->priv_key);
  #endif
@@ -950,19 +994,28 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	while ((node = sys_slist_get(&tls->sessions)) != NULL) {
  		struct tls_session_context *session_ctx =
-@@ -633,11 +957,41 @@ static int tls_release(struct tls_context *tls)
+ 			SYS_SLIST_CONTAINER(node, session_ctx, node);
+ 
++		/* tls_session_free() sends the close-notify, and on DTLS that
++		 * reaches dtls_wolf_tx(), which dereferences active_session.
++		 * Keep it pointing at the session being torn down so it never
++		 * follows a block already returned to the slab.
++		 */
++		tls->active_session = session_ctx;
++
  		tls_session_free(session_ctx);
  	}
  
++	tls->active_session = NULL;
++
 +#if defined(CONFIG_WOLFSSL)
 +	/* Free the CTX only after all sessions referencing it are gone.
 +	 *
-+	 * Detach the pointer under context_lock: the global session-cache
-+	 * purge (tls_opt_session_cache_purge_set) walks tls_contexts under
-+	 * that lock and may call into another socket's CTX. Detaching under
-+	 * the same lock guarantees the purge either sees a valid CTX (and
-+	 * finishes with it before this release proceeds) or sees NULL. The
-+	 * free itself happens outside the lock.
++	 * Detach the pointer under context_lock so that tls->ctx is only ever
++	 * mutated under that lock: any cross-context reader then sees either a
++	 * valid CTX or NULL, never a pointer being freed. tls_wolfssl_init()'s
++	 * error path follows the same rule. The free itself happens outside
++	 * the lock.
 +	 */
 +	{
 +		WOLFSSL_CTX *wolf_ctx;
@@ -992,7 +1045,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static bool peer_addr_cmp(const struct net_sockaddr *addr,
  			  const struct net_sockaddr *peer_addr)
  {
-@@ -661,7 +1015,9 @@ static bool peer_addr_cmp(const struct net_sockaddr *addr,
+@@ -661,7 +1063,9 @@ static bool peer_addr_cmp(const struct net_sockaddr *addr,
  
  	return false;
  }
@@ -1002,7 +1055,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static int tls_session_save(const struct net_sockaddr *peer_addr,
  			    mbedtls_ssl_session *session)
  {
-@@ -830,6 +1186,230 @@ static void tls_session_purge(void)
+@@ -830,6 +1234,248 @@ static void tls_session_purge(void)
  	mbedtls_ssl_cache_init(&server_cache);
  #endif
  }
@@ -1030,9 +1083,13 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +				break;
 +			}
 +
++			/* No free slot and no peer match yet: keep the
++			 * least-recently-used (oldest, i.e. smallest timestamp)
++			 * used slot as the eviction candidate.
++			 */
 +			if (entry == NULL ||
 +			    (entry->session != NULL &&
-+			     entry->timestamp < client_cache[i].timestamp)) {
++			     entry->timestamp > client_cache[i].timestamp)) {
 +				entry = &client_cache[i];
 +			}
 +		}
@@ -1043,6 +1100,8 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
 +
 +	if (entry->session != NULL) {
++		/* Evicted blob holds session secret material; scrub it. */
++		wc_ForceZero(entry->session, entry->session_len);
 +		XFREE(entry->session, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +		entry->session = NULL;
 +		entry->session_len = 0;
@@ -1070,6 +1129,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	struct tls_session_cache *entry;
 +	struct net_sockaddr_storage peer_addr = { 0 };
 +	unsigned char *serialized = NULL;
++	size_t alloc_len = 0;
 +	int size;
 +
 +	if (!context->options.cache_enabled ||
@@ -1096,7 +1156,9 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		goto exit;
 +	}
 +
-+	serialized = XMALLOC((size_t)size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	alloc_len = (size_t)size;
++
++	serialized = XMALLOC(alloc_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +	if (serialized == NULL) {
 +		NET_ERR("Failed to allocate session buffer.");
 +		goto exit;
@@ -1129,6 +1191,11 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +exit:
 +	if (serialized != NULL) {
++		/* Holds session secrets on the reserve-failure path, and a
++		 * partial serialization when i2d itself failed. Scrub the whole
++		 * allocation: the sizing query bounds whatever i2d wrote.
++		 */
++		wc_ForceZero(serialized, alloc_len);
 +		XFREE(serialized, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +	}
 +	wolfSSL_SESSION_free(session);
@@ -1201,6 +1268,8 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			if (client_cache[i].session != NULL &&
 +			    peer_addr_cmp(net_sad(&client_cache[i].peer_addr),
 +					  net_sad(&peer_addr))) {
++				wc_ForceZero(client_cache[i].session,
++					     client_cache[i].session_len);
 +				XFREE(client_cache[i].session, NULL,
 +				      DYNAMIC_TYPE_TMP_BUFFER);
 +				client_cache[i].session = NULL;
@@ -1209,6 +1278,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			}
 +		}
 +		k_mutex_unlock(&client_cache_lock);
++		wc_ForceZero(serialized_copy, serialized_len);
 +		XFREE(serialized_copy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +		return;
 +	}
@@ -1219,6 +1289,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
 +
 +	wolfSSL_SESSION_free(session);
++	wc_ForceZero(serialized_copy, serialized_len);
 +	XFREE(serialized_copy, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 +#endif /* HAVE_EXT_CACHE */
 +}
@@ -1233,7 +1304,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  static inline int time_left(uint32_t start, uint32_t timeout)
  {
-@@ -876,11 +1456,11 @@ static int wait(int sock, int timeout, int event)
+@@ -876,11 +1522,11 @@ static int wait(int sock, int timeout, int event)
  
  static int wait_for_reason(int sock, int timeout, int reason)
  {
@@ -1247,7 +1318,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  		return wait(sock, timeout, ZSOCK_POLLOUT);
  	}
  
-@@ -949,12 +1529,13 @@ static void dtls_peer_address_get(struct tls_session_context *session_ctx,
+@@ -949,12 +1595,13 @@ static void dtls_peer_address_get(struct tls_session_context *session_ctx,
  	*addrlen = len;
  }
  
@@ -1263,7 +1334,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  		dtls_server_refresh_session_timeout(tls_ctx->active_session);
  	}
  
-@@ -963,21 +1544,20 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
+@@ -963,21 +1610,20 @@ static int dtls_tx(void *ctx, const unsigned char *buf, size_t len)
  			    tls_ctx->active_session->dtls_peer_addrlen);
  	if (sent < 0) {
  		if (errno == EAGAIN) {
@@ -1288,22 +1359,21 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	ssize_t received;
  	uint8_t tmp_buf;
  
-@@ -987,11 +1567,26 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
+@@ -987,7 +1633,157 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
  				  net_sad(&addr), &addrlen);
  	if (received < 0) {
  		if (errno == EAGAIN) {
 -			return MBEDTLS_ERR_SSL_WANT_READ;
 +			return WOLFSSL_CBIO_ERR_WANT_READ;
- 		}
- 
- 		NET_ERR("DTLS server RX: failure %d", errno);
--		return MBEDTLS_ERR_NET_RECV_FAILED;
++		}
++
++		NET_ERR("DTLS server RX: failure %d", errno);
 +		return WOLFSSL_CBIO_ERR_GENERAL;
 +	}
 +
 +	if (received == 0) {
-+		/* Empty datagram (or local read-shutdown). Consume it here —
-+		 * before the peer-address check — so a spoofed zero-length
++		/* Empty datagram (or local read-shutdown). Consume it here -
++		 * before the peer-address check - so a spoofed zero-length
 +		 * packet can neither wedge the queue head nor drive session
 +		 * switching/allocation. Then signal EOF if the local read side
 +		 * was shut down (recv_eof), otherwise drop it: empty datagrams
@@ -1314,47 +1384,42 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +				     ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
 +		return tls_ctx->recv_eof ? WOLFSSL_CBIO_ERR_CONN_CLOSE
 +					 : WOLFSSL_CBIO_ERR_WANT_READ;
- 	}
- 
- 	/* Check if the peer address matches the current session. */
-@@ -1000,7 +1595,7 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
- 		/* Peer address does not match the current session, exit now
- 		 * and try to find the appropriate session or allocate a new one.
- 		 */
--		return MBEDTLS_ERR_SSL_WANT_READ;
++	}
++
++	/* Check if the peer address matches the current session. */
++	if (tls_ctx->active_session->dtls_peer_addrlen != 0 &&
++	    !dtls_is_peer_addr_valid(tls_ctx->active_session, net_sad(&addr), addrlen)) {
++		/* Peer address does not match the current session, exit now
++		 * and try to find the appropriate session or allocate a new one.
++		 */
 +		return WOLFSSL_CBIO_ERR_WANT_READ;
- 	}
- 
- 	/* If the session matches, read the actual packet. */
-@@ -1008,7 +1603,18 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
- 				  ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
- 	if (received < 0) {
- 		NET_ERR("DTLS server RX: failure %d", errno);
--		return MBEDTLS_ERR_NET_RECV_FAILED;
++	}
++
++	/* If the session matches, read the actual packet. */
++	received = zsock_recvfrom(tls_ctx->sock, buf, len,
++				  ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
++	if (received < 0) {
++		NET_ERR("DTLS server RX: failure %d", errno);
 +		return WOLFSSL_CBIO_ERR_GENERAL;
 +	}
 +
 +	if (received == 0) {
 +		/* Defensive fallback: empty datagrams are normally consumed by
 +		 * the peek branch above, but a fresh one can race in between the
-+		 * peek and this read. Same handling — EOF on local read-shutdown
++		 * peek and this read. Same handling - EOF on local read-shutdown
 +		 * (recv_eof), otherwise drop the spoofable empty datagram
 +		 * (WANT_READ) without refreshing the session timeout.
 +		 */
 +		return tls_ctx->recv_eof ? WOLFSSL_CBIO_ERR_CONN_CLOSE
 +					 : WOLFSSL_CBIO_ERR_WANT_READ;
- 	}
- 
- 	dtls_server_refresh_session_timeout(tls_ctx->active_session);
-@@ -1017,11 +1623,135 @@ static int dtls_server_rx(void *ctx, unsigned char *buf, size_t len)
- 	if (tls_ctx->active_session->dtls_peer_addrlen == 0) {
- 		dtls_peer_address_set(tls_ctx->active_session, net_sad(&addr), addrlen);
- 
--		err = mbedtls_ssl_set_client_transport_id(&tls_ctx->active_session->ssl,
--							 (const unsigned char *)&addr,
--							 addrlen);
--		if (err < 0) {
--			return err;
++	}
++
++	dtls_server_refresh_session_timeout(tls_ctx->active_session);
++
++	/* Only allow to store peer address for DTLS servers. */
++	if (tls_ctx->active_session->dtls_peer_addrlen == 0) {
++		dtls_peer_address_set(tls_ctx->active_session, net_sad(&addr), addrlen);
++
 +		if (wolfSSL_dtls_set_peer(ssl, (void *)&addr,
 +				(unsigned int)addrlen) != WOLFSSL_SUCCESS) {
 +			/* Roll back stored peer so retry doesn't
@@ -1386,9 +1451,9 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
 +
 +	if (received == 0) {
-+		/* Local read shutdown (recv_eof) → EOF; an empty UDP
++		/* Local read shutdown (recv_eof) -> EOF; an empty UDP
 +		 * datagram from the network (spoofable, carries no TLS
-+		 * record) → drop and keep the session.
++		 * record) -> drop and keep the session.
 +		 */
 +		return tls_ctx->recv_eof ? WOLFSSL_CBIO_ERR_CONN_CLOSE
 +					 : WOLFSSL_CBIO_ERR_WANT_READ;
@@ -1450,44 +1515,10 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	if (received < 0) {
 +		if (errno == EAGAIN) {
 +			return MBEDTLS_ERR_SSL_WANT_READ;
-+		}
-+
-+		NET_ERR("DTLS server RX: failure %d", errno);
-+		return MBEDTLS_ERR_NET_RECV_FAILED;
-+	}
-+
-+	/* Check if the peer address matches the current session. */
-+	if (tls_ctx->active_session->dtls_peer_addrlen != 0 &&
-+	    !dtls_is_peer_addr_valid(tls_ctx->active_session, net_sad(&addr), addrlen)) {
-+		/* Peer address does not match the current session, exit now
-+		 * and try to find the appropriate session or allocate a new one.
-+		 */
-+		return MBEDTLS_ERR_SSL_WANT_READ;
-+	}
-+
-+	/* If the session matches, read the actual packet. */
-+	received = zsock_recvfrom(tls_ctx->sock, buf, len,
-+				  ZSOCK_MSG_DONTWAIT, net_sad(&addr), &addrlen);
-+	if (received < 0) {
-+		NET_ERR("DTLS server RX: failure %d", errno);
-+		return MBEDTLS_ERR_NET_RECV_FAILED;
-+	}
-+
-+	dtls_server_refresh_session_timeout(tls_ctx->active_session);
-+
-+	/* Only allow to store peer address for DTLS servers. */
-+	if (tls_ctx->active_session->dtls_peer_addrlen == 0) {
-+		dtls_peer_address_set(tls_ctx->active_session, net_sad(&addr), addrlen);
-+
-+		err = mbedtls_ssl_set_client_transport_id(&tls_ctx->active_session->ssl,
-+							 (const unsigned char *)&addr,
-+							 addrlen);
-+		if (err < 0) {
-+			return err;
  		}
- 	}
  
-@@ -1059,9 +1789,16 @@ static int dtls_client_rx(void *ctx, unsigned char *buf, size_t len)
+ 		NET_ERR("DTLS server RX: failure %d", errno);
+@@ -1059,9 +1855,16 @@ static int dtls_client_rx(void *ctx, unsigned char *buf, size_t len)
  
  	return received;
  }
@@ -1504,7 +1535,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  /* Returns
   * - 0 when session was switched,
-@@ -1106,6 +1843,21 @@ static int dtls_server_new_active_session(struct tls_context *tls_ctx,
+@@ -1106,6 +1909,21 @@ static int dtls_server_new_active_session(struct tls_context *tls_ctx,
  		return -ENOMEM;
  	}
  
@@ -1526,7 +1557,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	ret = tls_mbedtls_session_init(session_ctx, tls_ctx, true);
  	if (ret < 0) {
  		tls_session_free(session_ctx);
-@@ -1128,6 +1880,7 @@ static int dtls_server_new_active_session(struct tls_context *tls_ctx,
+@@ -1128,6 +1946,7 @@ static int dtls_server_new_active_session(struct tls_context *tls_ctx,
  					 tls_ctx->active_session->ssl.hostname);
  	}
  #endif
@@ -1534,7 +1565,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	sys_slist_append(&tls_ctx->sessions, &session_ctx->node);
  	tls_ctx->active_session = session_ctx;
-@@ -1274,7 +2027,11 @@ static int dtls_server_free_active_session(struct tls_context *tls_ctx)
+@@ -1274,7 +2093,11 @@ static int dtls_server_free_active_session(struct tls_context *tls_ctx)
  						      session_ctx, node);
  	} else {
  		/* Last session, just reset it. */
@@ -1546,7 +1577,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	}
  
  	tls_ctx->error = 0;
-@@ -1290,7 +2047,14 @@ static bool dtls_server_check_expired_sessions(struct tls_context *tls_ctx)
+@@ -1290,7 +2113,14 @@ static bool dtls_server_check_expired_sessions(struct tls_context *tls_ctx)
  	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&tls_ctx->sessions, session_ctx, next, node) {
  		if (sys_timepoint_expired(session_ctx->session_expiry)) {
  			tls_ctx->active_session = session_ctx;
@@ -1561,7 +1592,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  			(void)dtls_server_free_active_session(tls_ctx);
  			expired = true;
  		}
-@@ -1300,6 +2064,7 @@ static bool dtls_server_check_expired_sessions(struct tls_context *tls_ctx)
+@@ -1300,6 +2130,7 @@ static bool dtls_server_check_expired_sessions(struct tls_context *tls_ctx)
  }
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
  
@@ -1569,7 +1600,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static int tls_tx(void *ctx, const unsigned char *buf, size_t len)
  {
  	struct tls_context *tls_ctx = ctx;
-@@ -1335,6 +2100,85 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
+@@ -1335,6 +2166,89 @@ static int tls_rx(void *ctx, unsigned char *buf, size_t len)
  
  	return received;
  }
@@ -1613,6 +1644,10 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	if (received < 0) {
 +		switch (errno) {
 +		case EAGAIN:
++			/* This callback is wired only for NET_SOCK_STREAM
++			 * sessions (DTLS uses dtls_wolf_*_rx), so wolfSSL_dtls()
++			 * is always false here; the DTLS arm is defensive.
++			 */
 +			if (!wolfSSL_dtls(ssl)) {
 +				return WOLFSSL_CBIO_ERR_WANT_READ;
 +			} else {
@@ -1655,7 +1690,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  #if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
  static bool crt_is_pem(const unsigned char *buf, size_t buflen)
-@@ -1347,7 +2191,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
+@@ -1347,7 +2261,24 @@ static bool crt_is_pem(const unsigned char *buf, size_t buflen)
  static int tls_add_ca_certificate(struct tls_context *tls,
  				  struct tls_credential *ca_cert)
  {
@@ -1681,7 +1716,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	int err;
  
  	if (tls->options.cert_nocopy == ZSOCK_TLS_CERT_NOCOPY_NONE ||
-@@ -1371,6 +2232,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
+@@ -1371,6 +2302,7 @@ static int tls_add_ca_certificate(struct tls_context *tls,
  	return -ENOTSUP;
  }
  
@@ -1689,7 +1724,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static void tls_set_ca_chain(struct tls_context *tls)
  {
  #if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
-@@ -1379,11 +2241,27 @@ static void tls_set_ca_chain(struct tls_context *tls)
+@@ -1379,11 +2311,34 @@ static void tls_set_ca_chain(struct tls_context *tls)
  				      &mbedtls_x509_crt_profile_default);
  #endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
  }
@@ -1706,8 +1741,15 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	if (crt_is_pem(own_cert->buf, own_cert->len)) {
 +		format = WOLFSSL_FILETYPE_PEM;
 +	}
-+	ret = wolfSSL_CTX_use_certificate_buffer(tls->ctx, own_cert->buf,
-+						 own_cert->len, format);
++	/* Chain variant, not the single-certificate one: applications ship the
++	 * leaf and its intermediates as one concatenated credential, and
++	 * mbedtls_x509_crt_parse() on the other backend loads all of them.
++	 * Loading only the leaf sends an incomplete chain to the peer.
++	 */
++	ret = wolfSSL_CTX_use_certificate_chain_buffer_format(tls->ctx,
++							      own_cert->buf,
++							      own_cert->len,
++							      format);
 +	if (ret != WOLFSSL_SUCCESS) {
 +		NET_ERR("Failed to parse certificate");
 +		return -EINVAL;
@@ -1718,7 +1760,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	int err;
  
  	if (tls->options.cert_nocopy == ZSOCK_TLS_CERT_NOCOPY_NONE ||
-@@ -1406,6 +2284,7 @@ static int tls_add_own_cert(struct tls_context *tls,
+@@ -1406,6 +2361,7 @@ static int tls_add_own_cert(struct tls_context *tls,
  	return -ENOTSUP;
  }
  
@@ -1726,7 +1768,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static int tls_set_own_cert(struct tls_context *tls)
  {
  #if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
-@@ -1420,11 +2299,27 @@ static int tls_set_own_cert(struct tls_context *tls)
+@@ -1420,11 +2376,27 @@ static int tls_set_own_cert(struct tls_context *tls)
  
  	return -ENOTSUP;
  }
@@ -1755,7 +1797,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	int err;
  
  	err = mbedtls_pk_parse_key(&tls->priv_key, priv_key->buf,
-@@ -1443,6 +2338,47 @@ static int tls_set_psk(struct tls_context *tls,
+@@ -1443,6 +2415,47 @@ static int tls_set_psk(struct tls_context *tls,
  		       struct tls_credential *psk,
  		       struct tls_credential *psk_id)
  {
@@ -1803,7 +1845,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_PSK_ENABLED)
  	int err = mbedtls_ssl_conf_psk(&tls->config,
  				       psk->buf, psk->len,
-@@ -1454,6 +2390,7 @@ static int tls_set_psk(struct tls_context *tls,
+@@ -1454,6 +2467,7 @@ static int tls_set_psk(struct tls_context *tls,
  
  	return 0;
  #endif
@@ -1811,7 +1853,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	return -ENOTSUP;
  }
-@@ -1496,6 +2433,7 @@ static int tls_set_credential(struct tls_context *tls,
+@@ -1496,6 +2510,7 @@ static int tls_set_credential(struct tls_context *tls,
  	return 0;
  }
  
@@ -1819,7 +1861,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static int tls_mbedtls_set_credentials(struct tls_context *tls)
  {
  	struct tls_credential *cred;
-@@ -1890,145 +2828,131 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
+@@ -1890,145 +2905,136 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
  
  	return 0;
  }
@@ -1864,7 +1906,12 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	}
  
 -	mbedtls_x509_crt_free(&cert_ctx);
-+	if (XSTRCMP(identity, (const char *)context->psk_id) != 0) {
++	/* TLS_CREDENTIAL_PSK_ID is length-delimited, so compare the full
++	 * registered length. XSTRCMP would stop at an embedded NUL and accept
++	 * a shorter identity that is a prefix of the registered one.
++	 */
++	if (XSTRLEN(identity) != context->psk_id_len ||
++	    XMEMCMP(identity, context->psk_id, context->psk_id_len) != 0) {
 +		return 0;
 +	}
  
@@ -1889,9 +1936,13 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
 -	mbedtls_pk_context key_ctx;
 -	int err;
--
--	mbedtls_pk_init(&key_ctx);
 +	struct tls_context *context = NULL;
+ 
+-	mbedtls_pk_init(&key_ctx);
++	context = (struct tls_context *)wolfSSL_get_psk_callback_ctx(ssl);
++	if (context == NULL) {
++		return 0;
++	}
  
 -	err = mbedtls_pk_parse_key(&key_ctx, priv_key->buf,
 -				   priv_key->len, NULL, 0);
@@ -1899,13 +1950,14 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
 -			"private key", priv_key->tag, -err);
 -		err = -EINVAL;
-+	context = (struct tls_context *)wolfSSL_get_psk_callback_ctx(ssl);
-+	if (context == NULL) {
++	if (context->psk == NULL || context->psk_id == NULL) {
 +		return 0;
  	}
  
 -	mbedtls_pk_free(&key_ctx);
-+	if (context->psk == NULL || context->psk_id == NULL) {
++	if (context->psk_len == 0 || context->psk_len > key_max_len ||
++	    context->psk_id_len == 0 ||
++	    context->psk_id_len + 1 > id_max_len) {
 +		return 0;
 +	}
  
@@ -1913,18 +1965,12 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -#else
 -	NET_ERR("TLS with certificates disabled. "
 -		"Reconfigure mbed TLS to support certificate based key exchange.");
-+	if (context->psk_len == 0 || context->psk_len > key_max_len ||
-+	    context->psk_id_len == 0 ||
-+	    context->psk_id_len + 1 > id_max_len) {
-+		return 0;
-+	}
- 
--	return -ENOTSUP;
--#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
 +	XMEMCPY(identity, context->psk_id, context->psk_id_len);
 +	identity[context->psk_id_len] = '\0';
 +	XMEMCPY(key, context->psk, context->psk_len);
-+
+ 
+-	return -ENOTSUP;
+-#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
 +	return context->psk_len;
  }
  
@@ -2050,7 +2096,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  			err = -ENOENT;
  			goto exit;
  		}
-@@ -2040,832 +2964,2213 @@ exit:
+@@ -2040,820 +3046,2280 @@ exit:
  	return err;
  }
  
@@ -2112,6 +2158,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -	ret = tls_check_credentials((const sec_tag_t *)optval, sec_tag_cnt);
 -	if (ret < 0) {
 -		return ret;
++#if defined(HAVE_SNI)
 +	if (context->options.is_hostname_set) {
 +		if (wolfSSL_UseSNI(session_ctx->wssl, WOLFSSL_SNI_HOST_NAME,
 +				   (const char *)context->host_name,
@@ -2119,10 +2166,15 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			return -EINVAL;
 +		}
  	}
++#endif /* HAVE_SNI */
  
 -	memcpy(context->options.sec_tag_list.sec_tags, optval, optlen);
 -	context->options.sec_tag_list.sec_tag_count = sec_tag_cnt;
--
++	/* Without HAVE_SNI the extension is simply not sent. The hostname is
++	 * still recorded and still drives the CN/SAN match in the verify
++	 * callback, which is what TLS_PEER_VERIFY depends on.
++	 */
+ 
  	return 0;
  }
  
@@ -2174,12 +2226,23 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	if (context->options.role != ZTLS_IS_CLIENT) {
 +		return;
 +	}
-+	/* mbedTLS parity: when no TLS_HOSTNAME is configured the CN/SAN check
-+	 * is skipped and chain validity alone governs (mirrors not calling
-+	 * mbedtls_ssl_set_hostname()). Only enforce a match when a hostname
-+	 * was actually set.
++	/* TLS_PEER_VERIFY_NONE means the application opted out of peer
++	 * verification entirely, so no name check applies. Without this the
++	 * name mismatch below would fail a handshake that OPTIONAL lets
++	 * through, making NONE stricter than OPTIONAL.
++	 */
++	if (context->options.verify_level == ZSOCK_TLS_PEER_VERIFY_NONE) {
++		return;
++	}
++	/* mbedTLS parity: a client that never set TLS_HOSTNAME gets
++	 * mbedtls_ssl_set_hostname(ssl, "") in tls_mbedtls_session_init(),
++	 * which no certificate can match, so the peer identity is rejected
++	 * rather than unchecked. Fail the same way here instead of accepting
++	 * a certificate issued for any name.
 +	 */
 +	if (!context->options.is_hostname_set || context->host_len == 0) {
++		session_ctx->verify_result_flags |= MBEDTLS_X509_BADCERT_CN_MISMATCH;
++		*effective_ok = 0;
 +		return;
 +	}
 +	if (tls_wolfssl_leaf_hostname_matches(context, store->current_cert)) {
@@ -2191,22 +2254,14 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -
 -	memcpy(optval, context->options.sec_tag_list.sec_tags, len);
 -	*optlen = len;
--
--	return 0;
 +	session_ctx->verify_result_flags |= MBEDTLS_X509_BADCERT_CN_MISMATCH;
 +	*effective_ok = 0;
- }
++}
  
--static int tls_opt_hostname_set(struct tls_context *context,
--				const void *optval, net_socklen_t optlen)
+-	return 0;
 +/* Map wolfSSL verify error to mbedTLS flag bits. */
 +static uint32_t tls_wolfssl_error_to_mbedtls_flags(int error)
- {
--	ARG_UNUSED(optlen);
--
--#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
--	if (mbedtls_ssl_set_hostname(&context->active_session->ssl, optval) != 0) {
--		return -EINVAL;
++{
 +	switch (error) {
 +	case 0:
 +		return 0;
@@ -2244,52 +2299,52 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		return MBEDTLS_X509_BADCERT_MISSING;
 +	default:
 +		return MBEDTLS_X509_BADCERT_OTHER;
- 	}
--#else
--	return -ENOPROTOOPT;
--#endif
--
--	context->options.is_hostname_set = true;
--
--	return 0;
++	}
  }
  
--static int tls_opt_ciphersuite_list_set(struct tls_context *context,
--					const void *optval, net_socklen_t optlen)
+-static int tls_opt_hostname_set(struct tls_context *context,
+-				const void *optval, net_socklen_t optlen)
 +static int tls_wolfssl_verify_accumulate_cb(int preverify_ok,
 +					     WOLFSSL_X509_STORE_CTX *store)
  {
--	int cipher_cnt;
+-	ARG_UNUSED(optlen);
 +	struct tls_session_context *session_ctx;
 +	struct tls_context *context;
 +	int effective_ok;
  
--	if (!optval) {
+-#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
+-	if (mbedtls_ssl_set_hostname(&context->active_session->ssl, optval) != 0) {
 -		return -EINVAL;
 +	if (store == NULL || store->userCtx == NULL) {
 +		return preverify_ok;
  	}
+-#else
+-	return -ENOPROTOOPT;
+-#endif
  
--	if (optlen % sizeof(int) != 0) {
--		return -EINVAL;
+-	context->options.is_hostname_set = true;
 +	session_ctx = (struct tls_session_context *)store->userCtx;
 +	context = session_ctx->tls_ctx;
 +	effective_ok = preverify_ok;
-+
+ 
+-	return 0;
+-}
 +	if (!preverify_ok && store->error != 0) {
 +		session_ctx->verify_result_flags |=
 +			tls_wolfssl_error_to_mbedtls_flags(store->error);
- 	}
++	}
  
--	cipher_cnt = optlen / sizeof(int);
+-static int tls_opt_ciphersuite_list_set(struct tls_context *context,
+-					const void *optval, net_socklen_t optlen)
+-{
+-	int cipher_cnt;
 +	tls_wolfssl_apply_leaf_hostname_check(context, session_ctx, store, &effective_ok);
  
--	/* + 1 for 0-termination. */
--	if (cipher_cnt + 1 > ARRAY_SIZE(context->options.ciphersuites)) {
+-	if (!optval) {
 -		return -EINVAL;
 +	/* OPTIONAL: return 1 so handshake continues after recording flags.
 +	 * Surface a warning when we're about to silently let an invalid
-+	 * chain through — applications that set OPTIONAL but never read
++	 * chain through - applications that set OPTIONAL but never read
 +	 * TLS_CERT_VERIFY_RESULT will otherwise accept bad certs with no
 +	 * trace. mbedTLS prints similar info at debug verbosity.
 +	 */
@@ -2303,54 +2358,41 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		return 1;
  	}
  
--	memcpy(context->options.ciphersuites, optval, optlen);
--	context->options.ciphersuites[cipher_cnt] = 0;
--
--	mbedtls_ssl_conf_ciphersuites(&context->config,
--				      context->options.ciphersuites);
--	return 0;
+-	if (optlen % sizeof(int) != 0) {
+-		return -EINVAL;
 +	return effective_ok;
- }
- 
--static int tls_opt_ciphersuite_list_get(struct tls_context *context,
--					void *optval, net_socklen_t *optlen)
++}
++
 +#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
 +static int tls_wolfssl_verify_cb_wrapper(int preverify_ok,
 +					 WOLFSSL_X509_STORE_CTX *store)
- {
--	const int *selected_ciphers;
--	int cipher_cnt, i = 0;
--	int *ciphers = optval;
++{
 +	struct tls_session_context *session_ctx;
 +	struct tls_context *context;
 +	zsock_tls_wolfssl_verify_cb_t user_cb;
 +	void *user_ctx;
 +	int effective_ok;
 +	int ret;
- 
--	if (*optlen % sizeof(int) != 0 || *optlen == 0) {
--		return -EINVAL;
++
 +	if (store == NULL || store->userCtx == NULL) {
 +		return preverify_ok;
  	}
  
--	if (context->options.ciphersuites[0] == 0) {
--		/* No specific ciphersuites configured, return all available. */
--		selected_ciphers = mbedtls_ssl_list_ciphersuites();
--	} else {
--		selected_ciphers = context->options.ciphersuites;
+-	cipher_cnt = optlen / sizeof(int);
 +	session_ctx = (struct tls_session_context *)store->userCtx;
 +	context = session_ctx->tls_ctx;
 +	effective_ok = preverify_ok;
-+
+ 
+-	/* + 1 for 0-termination. */
+-	if (cipher_cnt + 1 > ARRAY_SIZE(context->options.ciphersuites)) {
+-		return -EINVAL;
 +	if (!preverify_ok && store->error != 0) {
 +		session_ctx->verify_result_flags |=
 +			tls_wolfssl_error_to_mbedtls_flags(store->error);
  	}
  
--	cipher_cnt = *optlen / sizeof(int);
--	while (selected_ciphers[i] != 0) {
--		ciphers[i] = selected_ciphers[i];
+-	memcpy(context->options.ciphersuites, optval, optlen);
+-	context->options.ciphersuites[cipher_cnt] = 0;
 +	/* Mirror the accumulator's leaf hostname match so the application's
 +	 * verify callback sees a consistent preverify_ok regardless of
 +	 * whether it overrides the default accumulator.
@@ -2375,17 +2417,26 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	ret = user_cb(effective_ok, store);
 +	store->userCtx = session_ctx;
  
--		if (++i == cipher_cnt) {
+-	mbedtls_ssl_conf_ciphersuites(&context->config,
+-				      context->options.ciphersuites);
+-	return 0;
 +	return ret;
-+}
+ }
 +#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
-+
+ 
+-static int tls_opt_ciphersuite_list_get(struct tls_context *context,
+-					void *optval, net_socklen_t *optlen)
 +static int tls_wolfssl_set_verify(struct tls_context *context,
 +				  struct tls_session_context *session_ctx)
-+{
+ {
+-	const int *selected_ciphers;
+-	int cipher_cnt, i = 0;
+-	int *ciphers = optval;
 +	int verifyLevel = -1;
 +	VerifyCallback cb = NULL;
-+
+ 
+-	if (*optlen % sizeof(int) != 0 || *optlen == 0) {
+-		return -EINVAL;
 +	if (context->options.verify_level != -1) {
 +		switch (context->options.verify_level) {
 +		case ZSOCK_TLS_PEER_VERIFY_NONE:
@@ -2402,42 +2453,38 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			} else {
 +				verifyLevel = WOLFSSL_VERIFY_PEER;
 +			}
- 			break;
++			break;
 +		default:
 +			return -EINVAL;
- 		}
++		}
  	}
  
--	*optlen = i * sizeof(int);
-+	session_ctx->verify_result_flags = 0;
- 
--	return 0;
--}
+-	if (context->options.ciphersuites[0] == 0) {
+-		/* No specific ciphersuites configured, return all available. */
+-		selected_ciphers = mbedtls_ssl_list_ciphersuites();
 +	/* SetCertCbCtx plants the session so the chosen callback records flags
 +	 * on exactly the session being verified and reaches the context via
 +	 * session_ctx->tls_ctx.
 +	 */
 +	wolfSSL_SetCertCbCtx(session_ctx->wssl, session_ctx);
- 
--static struct tls_session_context *get_latest_session(struct tls_context *context)
--{
--	struct tls_session_context *session_ctx = NULL;
--	struct tls_session_context *latest_session_ctx = NULL;
++
 +#if defined(CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK)
 +	if (context->options.cert_verify_wolfssl.cb != NULL) {
 +		cb = tls_wolfssl_verify_cb_wrapper;
-+	} else {
+ 	} else {
+-		selected_ciphers = context->options.ciphersuites;
 +		cb = tls_wolfssl_verify_accumulate_cb;
-+	}
+ 	}
 +#else
 +	cb = tls_wolfssl_verify_accumulate_cb;
 +#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
  
--	SYS_SLIST_FOR_EACH_CONTAINER(&context->sessions, session_ctx, node) {
--		if ((latest_session_ctx == NULL) ||
--		    (session_ctx->handshake_timestamp >
--		     latest_session_ctx->handshake_timestamp)) {
--			latest_session_ctx = session_ctx;
+-	cipher_cnt = *optlen / sizeof(int);
+-	while (selected_ciphers[i] != 0) {
+-		ciphers[i] = selected_ciphers[i];
+-
+-		if (++i == cipher_cnt) {
+-			break;
 +	if (verifyLevel != -1 || cb != NULL) {
 +		if (verifyLevel == -1) {
 +			/* Match mbedTLS defaults: required for clients,
@@ -2452,62 +2499,76 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		wolfSSL_set_verify(session_ctx->wssl, verifyLevel, cb);
  	}
  
--	return latest_session_ctx;
-+	return 0;
+-	*optlen = i * sizeof(int);
+-
+ 	return 0;
  }
  
--static int tls_opt_ciphersuite_used_get(struct tls_context *context,
--					void *optval, net_socklen_t *optlen)
+-static struct tls_session_context *get_latest_session(struct tls_context *context)
 +static int tls_wolfssl_set_ciphersuites(struct tls_context *context,
 +					struct tls_session_context *session_ctx)
  {
--	struct tls_session_context *session_ctx;
--	const char *ciph;
+-	struct tls_session_context *session_ctx = NULL;
+-	struct tls_session_context *latest_session_ctx = NULL;
 +	/* mbedtls-style IDs are 16-bit but stored in int[]; pack each as a
 +	 * big-endian 2-byte pair for wolfSSL_set_cipher_list_bytes.
 +	 */
 +	byte cs_bytes[CONFIG_NET_SOCKETS_TLS_MAX_CIPHERSUITES * 2];
 +	int cipher_cnt = 0;
  
--	if (*optlen != sizeof(int)) {
--		return -EINVAL;
+-	SYS_SLIST_FOR_EACH_CONTAINER(&context->sessions, session_ctx, node) {
+-		if ((latest_session_ctx == NULL) ||
+-		    (session_ctx->handshake_timestamp >
+-		     latest_session_ctx->handshake_timestamp)) {
+-			latest_session_ctx = session_ctx;
+-		}
 +	/* Nothing to set */
 +	if (context->options.ciphersuites[0] == 0) {
 +		return 0;
  	}
  
--	session_ctx = get_latest_session(context);
--	if (session_ctx == NULL) {
--		return -ENOTCONN;
--	}
+-	return latest_session_ctx;
+-}
 +	for (int i = 0; context->options.ciphersuites[i] != 0; i++) {
 +		int id = context->options.ciphersuites[i];
  
--	ciph = mbedtls_ssl_get_ciphersuite(&session_ctx->ssl);
--	if (ciph == NULL) {
--		return -ENOTCONN;
+-static int tls_opt_ciphersuite_used_get(struct tls_context *context,
+-					void *optval, net_socklen_t *optlen)
+-{
+-	struct tls_session_context *session_ctx;
+-	const char *ciph;
 +		/* Defensive bound: never write past cs_bytes even if the stored
 +		 * list is somehow not terminated within MAX_CIPHERSUITES.
 +		 */
 +		if (cipher_cnt >= CONFIG_NET_SOCKETS_TLS_MAX_CIPHERSUITES) {
 +			return -EINVAL;
 +		}
-+
+ 
+-	if (*optlen != sizeof(int)) {
+-		return -EINVAL;
+-	}
 +		/* All ciphersuite IDs fit in 16 bits */
 +		if (id < 0 || id > 0xFFFF) {
 +			return -EINVAL;
 +		}
-+
+ 
+-	session_ctx = get_latest_session(context);
+-	if (session_ctx == NULL) {
+-		return -ENOTCONN;
 +		sys_put_be16((uint16_t)id, &cs_bytes[cipher_cnt * 2]);
 +		cipher_cnt++;
  	}
  
--	*(int *)optval = mbedtls_ssl_get_ciphersuite_id(ciph);
+-	ciph = mbedtls_ssl_get_ciphersuite(&session_ctx->ssl);
+-	if (ciph == NULL) {
+-		return -ENOTCONN;
 +	if (wolfSSL_set_cipher_list_bytes(session_ctx->wssl, cs_bytes,
 +					  cipher_cnt * 2) != WOLFSSL_SUCCESS) {
 +		return -EINVAL;
-+	}
+ 	}
  
+-	*(int *)optval = mbedtls_ssl_get_ciphersuite_id(ciph);
+-
  	return 0;
  }
  
@@ -2583,21 +2644,41 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -static int tls_opt_dtls_handshake_timeout_get(struct tls_context *context,
 -					      void *optval, net_socklen_t *optlen,
 -					      bool is_max)
+-{
+-	uint32_t *val = (uint32_t *)optval;
 +static int tls_wolfssl_set_dtls_timeouts(struct tls_context *context,
 +					 struct tls_session_context *session_ctx)
- {
--	uint32_t *val = (uint32_t *)optval;
--
++{
++	if (context->type == NET_SOCK_DGRAM) {
++		int init_s;
++		int max_s;
++
++		/* wolfSSL's DTLS retransmit timeout API takes whole seconds, but
++		 * dtls_handshake_timeout_min/max are stored in milliseconds (the
++		 * socket-option and mbedTLS-shared unit, and what the getter
++		 * converts back with * MSEC_PER_SEC). Convert here, rounding up so
++		 * a sub-second value never collapses to 0, and keep init <= max.
++		 */
++		init_s = (int)((context->options.dtls_handshake_timeout_min +
++				MSEC_PER_SEC - 1) / MSEC_PER_SEC);
++		if (init_s < 1) {
++			init_s = 1;
++		}
++		max_s = (int)((context->options.dtls_handshake_timeout_max +
++			       MSEC_PER_SEC - 1) / MSEC_PER_SEC);
++		if (max_s < init_s) {
++			max_s = init_s;
++		}
+ 
 -	if (sizeof(uint32_t) != *optlen) {
 -		return -EINVAL;
 -	}
-+	if (context->type == NET_SOCK_DGRAM) {
-+		if (wolfSSL_dtls_set_timeout_max(session_ctx->wssl,
-+				(int)context->options.dtls_handshake_timeout_max) != WOLFSSL_SUCCESS) {
++		if (wolfSSL_dtls_set_timeout_max(session_ctx->wssl, max_s)
++				!= WOLFSSL_SUCCESS) {
 +			return -EINVAL;
 +		}
-+		if (wolfSSL_dtls_set_timeout_init(session_ctx->wssl,
-+				(int)context->options.dtls_handshake_timeout_min) != WOLFSSL_SUCCESS) {
++		if (wolfSSL_dtls_set_timeout_init(session_ctx->wssl, init_s)
++				!= WOLFSSL_SUCCESS) {
 +			return -EINVAL;
 +		}
  
@@ -2626,7 +2707,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 + * Always returns 0: the authoritative effect of the setsockopt is the
 + * stored option (which every future session applies); pushing it into
 + * already-live sessions is best effort. Failing the call midway would
-+ * leave the stored option and the session states inconsistent — e.g. a
++ * leave the stored option and the session states inconsistent - e.g. a
 + * session whose handshake already completed may legitimately refuse a
 + * late SNI/ciphersuite update. Argument validation must therefore happen
 + * in the option handler before the option is stored, not in the setter.
@@ -2680,7 +2761,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -static int tls_opt_dtls_connection_id_set(struct tls_context *context,
 -					  const void *optval, net_socklen_t optlen)
 +/* Apply all per-SSL-object settings. Runs both on first session init and
-+ * again after wolfSSL_clear() in tls_wolfssl_reset_session — wolfSSL_clear
++ * again after wolfSSL_clear() in tls_wolfssl_reset_session - wolfSSL_clear
 + * drops per-SSL state configured after wolfSSL_new().
 + */
 +static int tls_wolfssl_session_setup(struct tls_session_context *session_ctx,
@@ -2691,20 +2772,37 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	int ret;
  
 -	if (optlen > 0 && optval == NULL) {
--		return -EINVAL;
--	}
 +	/* Record the owning context so the verify callbacks (planted below in
 +	 * tls_wolfssl_set_verify) can reach it for the exact session.
 +	 */
 +	session_ctx->tls_ctx = tls_ctx;
- 
--	if (optlen != sizeof(int)) {
++
 +	if (wolfSSL_set_fd(session_ctx->wssl, tls_ctx->sock) != WOLFSSL_SUCCESS) {
  		return -EINVAL;
  	}
  
+-	if (optlen != sizeof(int)) {
++	if (tls_ctx->type == NET_SOCK_STREAM) {
++		wolfSSL_SSLSetIORecv(session_ctx->wssl, tls_wolf_rx);
++		wolfSSL_SSLSetIOSend(session_ctx->wssl, tls_wolf_tx);
++	}
++#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
++	else if (tls_ctx->type == NET_SOCK_DGRAM) {
++		wolfSSL_SSLSetIORecv(session_ctx->wssl,
++				     is_server ? dtls_wolf_server_rx :
++						 dtls_wolf_client_rx);
++		wolfSSL_SSLSetIOSend(session_ctx->wssl, dtls_wolf_tx);
++	}
++#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
++	else {
+ 		return -EINVAL;
+ 	}
+ 
 -	value = *((int *)optval);
--
++	/* Set our TLS context as the read/write context since it contains the socket */
++	wolfSSL_SetIOReadCtx(session_ctx->wssl, (void *)tls_ctx);
++	wolfSSL_SetIOWriteCtx(session_ctx->wssl, (void *)tls_ctx);
+ 
 -	switch (value) {
 -	case ZSOCK_TLS_DTLS_CID_DISABLED:
 -		context->options.dtls_cid.enabled = false;
@@ -2729,30 +2827,19 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -		}
 -		break;
 -	default:
-+	if (tls_ctx->type == NET_SOCK_STREAM) {
-+		wolfSSL_SSLSetIORecv(session_ctx->wssl, tls_wolf_rx);
-+		wolfSSL_SSLSetIOSend(session_ctx->wssl, tls_wolf_tx);
-+	}
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-+	else if (tls_ctx->type == NET_SOCK_DGRAM) {
-+		wolfSSL_SSLSetIORecv(session_ctx->wssl,
-+				     is_server ? dtls_wolf_server_rx :
-+						 dtls_wolf_client_rx);
-+		wolfSSL_SSLSetIOSend(session_ctx->wssl, dtls_wolf_tx);
-+	}
-+#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
-+	else {
- 		return -EINVAL;
+-		return -EINVAL;
++#ifndef NO_PSK
++	if (NULL != tls_ctx->psk) {
++		wolfSSL_set_psk_callback_ctx(session_ctx->wssl, (void *)tls_ctx);
  	}
++#endif /* !NO_PSK */
  
 -	return 0;
 -#else
 -	return -ENOPROTOOPT;
 -#endif /* CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID */
 -}
-+	/* Set our TLS context as the read/write context since it contains the socket */
-+	wolfSSL_SetIOReadCtx(session_ctx->wssl, (void *)tls_ctx);
-+	wolfSSL_SetIOWriteCtx(session_ctx->wssl, (void *)tls_ctx);
++	session_ctx->verify_result_flags = 0;
  
 -static int tls_opt_dtls_connection_id_value_set(struct tls_context *context,
 -						const void *optval,
@@ -2761,26 +2848,21 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -#if defined(CONFIG_MBEDTLS_SSL_DTLS_CONNECTION_ID)
 -	if (optlen > 0 && optval == NULL) {
 -		return -EINVAL;
-+#ifndef NO_PSK
-+	if (NULL != tls_ctx->psk) {
-+		wolfSSL_set_psk_callback_ctx(session_ctx->wssl, (void *)tls_ctx);
++	ret = tls_wolfssl_set_verify(tls_ctx, session_ctx);
++	if (ret != 0) {
++		return ret;
  	}
-+#endif /* !NO_PSK */
  
 -	if (optlen > MBEDTLS_SSL_CID_IN_LEN_MAX) {
 -		return -EINVAL;
-+	ret = tls_wolfssl_set_verify(tls_ctx, session_ctx);
++	ret = tls_wolfssl_set_hostname(tls_ctx, session_ctx);
 +	if (ret != 0) {
 +		return ret;
  	}
  
 -	context->options.dtls_cid.cid_len = optlen;
 -	memcpy(context->options.dtls_cid.cid, optval, optlen);
-+	ret = tls_wolfssl_set_hostname(tls_ctx, session_ctx);
-+	if (ret != 0) {
-+		return ret;
-+	}
- 
+-
 -	return 0;
 -#else
 -	return -ENOPROTOOPT;
@@ -2913,7 +2995,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -	if (session_ctx == NULL) {
 -		return -ENOTCONN;
 +		/* wolfSSL_clear drops per-SSL settings configured after
-+		 * wolfSSL_new — re-apply them.
++		 * wolfSSL_new - re-apply them.
 +		 */
 +		ret = tls_wolfssl_session_setup(session_ctx, context, is_server);
 +		if (ret != 0) {
@@ -3079,7 +3161,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			/* wait_for_reason() returns 0 both when the socket
 +			 * became ready and when the poll timed out. Only
 +			 * report a timeout to wolfSSL when the DTLS
-+			 * retransmission timer elapsed — calling
++			 * retransmission timer elapsed - calling
 +			 * wolfSSL_dtls_got_timeout() on an early data-ready
 +			 * wakeup would needlessly retransmit the flight and
 +			 * double wolfSSL's internal timer. Residual: if data
@@ -3139,18 +3221,13 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
  
 -	return 0;
--}
 +	context->active_session->handshake_in_progress = false;
++
++	return ret;
+ }
  
 -static int tls_opt_session_cache_set(struct tls_context *context,
 -				     const void *optval, net_socklen_t optlen)
--{
--	int *val = (int *)optval;
-+	return ret;
-+}
- 
--	if (!optval) {
--		return -EINVAL;
 +static WOLFSSL_METHOD *tls_wolfssl_get_method(struct tls_context *context,
 +					      bool is_server)
 +{
@@ -3173,10 +3250,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		default:
 +			return NULL;
 +		}
- 	}
--
--	if (sizeof(int) != optlen) {
--		return -EINVAL;
++	}
 +#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS) && defined(WOLFSSL_DTLS)
 +	else if (context->type == NET_SOCK_DGRAM) {
 +		switch (context->tls_version) {
@@ -3192,48 +3266,60 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			 */
 +			return NULL;
 +		}
- 	}
--
--	context->options.cache_enabled = (*val == ZSOCK_TLS_SESSION_CACHE_ENABLED);
--
--	return 0;
++	}
 +#endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS && WOLFSSL_DTLS */
 +	return NULL;
- }
- 
--static int tls_opt_session_cache_get(struct tls_context *context,
--				     void *optval, net_socklen_t *optlen)
++}
++
 +static int tls_wolfssl_init(struct tls_context *context, bool is_server)
  {
--	int cache_enabled = context->options.cache_enabled ?
--			    ZSOCK_TLS_SESSION_CACHE_ENABLED :
--			    ZSOCK_TLS_SESSION_CACHE_DISABLED;
+-	int *val = (int *)optval;
 +	WOLFSSL_METHOD *method;
 +	int ret;
  
--	if (*optlen != sizeof(cache_enabled)) {
+-	if (!optval) {
+-		return -EINVAL;
++	/* Do not clobber an explicitly configured TLS_DTLS_ROLE: connect() on a
++	 * DTLS socket would otherwise demote a socket the application set up as
++	 * a server, and options.role drives verify level, BIO callbacks and the
++	 * session-reset path.
++	 */
++	if (!context->role_set) {
++		context->options.role = is_server ? ZTLS_IS_SERVER : ZTLS_IS_CLIENT;
+ 	}
+ 
+-	if (sizeof(int) != optlen) {
 -		return -EINVAL;
 -	}
-+	context->options.role = is_server ? ZTLS_IS_SERVER : ZTLS_IS_CLIENT;
- 
--	*(int *)optval = cache_enabled;
 +#if defined(CONFIG_WOLFSSL_DEBUG)
 +	wolfSSL_Debugging_ON();
 +#endif /* CONFIG_WOLFSSL_DEBUG */
  
--	return 0;
--}
+-	context->options.cache_enabled = (*val == ZSOCK_TLS_SESSION_CACHE_ENABLED);
 +	method = tls_wolfssl_get_method(context, is_server);
  
--static int tls_opt_cert_verify_result_get(struct tls_context *context,
--					  void *optval, net_socklen_t *optlen)
--{
--	struct tls_session_context *session_ctx;
+-	return 0;
+-}
 +	if (method == NULL) {
 +		return -ENOTSUP;
 +	}
  
--	if (*optlen != sizeof(uint32_t)) {
+-static int tls_opt_session_cache_get(struct tls_context *context,
+-				     void *optval, net_socklen_t *optlen)
+-{
+-	int cache_enabled = context->options.cache_enabled ?
+-			    ZSOCK_TLS_SESSION_CACHE_ENABLED :
+-			    ZSOCK_TLS_SESSION_CACHE_DISABLED;
++	/* wolfSSL_CTX_new() takes ownership of the method, so an already
++	 * initialized context (a DTLS client re-connecting) must release it
++	 * rather than allocate one per call.
++	 */
++	if (context->ctx != NULL) {
++		XFREE(method, NULL, DYNAMIC_TYPE_METHOD);
++		method = NULL;
++	}
+ 
+-	if (*optlen != sizeof(cache_enabled)) {
 -		return -EINVAL;
 +	if (context->ctx == NULL) {
 +		context->ctx = wolfSSL_CTX_new(method);
@@ -3242,15 +3328,14 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		}
  	}
  
--	session_ctx = get_latest_session(context);
--	if (session_ctx == NULL) {
--		return -ENOTCONN;
+-	*(int *)optval = cache_enabled;
 +	ret = tls_wolfssl_set_credentials(context);
 +	if (ret != 0) {
 +		goto err_cleanup;
- 	}
++	}
  
--	*(uint32_t *)optval = mbedtls_ssl_get_verify_result(&session_ctx->ssl);
+-	return 0;
+-}
 +#ifndef NO_PSK
 +	if (NULL != context->psk) {
 +		if (is_server) {
@@ -3271,15 +3356,43 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
 +#endif /* !NO_PSK */
  
--	return 0;
--}
-+#if defined(CONFIG_WOLFSSL_MAX_FRAGMENT_LEN)
+-static int tls_opt_cert_verify_result_get(struct tls_context *context,
+-					  void *optval, net_socklen_t *optlen)
+-{
+-	struct tls_session_context *session_ctx;
++#if defined(CONFIG_WOLFSSL_MAX_FRAGMENT_LEN) && \
++	defined(CONFIG_NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH)
++	/* Gate on the socket-layer MFL toggle too, so setting it n disables
++	 * max_fragment_length negotiation on wolfSSL as the option advertises.
++	 */
 +	if (wolfSSL_CTX_UseMaxFragment(context->ctx,
 +				       CONFIG_WOLFSSL_MAX_FRAGMENT_LEN) != WOLFSSL_SUCCESS) {
 +		ret = -EINVAL;
 +		goto err_cleanup;
 +	}
-+#endif /* CONFIG_WOLFSSL_MAX_FRAGMENT_LEN */
++#endif /* WOLFSSL_MAX_FRAGMENT_LEN && NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH */
+ 
+-	if (*optlen != sizeof(uint32_t)) {
+-		return -EINVAL;
++	ret = tls_wolfssl_set_session_cache_mode(context);
++	if (ret != 0) {
++		goto err_cleanup;
+ 	}
+ 
+-	session_ctx = get_latest_session(context);
+-	if (session_ctx == NULL) {
+-		return -ENOTCONN;
++	ret = tls_wolfssl_session_init(context->active_session, context,
++				       is_server);
++	if (ret != 0) {
++		goto err_cleanup;
+ 	}
+ 
+-	*(uint32_t *)optval = mbedtls_ssl_get_verify_result(&session_ctx->ssl);
++	context->is_initialized = true;
+ 
+ 	return 0;
+-}
  
 -static int tls_opt_session_cache_purge_set(struct tls_context *context,
 -					   const void *optval, net_socklen_t optlen)
@@ -3287,84 +3400,79 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -	ARG_UNUSED(context);
 -	ARG_UNUSED(optval);
 -	ARG_UNUSED(optlen);
-+	ret = tls_wolfssl_set_session_cache_mode(context);
-+	if (ret != 0) {
-+		goto err_cleanup;
-+	}
++err_cleanup:
++	{
++		WOLFSSL_CTX *wolf_ctx;
  
 -	tls_session_purge();
-+	ret = tls_wolfssl_session_init(context->active_session, context,
-+				       is_server);
-+	if (ret != 0) {
-+		goto err_cleanup;
-+	}
++		k_mutex_lock(&context_lock, K_FOREVER);
++		wolf_ctx = context->ctx;
++		context->ctx = NULL;
++		k_mutex_unlock(&context_lock);
  
 -	return 0;
--}
-+	context->is_initialized = true;
- 
--static int tls_opt_peer_verify_set(struct tls_context *context,
--				   const void *optval, net_socklen_t optlen)
--{
--	int *peer_verify;
-+	return 0;
- 
--	if (!optval) {
--		return -EINVAL;
-+err_cleanup:
-+	if (context->ctx != NULL) {
-+		wolfSSL_CTX_free(context->ctx);
-+		context->ctx = NULL;
- 	}
- 
--	if (optlen != sizeof(int)) {
--		return -EINVAL;
--	}
++		if (wolf_ctx != NULL) {
++			wolfSSL_CTX_free(wolf_ctx);
++		}
++	}
++
++	/* The context owns no CTX and no WOLFSSL object now, so a later
++	 * connect()/accept() must run the whole setup again rather than take
++	 * the is_initialized shortcut.
++	 */
++	context->is_initialized = false;
++
 +	return ret;
-+}
+ }
 +#endif /* CONFIG_WOLFSSL */
 +
 +#if defined(CONFIG_WOLFSSL)
 +/* wolfSSL_X509_load_certificate_buffer is gated in
-+ * modules/crypto/wolfssl/src/x509.c around line 6055 on
++ * modules/crypto/wolfssl/src/x509.c on
 + *   OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || WOLFSSL_WPAS_SMALL ||
 + *   KEEP_PEER_CERT || SESSION_CERTS
-+ * (the OPENSSL_EXTRA_X509_SMALL arm is our downstream patch). The Zephyr
-+ * TLS sockets backend force-selects WOLFSSL_OPENSSL_EXTRA_X509_SMALL, so
-+ * the function is normally available — but if a wolfSSL uprev drops the
-+ * downstream patch and no user-supplied flag fills the gap, the build
-+ * would fail with an obscure linker error. Fail loudly here instead.
++ * The OPENSSL_EXTRA_X509_SMALL arm is upstream as of wolfSSL 5.9.2, and the
++ * Zephyr TLS sockets backend force-selects WOLFSSL_OPENSSL_EXTRA_X509_SMALL
++ * (subsys/net/lib/sockets/Kconfig). The same flag is required regardless for
++ * the client hostname/verify path (wolfSSL_X509_check_host,
++ * WOLFSSL_X509_STORE_CTX), so the X509 layer is always compiled in and this
++ * function is normally available. If a minimal or future config leaves all
++ * of these gate flags undefined, the build would fail with an obscure linker
++ * error; fail loudly here instead.
 + */
 +#if !defined(OPENSSL_EXTRA) && !defined(OPENSSL_EXTRA_X509_SMALL) && \
 +    !defined(WOLFSSL_WPAS_SMALL) && !defined(KEEP_PEER_CERT) && \
 +    !defined(SESSION_CERTS)
-+#error "tls_check_cert needs wolfSSL_X509_load_certificate_buffer. Either "\
-+       "re-apply the modules/crypto/wolfssl/src/x509.c gate-relaxation "\
-+       "patch (OPENSSL_EXTRA_X509_SMALL) or enable one of OPENSSL_EXTRA, "\
-+       "WOLFSSL_WPAS_SMALL, KEEP_PEER_CERT, SESSION_CERTS."
++#error "tls_check_cert needs wolfSSL_X509_load_certificate_buffer. Enable one "\
++       "of OPENSSL_EXTRA_X509_SMALL (CONFIG_WOLFSSL_OPENSSL_EXTRA_X509_SMALL), "\
++       "OPENSSL_EXTRA, WOLFSSL_WPAS_SMALL, KEEP_PEER_CERT, or SESSION_CERTS."
 +#endif /* X509 gate flags */
 +#endif /* CONFIG_WOLFSSL */
  
--	peer_verify = (int *)optval;
+-static int tls_opt_peer_verify_set(struct tls_context *context,
+-				   const void *optval, net_socklen_t optlen)
 +static int tls_check_cert(struct tls_credential *cert)
-+{
+ {
+-	int *peer_verify;
 +#if defined(CONFIG_WOLFSSL)
 +	/* Parse the cert here so setsockopt(TLS_SEC_TAG_LIST) returns EINVAL
 +	 * on malformed credentials (mbedTLS-parity contract exercised by
 +	 * test_tls_bad_cred). The X509 is freed immediately so no peer-cert
-+	 * retention is needed — the OPENSSL_EXTRA_X509_SMALL arm of the gate
-+	 * (see modules/crypto/wolfssl/src/x509.c:6055) is our downstream
-+	 * relaxation so KEEP_PEER_CERT isn't forced just for validation.
++	 * retention is needed - OPENSSL_EXTRA_X509_SMALL (upstream in wolfSSL
++	 * 5.9.2, force-selected by the sockets backend and already required by
++	 * the hostname/verify path) satisfies the gate, so KEEP_PEER_CERT is
++	 * not forced just for validation.
 +	 */
 +	WOLFSSL_X509 *x509;
 +	int fmt;
  
--	if (*peer_verify != MBEDTLS_SSL_VERIFY_NONE &&
--	    *peer_verify != MBEDTLS_SSL_VERIFY_OPTIONAL &&
--	    *peer_verify != MBEDTLS_SSL_VERIFY_REQUIRED) {
+-	if (!optval) {
+-		return -EINVAL;
+-	}
 +	fmt = crt_is_pem(cert->buf, cert->len) ?
 +	      WOLFSSL_FILETYPE_PEM : WOLFSSL_FILETYPE_ASN1;
-+
+ 
+-	if (optlen != sizeof(int)) {
 +	x509 = wolfSSL_X509_load_certificate_buffer(cert->buf,
 +						     (int)cert->len, fmt);
 +	if (x509 == NULL) {
@@ -3373,24 +3481,17 @@ index 4c8bded0e47..7d5ed85aff3 100644
  		return -EINVAL;
  	}
  
--	context->options.verify_level = *peer_verify;
+-	peer_verify = (int *)optval;
 +	wolfSSL_X509_free(x509);
- 
- 	return 0;
--}
++
++	return 0;
 +#else
 +#if defined(CONFIG_MBEDTLS_X509_CRT_PARSE_C)
 +	mbedtls_x509_crt cert_ctx;
 +	int err;
- 
--static int tls_opt_cert_nocopy_set(struct tls_context *context,
--				   const void *optval, net_socklen_t optlen)
--{
--	int *cert_nocopy;
++
 +	mbedtls_x509_crt_init(&cert_ctx);
- 
--	if (!optval) {
--		return -EINVAL;
++
 +	if (crt_is_pem(cert->buf, cert->len)) {
 +		err = mbedtls_x509_crt_parse(&cert_ctx, cert->buf, cert->len);
 +	} else {
@@ -3399,40 +3500,36 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		 */
 +		err = mbedtls_x509_crt_parse_der_nocopy(&cert_ctx, cert->buf,
 +							cert->len);
- 	}
++	}
  
--	if (optlen != sizeof(int)) {
+-	if (*peer_verify != MBEDTLS_SSL_VERIFY_NONE &&
+-	    *peer_verify != MBEDTLS_SSL_VERIFY_OPTIONAL &&
+-	    *peer_verify != MBEDTLS_SSL_VERIFY_REQUIRED) {
 +	if (err != 0) {
 +		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
 +			"certificate", cert->tag, -err);
  		return -EINVAL;
  	}
  
--	cert_nocopy = (int *)optval;
--
--	if (*cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_NONE &&
--	    *cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_OPTIONAL) {
--		return -EINVAL;
--	}
+-	context->options.verify_level = *peer_verify;
 +	mbedtls_x509_crt_free(&cert_ctx);
  
--	context->options.cert_nocopy = *cert_nocopy;
+-	return 0;
 +	return err;
 +#else
 +	NET_ERR("TLS with certificates disabled. "
 +		"Reconfigure mbed TLS to support certificate based key exchange.");
- 
--	return 0;
++
 +	return -ENOTSUP;
 +#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
 +#endif /* CONFIG_WOLFSSL */
  }
  
--static int tls_opt_dtls_role_set(struct tls_context *context,
--				 const void *optval, net_socklen_t optlen)
+-static int tls_opt_cert_nocopy_set(struct tls_context *context,
+-				   const void *optval, net_socklen_t optlen)
 +static int tls_check_priv_key(struct tls_credential *priv_key)
  {
--	int *role;
+-	int *cert_nocopy;
 +#if defined(CONFIG_WOLFSSL)
 +	WOLFSSL_CTX *tmp_ctx;
 +	int fmt;
@@ -3440,7 +3537,15 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
 -	if (!optval) {
 -		return -EINVAL;
++	/* wolfSSL has no CTX-free private key parser without OPENSSL_EXTRA, so
++	 * validation borrows a throwaway CTX. Pick a method that exists in this
++	 * build: wolfSSLv23_client_method() is compiled out by NO_WOLFSSL_CLIENT.
++	 */
++#ifndef NO_WOLFSSL_CLIENT
 +	tmp_ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
++#else
++	tmp_ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
++#endif
 +	if (tmp_ctx == NULL) {
 +		return -ENOMEM;
  	}
@@ -3451,20 +3556,20 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	fmt = key_is_pem(priv_key->buf, priv_key->len) ?
 +	      WOLFSSL_FILETYPE_PEM : WOLFSSL_FILETYPE_ASN1;
  
--	role = (int *)optval;
--	if (*role != MBEDTLS_SSL_IS_CLIENT &&
--	    *role != MBEDTLS_SSL_IS_SERVER) {
+-	cert_nocopy = (int *)optval;
 +	ret = wolfSSL_CTX_use_PrivateKey_buffer(tmp_ctx, priv_key->buf,
 +						(long)priv_key->len, fmt);
 +	wolfSSL_CTX_free(tmp_ctx);
-+
+ 
+-	if (*cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_NONE &&
+-	    *cert_nocopy != ZSOCK_TLS_CERT_NOCOPY_OPTIONAL) {
 +	if (ret != WOLFSSL_SUCCESS) {
 +		NET_ERR("Failed to parse %s on tag %d",
 +			"private key", priv_key->tag);
  		return -EINVAL;
  	}
  
--	context->options.role = *role;
+-	context->options.cert_nocopy = *cert_nocopy;
 -
  	return 0;
 -}
@@ -3472,31 +3577,48 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	mbedtls_pk_context key_ctx;
 +	int err;
  
--#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
--static int tls_opt_cert_verify_callback_set(struct tls_context *context,
--					    const void *optval,
--					    net_socklen_t optlen)
+-static int tls_opt_dtls_role_set(struct tls_context *context,
+-				 const void *optval, net_socklen_t optlen)
+-{
+-	int *role;
+-
+-	if (!optval) {
+-		return -EINVAL;
+-	}
 +	mbedtls_pk_init(&key_ctx);
-+
+ 
+-	if (optlen != sizeof(int)) {
+-		return -EINVAL;
 +	err = mbedtls_pk_parse_key(&key_ctx, priv_key->buf,
 +				   priv_key->len, NULL, 0);
 +	if (err != 0) {
 +		NET_ERR("Failed to parse %s on tag %d, err: -0x%x",
 +			"private key", priv_key->tag, -err);
 +		err = -EINVAL;
-+	}
-+
+ 	}
+ 
+-	role = (int *)optval;
+-	if (*role != MBEDTLS_SSL_IS_CLIENT &&
+-	    *role != MBEDTLS_SSL_IS_SERVER) {
+-		return -EINVAL;
+-	}
 +	mbedtls_pk_free(&key_ctx);
-+
+ 
+-	context->options.role = *role;
 +	return err;
 +#else
 +	NET_ERR("TLS with certificates disabled. "
 +		"Reconfigure mbed TLS to support certificate based key exchange.");
-+
+ 
+-	return 0;
 +	return -ENOTSUP;
 +#endif /* CONFIG_MBEDTLS_X509_CRT_PARSE_C */
-+}
-+
+ }
+ 
+-#if defined(CONFIG_NET_SOCKETS_TLS_CERT_VERIFY_CALLBACK)
+-static int tls_opt_cert_verify_callback_set(struct tls_context *context,
+-					    const void *optval,
+-					    net_socklen_t optlen)
 +static int tls_check_psk(struct tls_credential *psk)
  {
 -	struct zsock_tls_cert_verify_cb *cert_verify;
@@ -3757,66 +3879,75 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -	int ret;
 -	int sock_flags;
 -	bool is_non_block;
--
++#if defined(CONFIG_WOLFSSL)
++	char *host_name;
+ 
 -	sock_flags = zsock_fcntl(ctx->sock, ZVFS_F_GETFL, 0);
 -	if (sock_flags < 0) {
 -		return -EIO;
-+#if defined(CONFIG_WOLFSSL)
-+	if (NULL != context->host_name) {
-+		XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-+		context->host_name = NULL;
-+		context->host_len = 0;
++	if (optval == NULL) {
++		if (context->host_name != NULL) {
++			XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++			context->host_name = NULL;
++			context->host_len = 0;
++		}
++		context->options.is_hostname_set = false;
++		return 0;
  	}
  
 -	is_non_block = sock_flags & ZVFS_O_NONBLOCK;
 -	if (is_non_block) {
 -		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL,
 -				  sock_flags & ~ZVFS_O_NONBLOCK);
-+	if (optval == NULL) {
-+		context->options.is_hostname_set = false;
-+		return 0;
++	/* The mbedTLS backend treats optval as a C string and ignores optlen
++	 * entirely, so trim any trailing NUL padding rather than carrying it
++	 * into the SNI extension and the certificate name match.
++	 */
++	while (optlen > 0 && ((const char *)optval)[optlen - 1] == '\0') {
++		optlen--;
  	}
  
 -	ret = zsock_connect(ctx->sock, addr, addrlen);
 -	if (ret < 0) {
 -		return ret;
-+	/* The mbedTLS backend treats optval as a C string and ignores
-+	 * optlen entirely. Tolerate a NUL-terminated optval here too so
-+	 * an application passing strlen() + 1 doesn't end up with a NUL
-+	 * byte embedded in the SNI / hostname match on this backend only.
++	/* An empty hostname cannot match any certificate and would silently
++	 * disable the name check, so reject it instead.
 +	 */
-+	if (optlen > 0 && ((const char *)optval)[optlen - 1] == '\0') {
-+		optlen--;
++	if (optlen == 0) {
++		return -EINVAL;
  	}
  
 -	if (is_non_block) {
 -		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL, sock_flags);
+-	}
 +	/* RFC 6066 SNI HostName is at most 2^16 - 1; reject anything larger
 +	 * so the unchecked `optlen + 1` below cannot wrap. net_socklen_t is
 +	 * unsigned, so the lower bound is implicit.
 +	 */
 +	if (optlen > UINT16_MAX) {
 +		return -EINVAL;
- 	}
- 
--#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
--	if (ctx->type == NET_SOCK_DGRAM) {
--		dtls_peer_address_set(ctx->active_session, addr, addrlen);
-+	/* +1 for NUL — wolfSSL APIs require C strings. */
-+	context->host_name = XMALLOC(optlen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-+	if (context->host_name == NULL) {
-+		context->options.is_hostname_set = false;
++	}
++
++	/* mbedTLS validates before touching the configured hostname ("Check if
++	 * new hostname is valid before making any change to current one"). Keep
++	 * the old one until the new one is committed, otherwise a rejected
++	 * setsockopt leaves the socket with no name check at all.
++	 */
++
++	/* +1 for NUL - wolfSSL APIs require C strings. */
++	host_name = XMALLOC(optlen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	if (host_name == NULL) {
 +		return -ENOMEM;
- 	}
--#endif
- 
--	if (ctx->type == NET_SOCK_STREAM
--#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
--	    || (ctx->type == NET_SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
--#endif
--	    ) {
-+	XMEMCPY(context->host_name, optval, optlen);
-+	context->host_name[optlen] = '\0';
++	}
++
++	XMEMCPY(host_name, optval, optlen);
++	host_name[optlen] = '\0';
++
++	if (context->host_name != NULL) {
++		XFREE(context->host_name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
++	}
++
++	context->host_name = host_name;
 +	context->host_len = optlen;
 +	context->options.is_hostname_set = true;
 +
@@ -3860,7 +3991,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
 +
 +#if defined(CONFIG_WOLFSSL)
-+	/* Validate before storing — tls_wolfssl_apply_all_sessions is
++	/* Validate before storing - tls_wolfssl_apply_all_sessions is
 +	 * best-effort and must not be relied on for argument validation.
 +	 */
 +	for (int i = 0; i < cipher_cnt; i++) {
@@ -4436,22 +4567,15 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	ARG_UNUSED(optval);
 +	ARG_UNUSED(optlen);
 +
-+#if defined(CONFIG_WOLFSSL) && defined(HAVE_EXT_CACHE)
-+	/* wolfSSL's internal (server-side) session cache is global, but
-+	 * flushing it requires a live CTX handle and the socket this option
-+	 * is invoked on may never have been connected. Find any in-use
-+	 * context that owns a CTX so the purge works regardless of which
-+	 * socket it is called on — parity with the mbedTLS backend, which
-+	 * purges its global server_cache.
++#if defined(CONFIG_WOLFSSL)
++	/* wolfSSL's server-side session cache is global and lives whenever
++	 * NO_SESSION_CACHE is undefined, independently of the external cache
++	 * that HAVE_EXT_CACHE gates. Flush it unconditionally, otherwise this
++	 * option reports success while leaving resumable sessions in place.
++	 * wolfSSL_CTX_flush_sessions() ignores its ctx argument and walks the
++	 * global cache, so no context handle is needed.
 +	 */
-+	k_mutex_lock(&context_lock, K_FOREVER);
-+	for (int i = 0; i < ARRAY_SIZE(tls_contexts); i++) {
-+		if (tls_contexts[i].is_used && tls_contexts[i].ctx != NULL) {
-+			wolfSSL_CTX_flush_sessions(tls_contexts[i].ctx, -1);
-+			break;
-+		}
-+	}
-+	k_mutex_unlock(&context_lock);
++	wolfSSL_CTX_flush_sessions(NULL, -1);
 +#endif
 +	tls_session_purge();
 +
@@ -4529,6 +4653,9 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	}
 +
 +	context->options.role = *role;
++#if defined(CONFIG_WOLFSSL)
++	context->role_set = true;
++#endif
 +
 +	return 0;
 +}
@@ -4623,13 +4750,21 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +	context->options.cert_verify_wolfssl = *wolfssl_cb;
 +
-+	return 0;
++	/* Every other per-SSL option propagates to sessions already set up.
++	 * Without this the callback only takes effect after a session reset,
++	 * which the application cannot observe.
++	 */
++	return tls_wolfssl_apply_all_sessions(context, tls_wolfssl_set_verify);
 +}
 +#else
 +static int tls_opt_cert_verify_callback_wolfssl_set(struct tls_context *context,
 +						    const void *optval,
 +						    net_socklen_t optlen)
 +{
++	ARG_UNUSED(context);
++	ARG_UNUSED(optval);
++	ARG_UNUSED(optlen);
++
 +	return -ENOPROTOOPT;
 +}
 +#endif /* CONFIG_NET_SOCKETS_TLS_WOLFSSL_VERIFY_CALLBACK */
@@ -4775,18 +4910,13 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	if (is_non_block) {
 +		(void)zsock_fcntl(ctx->sock, ZVFS_F_SETFL, sock_flags);
 +	}
-+
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-+	if (ctx->type == NET_SOCK_DGRAM) {
-+		dtls_peer_address_set(ctx->active_session, addr, addrlen);
-+	}
-+#endif
-+
-+	if (ctx->type == NET_SOCK_STREAM
-+#if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-+	    || (ctx->type == NET_SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
-+#endif
-+	    ) {
+ 
+ #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
+ 	if (ctx->type == NET_SOCK_DGRAM) {
+@@ -2866,6 +5332,32 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
+ 	    || (ctx->type == NET_SOCK_DGRAM && ctx->options.dtls_handshake_on_connect)
+ #endif
+ 	    ) {
 +#if defined(CONFIG_WOLFSSL)
 +		ret = tls_wolfssl_init(ctx, false);
 +		if (ret < 0) {
@@ -4816,7 +4946,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  		ret = tls_mbedtls_init(ctx, false);
  		if (ret < 0) {
  			goto error;
-@@ -2890,6 +5195,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
+@@ -2890,6 +5382,7 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
  		}
  
  		tls_session_store(ctx, addr, addrlen);
@@ -4824,10 +4954,17 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	}
  
  	return 0;
-@@ -2930,6 +5236,30 @@ int ztls_accept_ctx(struct tls_context *parent, struct net_sockaddr *addr,
+@@ -2925,11 +5418,35 @@ int ztls_accept_ctx(struct tls_context *parent, struct net_sockaddr *addr,
+ 		goto error;
+ 	}
  
- 	child->sock = sock;
- 
+-	zvfs_finalize_typed_fd(fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+-			    ZVFS_MODE_IFSOCK);
++	zvfs_finalize_typed_fd(fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
++			    ZVFS_MODE_IFSOCK);
++
++	child->sock = sock;
++
 +#if defined(CONFIG_WOLFSSL)
 +	ret = tls_wolfssl_init(child, true);
 +	if (ret < 0) {
@@ -4836,7 +4973,8 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +	/* Do not use any socket flags during the handshake. */
 +	child->flags = 0;
-+
+ 
+-	child->sock = sock;
 +	/* TODO For simplicity, TLS handshake blocks the socket even for
 +	 * non-blocking socket.
 +	 */
@@ -4849,13 +4987,13 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +		goto error;
 +	}
-+
+ 
 +	return fd;
 +#else
  	ret = tls_mbedtls_init(child, true);
  	if (ret < 0) {
  		goto error;
-@@ -2952,6 +5282,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct net_sockaddr *addr,
+@@ -2952,6 +5469,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct net_sockaddr *addr,
  	}
  
  	return fd;
@@ -4863,7 +5001,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  error:
  	if (child != NULL) {
-@@ -2970,6 +5301,79 @@ error:
+@@ -2970,6 +5488,95 @@ error:
  	return -1;
  }
  
@@ -4903,6 +5041,14 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +		err = wolfSSL_get_error(ctx->active_session->wssl, ret);
 +
++		/* A zero-length write is legal and wolfSSL reports it as 0 with
++		 * no error latched. Treat it as the no-op the mbedTLS backend
++		 * does, otherwise the catch-all below tears down the session.
++		 */
++		if (ret == 0 && err == WOLFSSL_ERROR_NONE) {
++			return 0;
++		}
++
 +		if (err == WOLFSSL_ERROR_WANT_READ ||
 +		    err == WOLFSSL_ERROR_WANT_WRITE) {
 +			int timeout_ms;
@@ -4928,9 +5074,17 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			}
 +		} else {
 +			NET_ERR("TLS send error: %x", err);
-+			tls_wolfssl_reset_session(ctx);
-+			ctx->error = ECONNABORTED;
-+			errno = ECONNABORTED;
++			/* Distinguish a failed session reset from a plain abort,
++			 * as the mbedTLS arm does: the SSL object is unusable in
++			 * that case, not merely disconnected.
++			 */
++			if (tls_wolfssl_reset_session(ctx) != 0) {
++				ctx->error = ENOMEM;
++				errno = ENOMEM;
++			} else {
++				ctx->error = ECONNABORTED;
++				errno = ECONNABORTED;
++			}
 +			break;
 +		}
 +	} while (true);
@@ -4943,7 +5097,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static ssize_t send_tls(struct tls_context *ctx, const void *buf,
  			size_t len, int flags)
  {
-@@ -3048,8 +5452,107 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
+@@ -3048,8 +5655,107 @@ static ssize_t send_tls(struct tls_context *ctx, const void *buf,
  
  	return -1;
  }
@@ -5052,7 +5206,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static ssize_t sendto_dtls_client(struct tls_context *ctx, const void *buf,
  				  size_t len, int flags,
  				  const struct net_sockaddr *dest_addr,
-@@ -3143,7 +5646,7 @@ static ssize_t sendto_dtls_server(struct tls_context *ctx, const void *buf,
+@@ -3143,7 +5849,7 @@ static ssize_t sendto_dtls_server(struct tls_context *ctx, const void *buf,
  
  	return ret;
  }
@@ -5061,7 +5215,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  			int flags, const struct net_sockaddr *dest_addr,
-@@ -3151,6 +5654,26 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+@@ -3151,6 +5857,26 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  {
  	ctx->flags = flags;
  
@@ -5088,7 +5242,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	/* TLS */
  	if (ctx->type == NET_SOCK_STREAM) {
  		return send_tls(ctx, buf, len, flags);
-@@ -3168,6 +5691,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
+@@ -3168,6 +5894,7 @@ ssize_t ztls_sendto_ctx(struct tls_context *ctx, const void *buf, size_t len,
  	errno = ENOTSUP;
  	return -1;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
@@ -5096,7 +5250,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  }
  
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
-@@ -3257,24 +5781,133 @@ ssize_t ztls_sendmsg_ctx(struct tls_context *ctx, const struct net_msghdr *msg,
+@@ -3257,24 +5984,143 @@ ssize_t ztls_sendmsg_ctx(struct tls_context *ctx, const struct net_msghdr *msg,
  				goto send_loop;
  			}
  
@@ -5162,7 +5316,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			 * below would land us in the EIO arm.
 +			 *
 +			 * Return what's been drained across earlier iterations
-+			 * (recv_len) — POSIX semantics: a partial recv followed
++			 * (recv_len) - POSIX semantics: a partial recv followed
 +			 * by EOF reports the partial. recv_len may be 0 on the
 +			 * first iteration, in which case the caller sees clean
 +			 * EOF immediately. The DTLS sibling
@@ -5225,6 +5379,16 @@ index 4c8bded0e47..7d5ed85aff3 100644
 -			errno = EMSGSIZE;
 -			return -1;
 +		if (ret == 0) {
++			/* wolfSSL reports a clean TLS-level closure as 0 with the
++			 * reason latched in ssl->error. Mark the session closed so
++			 * a later send() fails like the mbedTLS backend instead of
++			 * writing to a shut-down session.
++			 */
++			err = wolfSSL_get_error(ctx->active_session->wssl, ret);
++			if (err == WOLFSSL_ERROR_ZERO_RETURN ||
++			    err == SOCKET_PEER_CLOSED_E) {
++				ctx->active_session->session_closed = true;
++			}
 +			break;
  		}
 -	}
@@ -5242,7 +5406,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  			size_t max_len, int flags)
  {
-@@ -3321,61 +5954,415 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
+@@ -3321,61 +6167,420 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
  				 * supported. See mbedtls_ssl_read API
  				 * documentation.
  				 */
@@ -5340,7 +5504,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +		retry = false;
 +		ret = wolfSSL_read(ctx->active_session->wssl, buf, max_len);
-+		/* Note: <= 0, not < 0 — wolfSSL_read returns 0 for a clean
++		/* Note: <= 0, not < 0 - wolfSSL_read returns 0 for a clean
 +		 * TLS-level closure (peer close-notify), with the actual
 +		 * cause reported via wolfSSL_get_error (ZERO_RETURN).
 +		 */
@@ -5349,7 +5513,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +
 +			/* Local shutdown(SHUT_RD/RDWR) racing with a blocked
 +			 * recv(): same hazard as the TCP/TLS path, just
-+			 * surfaced differently — the DTLS BIO callbacks map a
++			 * surfaced differently - the DTLS BIO callbacks map a
 +			 * 0-byte recvfrom to CBIO_ERR_CONN_CLOSE (symmetry
 +			 * with tls_wolf_rx); without this shortcut the next
 +			 * iteration would still re-block.
@@ -5357,7 +5521,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			 * Return 0 unconditionally here (unlike the TCP/TLS
 +			 * sibling recv_tls_wolfssl which returns its
 +			 * accumulated recv_len). That's not a wolfSSL quirk
-+			 * — DTLS recv reads at most one datagram per call,
++			 * - DTLS recv reads at most one datagram per call,
 +			 * with no cross-iteration accumulation, exactly
 +			 * matching the mbedTLS DTLS path (recvfrom_dtls_common).
 +			 * The asymmetry between TCP and DTLS is intrinsic to
@@ -5474,12 +5638,17 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +			int r = wolfSSL_read(ctx->active_session->wssl, dummy, to_read);
 +
 +			if (r <= 0) {
++				wc_ForceZero(dummy, sizeof(dummy));
 +				NET_ERR("Error while flushing the rest of the"
 +					" datagram, err %d", r);
 +				ret = -EIO;
 +				break;
 +			}
 +			remaining -= r;
++			/* Scrub the decrypted plaintext drained into the
++			 * discard buffer before it leaves scope.
++			 */
++			wc_ForceZero(dummy, sizeof(dummy));
 +		}
 +
 +		return ret;
@@ -5696,7 +5865,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static ssize_t recvfrom_dtls_common(struct tls_context *ctx, void *buf,
  				    size_t max_len, int flags,
  				    struct net_sockaddr *src_addr,
-@@ -3691,7 +6678,7 @@ error:
+@@ -3691,7 +6896,7 @@ error:
  	errno = -ret;
  	return -1;
  }
@@ -5705,7 +5874,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  			  int flags, struct net_sockaddr *src_addr,
-@@ -3707,6 +6694,26 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+@@ -3707,6 +6912,26 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  
  	ctx->flags = flags;
  
@@ -5732,7 +5901,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	/* TLS */
  	if (ctx->type == NET_SOCK_STREAM) {
  		return recv_tls(ctx, buf, max_len, flags);
-@@ -3725,18 +6732,26 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
+@@ -3725,18 +6950,26 @@ ssize_t ztls_recvfrom_ctx(struct tls_context *ctx, void *buf, size_t max_len,
  	errno = ENOTSUP;
  	return -1;
  #endif /* CONFIG_NET_SOCKETS_ENABLE_DTLS */
@@ -5760,7 +5929,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	}
  
  	return 0;
-@@ -3757,7 +6772,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
+@@ -3757,7 +6990,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
  	 * it actually starts to poll for data.
  	 */
  	if ((pfd->events & ZSOCK_POLLIN) && (ctx->type == NET_SOCK_DGRAM) &&
@@ -5769,7 +5938,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	    !is_handshake_complete(ctx->active_session)) {
  		(*pev)->obj = &ctx->active_session->tls_established;
  		(*pev)->type = K_POLL_TYPE_SEM_AVAILABLE;
-@@ -3811,6 +6826,44 @@ static int tls_data_check(struct tls_context *ctx)
+@@ -3811,6 +7044,48 @@ static int tls_data_check(struct tls_context *ctx)
  
  	ctx->flags = ZSOCK_MSG_DONTWAIT;
  
@@ -5777,8 +5946,12 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	{
 +		byte dummy[1];
 +
++		/* <= 0, not < 0 - wolfSSL_peek returns 0 for a clean TLS-level
++		 * closure and latches the reason in ssl->error.
++		 */
 +		ret = wolfSSL_peek(ctx->active_session->wssl, dummy, sizeof(dummy));
-+		if (ret < 0) {
++		wc_ForceZero(dummy, sizeof(dummy));
++		if (ret <= 0) {
 +			int err = wolfSSL_get_error(ctx->active_session->wssl, ret);
 +
 +			if (err == SOCKET_PEER_CLOSED_E ||
@@ -5814,7 +5987,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	ret = mbedtls_ssl_read(&ctx->active_session->ssl, NULL, 0);
  	if (ret < 0) {
  		if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
-@@ -3842,6 +6895,7 @@ static int tls_data_check(struct tls_context *ctx)
+@@ -3842,6 +7117,7 @@ static int tls_data_check(struct tls_context *ctx)
  	}
  
  	return mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl);
@@ -5822,7 +5995,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  }
  
  static int tls_update_pollin(int fd, struct tls_context *ctx,
-@@ -3851,10 +6905,18 @@ static int tls_update_pollin(int fd, struct tls_context *ctx,
+@@ -3851,10 +7127,18 @@ static int tls_update_pollin(int fd, struct tls_context *ctx,
  
  	if (!ctx->is_listening) {
  		/* Already had TLS data to read on socket. */
@@ -5841,7 +6014,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  	}
  
  	if ((pfd->revents & ZSOCK_POLLIN) == 0) {
-@@ -3892,6 +6954,119 @@ again:
+@@ -3892,6 +7176,124 @@ again:
  }
  
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
@@ -5902,8 +6075,13 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +		byte dummy[1];
 +
 +		ret = wolfSSL_peek(ctx->active_session->wssl, dummy, sizeof(dummy));
++		wc_ForceZero(dummy, sizeof(dummy));
 +	}
-+	if (ret < 0) {
++	/* <= 0, not < 0 - wolfSSL_peek returns 0 for a clean TLS-level closure.
++	 * UDP has no FIN to drive a later retry, so a missed close_notify leaks
++	 * the session until the DTLS timeout, or forever when it is disabled.
++	 */
++	if (ret <= 0) {
 +		int err = wolfSSL_get_error(ctx->active_session->wssl, ret);
 +
 +		if (err == SOCKET_PEER_CLOSED_E ||
@@ -5961,7 +6139,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  static int dtls_data_check(struct tls_context *ctx)
  {
  	bool is_server = ctx->options.role == MBEDTLS_SSL_IS_SERVER;
-@@ -4012,6 +7187,7 @@ again:
+@@ -4012,6 +7414,7 @@ again:
  
  	return mbedtls_ssl_get_bytes_avail(&ctx->active_session->ssl);
  }
@@ -5969,7 +6147,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  static int dtls_update_pollin(int fd, struct tls_context *ctx,
  			      struct zsock_pollfd *pfd)
-@@ -4019,10 +7195,18 @@ static int dtls_update_pollin(int fd, struct tls_context *ctx,
+@@ -4019,10 +7422,18 @@ static int dtls_update_pollin(int fd, struct tls_context *ctx,
  	int ret;
  
  	/* Already had DTLS data to read on socket. */
@@ -5988,7 +6166,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  	/* Perform data check without incoming data for completed DTLS connections.
  	 * This allows the connections to timeout with CONFIG_NET_SOCKETS_DTLS_TIMEOUT.
-@@ -4154,7 +7338,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+@@ -4154,7 +7565,7 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
  	 * reports that data is ready.
  	 */
  	if ((ctx->type != NET_SOCK_DGRAM) ||
@@ -5997,7 +6175,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  		return false;
  	}
  
-@@ -4167,13 +7351,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
+@@ -4167,13 +7578,13 @@ static bool poll_offload_dtls_client_retry(struct tls_context *ctx,
  		pfd->revents &= ~ZSOCK_POLLIN;
  		return true;
  	} else if (!is_handshake_complete(ctx->active_session)) {
@@ -6013,7 +6191,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  				 ZSOCK_MSG_DONTWAIT);
  		if (ret < 0) {
  			pfd->revents |= ZSOCK_POLLERR;
-@@ -4492,6 +7676,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
+@@ -4492,6 +7903,16 @@ int ztls_setsockopt_ctx(struct tls_context *ctx, int level, int optname,
  		err = tls_opt_cert_verify_callback_set(ctx, optval, optlen);
  		break;
  
@@ -6021,7 +6199,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	case ZSOCK_TLS_CERT_VERIFY_CALLBACK_WOLFSSL:
 +		err = tls_opt_cert_verify_callback_wolfssl_set(ctx, optval, optlen);
 +		break;
-+	/* Under mbedTLS the option number 21 is reserved but unhandled — it
++	/* Under mbedTLS the option number 21 is reserved but unhandled - it
 +	 * falls through to the default case and surfaces as -ENOPROTOOPT,
 +	 * which matches the upstream "unknown sockopt" contract.
 +	 */
@@ -6030,7 +6208,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  #if defined(CONFIG_NET_SOCKETS_ENABLE_DTLS)
  	case ZSOCK_TLS_DTLS_HANDSHAKE_TIMEOUT_MIN:
  		err = tls_opt_dtls_handshake_timeout_set(ctx, optval,
-@@ -4538,6 +7732,20 @@ out:
+@@ -4538,6 +7959,20 @@ out:
  }
  
  #if defined(CONFIG_NET_TEST)
@@ -6051,7 +6229,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
  {
  	struct tls_context *ctx;
-@@ -4550,6 +7758,7 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
+@@ -4550,6 +7985,7 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
  
  	return &ctx->active_session->ssl;
  }
@@ -6059,7 +6237,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  
  uint32_t ztls_get_session_count(void)
  {
-@@ -4558,15 +7767,15 @@ uint32_t ztls_get_session_count(void)
+@@ -4558,15 +7994,15 @@ uint32_t ztls_get_session_count(void)
  
  #endif /* CONFIG_NET_TEST */
  
@@ -6079,7 +6257,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
  }
  
  static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
-@@ -4652,8 +7861,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+@@ -4652,8 +8088,22 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
  static int tls_sock_shutdown_vmeth(void *obj, int how)
  {
  	struct tls_context *ctx = obj;
@@ -6088,7 +6266,7 @@ index 4c8bded0e47..7d5ed85aff3 100644
 +	ret = zsock_shutdown(ctx->sock, how);
 +#if defined(CONFIG_WOLFSSL)
 +	/* Mark the TLS layer's read side closed only after the underlying
-+	 * socket accepted the shutdown — setting recv_eof before forwarding
++	 * socket accepted the shutdown - setting recv_eof before forwarding
 +	 * would poison the recv path for an unsuccessful shutdown. mbedTLS
 +	 * does not consult recv_eof, so the write is gated to the wolfSSL
 +	 * backend to keep the mbedTLS contract byte-identical with upstream.
@@ -6127,10 +6305,24 @@ index 4326b7142ad..d88246531ca 100644
 +zephyr_library_link_libraries(wolfSSL)
 +endif()
 diff --git a/subsys/random/Kconfig b/subsys/random/Kconfig
-index a759d7b88ed..93ffbef5abe 100644
+index a759d7b88ed..8a7840c92ac 100644
 --- a/subsys/random/Kconfig
 +++ b/subsys/random/Kconfig
-@@ -161,6 +161,17 @@ config PSA_CSPRNG_GENERATOR
+@@ -121,6 +121,13 @@ config CSPRNG_ENABLED
+ 
+ choice CSPRNG_GENERATOR_CHOICE
+ 	prompt "Cryptographically secure random generator"
++	# When wolfSSL is the crypto backend, prefer the standard PSA CSPRNG backed
++	# by the wolfPSA provider (sys_csrand_get -> psa_generate_random -> wolfPSA);
++	# with wolfSSL but no PSA provider, fall back to the wolfSSL Hash-DRBG CSPRNG.
++	# These lead the list so the whole image draws randomness through one
++	# wolfCrypt RNG path; the original hardware/test defaults follow unchanged.
++	default PSA_CSPRNG_GENERATOR if WOLFPSA
++	default WOLFSSL_CSPRNG_GENERATOR if WOLFSSL
+ 	default HARDWARE_DEVICE_CS_GENERATOR
+ 	default TEST_CSPRNG_GENERATOR
+ 	help
+@@ -161,6 +168,17 @@ config PSA_CSPRNG_GENERATOR
  	  security-sensitive applications.
  
  
@@ -6148,28 +6340,12 @@ index a759d7b88ed..93ffbef5abe 100644
  config TEST_CSPRNG_GENERATOR
  	bool "Use insecure CSPRNG for testing purposes"
  	depends on TEST_RANDOM_GENERATOR
-@@ -170,6 +181,15 @@ config TEST_CSPRNG_GENERATOR
- 
- endchoice # CSPRNG_GENERATOR_CHOICE
- 
-+config WOLFSSL_CSPRNG_PERSONALIZATION
-+	string "wolfSSL DRBG personalization string"
-+	default "zephyr wolfssl-rng seed"
-+	depends on WOLFSSL_CSPRNG_GENERATOR
-+	help
-+	  Personalization (nonce) string fed into the wolfSSL DRBG at
-+	  instantiation, in addition to the entropy input from the
-+	  entropy driver.
-+
- config CS_CTR_DRBG_PERSONALIZATION
- 	string "CTR-DRBG Personalization string"
- 	default "zephyr ctr-drbg seed"
 diff --git a/subsys/random/random_wolfssl.c b/subsys/random/random_wolfssl.c
 new file mode 100644
-index 00000000000..7bdaadef40d
+index 00000000000..d2cb082a26d
 --- /dev/null
 +++ b/subsys/random/random_wolfssl.c
-@@ -0,0 +1,96 @@
+@@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) 2026 wolfSSL Inc.
 + *
@@ -6177,9 +6353,9 @@ index 00000000000..7bdaadef40d
 + */
 +
 +#include <zephyr/init.h>
-+#include <zephyr/device.h>
-+#include <zephyr/drivers/entropy.h>
 +#include <zephyr/kernel.h>
++#include <zephyr/random/random.h>
++#include <stdint.h>
 +#include <string.h>
 +
 +#ifndef WOLFSSL_USER_SETTINGS
@@ -6188,46 +6364,26 @@ index 00000000000..7bdaadef40d
 +#include <wolfssl/wolfcrypt/settings.h>
 +#include <wolfssl/wolfcrypt/random.h>
 +
-+/*
-+ * entropy_dev is initialized at runtime to allow first time initialization
-+ * of the wolfSSL DRBG engine.
-+ */
-+static const struct device *entropy_dev;
-+static const unsigned char drbg_seed[] = CONFIG_WOLFSSL_CSPRNG_PERSONALIZATION;
 +static bool rng_initialised;
 +static K_MUTEX_DEFINE(rng_lock);
 +
 +static WC_RNG rng_ctx;
 +
-+static int wolfssl_rng_entropy_cb(OS_Seed *os, byte *seed, word32 sz)
-+{
-+	return entropy_get_entropy(entropy_dev, (void *)seed, (size_t)sz);
-+}
-+
 +static int wolfssl_rng_initialize(void)
 +{
 +	int ret;
 +
-+	entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
-+
-+	if (!device_is_ready(entropy_dev)) {
-+		/* Recoverable error reported through the syscall return — not a
-+		 * fatal __ASSERT, so the failure semantics are the same in
-+		 * assert-enabled and assert-disabled builds.
-+		 */
-+		return -ENODEV;
-+	}
-+
-+	ret = wc_SetSeed_Cb(wolfssl_rng_entropy_cb);
-+	if (ret != 0) {
-+		return -EIO;
-+	}
-+
-+	/* sizeof() - 1 drops the string's NUL terminator so it is not fed into
-+	 * the DRBG as personalization data (and an empty string means none).
++	/* wc_InitRng_ex() seeds the DRBG through wc_GenerateSeed(), which on
++	 * Zephyr draws from the hardware entropy driver (see
++	 * wolfcrypt/src/random.c). A dead entropy source therefore surfaces here as
++	 * a wolfCrypt failure.
++	 *
++	 * Supplying no nonce is deliberate: _InitRng() then requests MAX_SEED_SZ
++	 * from the entropy source and derives the SP 800-90A nonce from it,
++	 * instead of shortening the seed by SEED_SZ/2 to make room for a
++	 * caller-provided one.
 +	 */
-+	ret = wc_InitRngNonce_ex(&rng_ctx, (byte *)drbg_seed, sizeof(drbg_seed) - 1,
-+				 NULL, 0);
++	ret = wc_InitRng_ex(&rng_ctx, NULL, 0);
 +	if (ret != 0) {
 +		(void)wc_FreeRng(&rng_ctx);
 +		return -EIO;
@@ -6237,7 +6393,7 @@ index 00000000000..7bdaadef40d
 +	return 0;
 +}
 +
-+int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
++int z_impl_sys_csrand_get(void *dst, size_t outlen)
 +{
 +	int ret;
 +
@@ -6246,11 +6402,17 @@ index 00000000000..7bdaadef40d
 +	if (unlikely(!rng_initialised)) {
 +		ret = wolfssl_rng_initialize();
 +		if (ret != 0) {
-+			/* Already a negative errno (-ENODEV / -EIO); preserve it
-+			 * rather than collapsing every init failure to -EIO.
-+			 */
++			/* Already a negative errno; preserve it. */
 +			goto end;
 +		}
++	}
++
++	/* wc_RNG_GenerateBlock() takes a word32. Truncating here would fill
++	 * only part of the buffer and still report success.
++	 */
++	if (outlen > UINT32_MAX) {
++		ret = -EINVAL;
++		goto end;
 +	}
 +
 +	ret = wc_RNG_GenerateBlock(&rng_ctx, (byte *)dst, (word32)outlen);


### PR DESCRIPTION
Rebases the Zephyr 4.3 patches onto the 4.3.1 release, refreshes the 4.4 patches for 4.4.1, adds an optional mbedTLS-decoupling patch to both, and folds in a round of wolfSSL backend fixes.

### Patch set

Each release now ships three patches, all generated against the named release tag:

| Patch | Required | Purpose |
| --- | --- | --- |
| `zephyr-tls-<ver>.patch` | yes | Core wolfSSL backend: the BSD-sockets TLS layer and the RNG/CSPRNG |
| `zephyr-tls-<ver>-tests.patch` | no | Twister scenarios and the echo_server overlay; depends on the core patch |
| `zephyr-tls-<ver>-mbedtls-decoupling.patch` | no, new | Frees the subsystems that still hard-depend on mbedTLS but whose crypto already runs through PSA or the TLS socket layer, so an image using wolfSSL plus the wolfPSA PSA provider can drop `CONFIG_MBEDTLS` entirely |

### Backend fixes

In both releases unless noted.

**Peer identity.** `TLS_PEER_VERIFY_NONE` no longer fails a handshake on a certificate name mismatch, which made `NONE` stricter than `OPTIONAL`. Setting `TLS_HOSTNAME` validates the new value before replacing the configured one, so a rejected `setsockopt` no longer leaves the socket with no name check at all, and trailing NUL padding is trimmed. **On 4.4 only**, a client that never set `TLS_HOSTNAME` accepted a certificate issued for any name; it is now rejected, matching the mbedTLS backend, which sets an empty hostname precisely so that no certificate can match.

**Data path.** A zero-length `send()` no longer tears the session down and latches a sticky `ECONNABORTED` that killed every later send and recv on the socket. A clean close_notify, which wolfSSL reports as a `0` return rather than a negative one, is now recognised, so DTLS sessions are reclaimed instead of leaking until the timeout and `poll()` no longer blocks on a TLS half-close.

**Credentials.** The own certificate is installed with the chain variant, so intermediates in a concatenated credential reach the peer. The PSK identity is compared by its registered length rather than as a C string.

**Lifetimes.** Fixes a use-after-free tearing down a multi-session DTLS socket (4.4 only), a `WOLFSSL_METHOD` leak on DTLS reconnect, and the loss of an explicitly configured `TLS_DTLS_ROLE` on `connect()`.

**Secrets.** A partially serialized session is scrubbed before being freed, and the plaintext byte left on the stack by the poll probe is cleared.

**RNG.** The DRBG is seeded through `wc_InitRng_ex()` so it requests the full seed and derives its own nonce. The personalization string was being passed as the nonce, which shortened the entropy request and pinned the nonce to a build-time constant, while never reaching the personalization input.

**Build guards.** `CONFIG_WOLFSSL_CRYPTO_ONLY` and `NO_SESSION_CACHE` are rejected with a message naming the responsible option instead of a wall of link errors, and `CONFIG_WOLFSSL_SNI=n` now builds: the extension is not sent, but the certificate name check still runs.

### Tests

The tests patches add two peer-identity regression tests. Both pass on the wolfSSL **and** mbedTLS backends, so the parity is enforced rather than assumed.

### Verification

On `native_sim/native/64`:

- 4.4 wolfssl-tagged scenarios: 8/8 configurations, 94/94 test cases
- 4.4 shared TLS scenarios across both backends: 19/19 configurations, 422/422 test cases
- 4.3 `tests/net/socket/tls` and `tests/net/socket/tls_ext`: pass

Every patch applies to a pristine release tree with `git apply --whitespace=error-all`, standalone and stacked, and applying the full set reproduces the integration branch byte for byte.

### Notes for users

Both READMEs record the required wolfSSL revision, the module options the integration force-selects, and the one behaviour change worth knowing about: a client that does not set `TLS_HOSTNAME` is rejected under `TLS_PEER_VERIFY_REQUIRED`. Applications relying on the previous 4.4 behaviour should set `TLS_HOSTNAME`, or use `TLS_PEER_VERIFY_OPTIONAL` and read `TLS_CERT_VERIFY_RESULT`.

The 4.4 integration requires a wolfSSL newer than 5.9.2, since the Zephyr 4.4 module support landed after that tag in wolfSSL/wolfssl#10983. The 4.3 integration is satisfied by 5.9.2 itself.
