### PR TITLE
Make SE05x SCP03-only builds slimmer

### DIFF
--- a/nxp-se05x-middleware/README.md
+++ b/nxp-se05x-middleware/README.md
@@ -56,6 +56,17 @@ $ make
 $ sudo make install
 ```
 
+When `PTMW_SE05X_Auth=PlatfSCP03`, the patched wolfSSL HostCrypto backend is
+compiled in an SCP03-only mode. It keeps only the AES-CBC, CMAC, and RNG calls
+used by platform SCP03, so unused RSA, ECC, HMAC, digest, DES3, HKDF, and AEAD
+code is not pulled from a statically linked wolfSSL library. Combined
+authentication modes (for example `ECKey_PlatfSCP03`) retain the full backend
+because their non-platform authentication method needs additional algorithms.
+
+`--enable-cmac` is still required. `--enable-keygen` is not required by the
+SCP03-only middleware path itself, but remains necessary if the application
+uses wolfSSL key generation after the authenticated channel is established.
+
 Then, build SE05x Middleware:
 
 ```

--- a/nxp-se05x-middleware/simw-top-v040200.patch
+++ b/nxp-se05x-middleware/simw-top-v040200.patch
@@ -3023,7 +3023,7 @@ diff -Naur simw-top/sss/src/keystore/keystore_pc.c /home/pi/se_mw/simw-top/sss/s
 diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 --- simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	1969-12-31 17:00:00.000000000 -0700
 +++ /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	2022-11-11 10:27:06.335662156 -0700
-@@ -0,0 +1,3298 @@
+@@ -0,0 +1,3418 @@
 +/*
 + *
 + * Copyright 2018-2020 NXP
@@ -3059,6 +3059,38 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +#include <string.h>
 +
 +#include "nxLog_sss.h"
++
++#define SSS_WOLFSSL_SCP03_ONLY SSS_HAVE_SE05X_AUTH_PLATFSCP03
++
++/* A pure Platform SCP03 build only needs AES-CBC, CMAC and the RNG used to
++ * create the host challenge. Keep the complete SSS API surface available,
++ * but do not make the unused implementations reference other wolfCrypt
++ * algorithms. This is intentionally done after the wolfSSL headers have been
++ * included so the library configuration and public type layouts stay intact. */
++#if SSS_WOLFSSL_SCP03_ONLY
++    #undef SSSFTR_SW_ECC
++    #define SSSFTR_SW_ECC 0
++    #undef SSSFTR_SW_RSA
++    #define SSSFTR_SW_RSA 0
++    #ifndef NO_RSA
++        #define NO_RSA
++    #endif
++    #ifndef NO_HMAC
++        #define NO_HMAC
++    #endif
++    #ifndef NO_DES3
++        #define NO_DES3
++    #endif
++    #undef HAVE_ECC
++    #undef HAVE_CURVE25519
++    #undef HAVE_CURVE448
++    #undef HAVE_ED25519
++    #undef HAVE_HKDF
++    #undef HAVE_AESGCM
++    #undef WOLFSSL_AESGCM
++    #undef HAVE_AESCCM
++    #undef WOLFSSL_CCM
++#endif
 +
 +#define MAX_KEY_OBJ_COUNT KS_N_ENTIRES
 +#define MAX_FILE_NAME_SIZE 255
@@ -4474,6 +4506,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    uint8_t *destData, size_t *destLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    sss_wolfssl_object_t *keyObj = context->keyObject;
 +    int ret      = 0;
 +    int padding  = 0;
@@ -4506,6 +4539,13 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    }
 +
 +    wc_FreeRng(&rng);
++#else
++    (void)context;
++    (void)srcData;
++    (void)srcLen;
++    (void)destData;
++    (void)destLen;
++#endif
 +
 +    return retval;
 +}
@@ -4515,6 +4555,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    uint8_t *destData, size_t *destLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    sss_wolfssl_object_t *keyObj = context->keyObject;
 +    int ret     = 0;
 +    int padding = 0;
@@ -4539,6 +4580,13 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +        *destLen = ret;
 +        retval = kStatus_SSS_Success;
 +    }
++#else
++    (void)context;
++    (void)srcData;
++    (void)srcLen;
++    (void)destData;
++    (void)destLen;
++#endif
 +
 +    return retval;
 +}
@@ -4548,6 +4596,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    uint8_t *signature, size_t *signatureLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret      = 0;
 +    int padding  = 0;
 +    int mgf      = 0;
@@ -4637,6 +4686,13 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    }
 +
 +    wc_FreeRng(&rng);
++#else
++    (void)context;
++    (void)digest;
++    (void)digestLen;
++    (void)signature;
++    (void)signatureLen;
++#endif
 +
 +    return retval;
 +}
@@ -4646,6 +4702,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    uint8_t *signature, size_t signatureLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret      = 0;
 +    int padding  = 0;
 +    int mgf      = 0;
@@ -4746,6 +4803,13 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +            LOG_E("Unsupported cipherType for digest sign");
 +            break;
 +    }
++#else
++    (void)context;
++    (void)digest;
++    (void)digestLen;
++    (void)signature;
++    (void)signatureLen;
++#endif
 +
 +    return retval;
 +
@@ -5831,6 +5895,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +/* Functions : sss_wolfssl_md                                                 */
 +/* ************************************************************************** */
 +
++#if !SSS_WOLFSSL_SCP03_ONLY
 +sss_status_t sss_wolfssl_digest_context_init(
 +    sss_wolfssl_digest_t *context, sss_wolfssl_session_t *session,
 +    sss_algorithm_t algorithm, sss_mode_t mode)
@@ -6003,6 +6068,61 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    }
 +    memset(context, 0, sizeof(*context));
 +}
++#else
++sss_status_t sss_wolfssl_digest_context_init(
++    sss_wolfssl_digest_t *context, sss_wolfssl_session_t *session,
++    sss_algorithm_t algorithm, sss_mode_t mode)
++{
++    (void)context;
++    (void)session;
++    (void)algorithm;
++    (void)mode;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_one_go(
++    sss_wolfssl_digest_t *context, const uint8_t *message, size_t messageLen,
++    uint8_t *digest, size_t *digestLen)
++{
++    (void)context;
++    (void)message;
++    (void)messageLen;
++    (void)digest;
++    (void)digestLen;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_init(sss_wolfssl_digest_t *context)
++{
++    (void)context;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_update(sss_wolfssl_digest_t *context,
++    const uint8_t *message, size_t messageLen)
++{
++    (void)context;
++    (void)message;
++    (void)messageLen;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_finish(sss_wolfssl_digest_t *context,
++    uint8_t *digest, size_t *digestLen)
++{
++    (void)context;
++    (void)digest;
++    (void)digestLen;
++    return kStatus_SSS_Fail;
++}
++
++void sss_wolfssl_digest_context_free(sss_wolfssl_digest_t *context)
++{
++    if (context != NULL) {
++        memset(context, 0, sizeof(*context));
++    }
++}
++#endif /* !SSS_WOLFSSL_SCP03_ONLY */
 +
 +/* End: wolfssl_md */
 +

--- a/nxp-se05x-middleware/simw-top-v040200.patch
+++ b/nxp-se05x-middleware/simw-top-v040200.patch
@@ -3023,7 +3023,7 @@ diff -Naur simw-top/sss/src/keystore/keystore_pc.c /home/pi/se_mw/simw-top/sss/s
 diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 --- simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	1969-12-31 17:00:00.000000000 -0700
 +++ /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	2022-11-11 10:27:06.335662156 -0700
-@@ -0,0 +1,3418 @@
+@@ -0,0 +1,3423 @@
 +/*
 + *
 + * Copyright 2018-2020 NXP
@@ -3059,6 +3059,11 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +#include <string.h>
 +
 +#include "nxLog_sss.h"
++
++/* Record the Aes layout before SCP03-only pruning removes HAVE_AESGCM. */
++#if defined(WOLFSSL_SE050) && defined(HAVE_AESGCM)
++    #define SSS_WOLFSSL_AES_HAS_USESWCRYPT
++#endif
 +
 +#define SSS_WOLFSSL_SCP03_ONLY SSS_HAVE_SE05X_AUTH_PLATFSCP03
 +
@@ -4868,7 +4873,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +        case kAlgorithm_SSS_AES_CBC:
 +        case kAlgorithm_SSS_AES_CTR:
 +            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
-+        #ifdef WOLFSSL_SE050
++        #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +            if (ret == 0) {
 +                /* HostCrypto should use software crypto, not SE05x */
 +                aes.useSWCrypt = 1;
@@ -5148,7 +5153,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    if (context->algorithm == kAlgorithm_SSS_AES_GCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESGCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef WOLFSSL_SE050
++    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -5182,7 +5187,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    else if (context->algorithm == kAlgorithm_SSS_AES_CCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESCCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef WOLFSSL_SE050
++    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -5242,7 +5247,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
 +    ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef WOLFSSL_SE050
++    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +    if (ret == 0) {
 +        /* HostCrypto should use software crypto, not SE05x */
 +        context->aes->useSWCrypt = 1;

--- a/nxp-se05x-middleware/simw-top-v040200.patch
+++ b/nxp-se05x-middleware/simw-top-v040200.patch
@@ -3023,7 +3023,7 @@ diff -Naur simw-top/sss/src/keystore/keystore_pc.c /home/pi/se_mw/simw-top/sss/s
 diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 --- simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	1969-12-31 17:00:00.000000000 -0700
 +++ /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	2022-11-11 10:27:06.335662156 -0700
-@@ -0,0 +1,3423 @@
+@@ -0,0 +1,3429 @@
 +/*
 + *
 + * Copyright 2018-2020 NXP
@@ -3107,8 +3107,10 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +static sss_status_t sss_wolfssl_generate_rsa_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#ifdef HAVE_ECC
 +static sss_status_t sss_wolfssl_generate_ecc_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#endif
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
 +static sss_status_t sss_wolfssl_generate_ed_key(
@@ -4106,11 +4108,13 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +    switch (cipher_type) {
 +#if SSSFTR_SW_ECC
++#ifdef HAVE_ECC
 +        case kSSS_CipherType_EC_NIST_P:
 +        case kSSS_CipherType_EC_NIST_K:
 +        case kSSS_CipherType_EC_BRAINPOOL:
 +            retval = sss_wolfssl_generate_ecc_key(keyObject, keyBitLen);
 +            break;
++#endif
 +        case kSSS_CipherType_EC_MONTGOMERY:
 +            retval = sss_wolfssl_generate_ec_mont_key(keyObject, keyBitLen);
 +            break;
@@ -6201,6 +6205,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +/* ************************************************************************** */
 +/* Functions : Private sss wolfssl functions                                  */
 +/* ************************************************************************** */
++#ifdef HAVE_ECC
 +static sss_status_t sss_wolfssl_generate_ecc_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
 +{
@@ -6313,6 +6318,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +    return retval;
 +}
++#endif
 +
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen)

--- a/nxp-se05x-middleware/simw-top-v040200.patch
+++ b/nxp-se05x-middleware/simw-top-v040200.patch
@@ -3023,7 +3023,7 @@ diff -Naur simw-top/sss/src/keystore/keystore_pc.c /home/pi/se_mw/simw-top/sss/s
 diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 --- simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	1969-12-31 17:00:00.000000000 -0700
 +++ /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	2022-11-11 10:27:06.335662156 -0700
-@@ -0,0 +1,3429 @@
+@@ -0,0 +1,3447 @@
 +/*
 + *
 + * Copyright 2018-2020 NXP
@@ -3062,7 +3062,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +/* Record the Aes layout before SCP03-only pruning removes HAVE_AESGCM. */
 +#if defined(WOLFSSL_SE050) && defined(HAVE_AESGCM)
-+    #define SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #define SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +#endif
 +
 +#define SSS_WOLFSSL_SCP03_ONLY SSS_HAVE_SE05X_AUTH_PLATFSCP03
@@ -3105,16 +3105,20 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +/* Functions : Private sss wolfSSL declaration                                */
 +/* ************************************************************************** */
 +
++#if SSSFTR_SW_RSA
 +static sss_status_t sss_wolfssl_generate_rsa_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#endif
 +#ifdef HAVE_ECC
 +static sss_status_t sss_wolfssl_generate_ecc_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
 +#endif
++#if SSSFTR_SW_ECC
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
 +static sss_status_t sss_wolfssl_generate_ed_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#endif
 +
 +#ifndef NO_HMAC
 +static int sss_wolfssl_get_hmac_type_from_algo(int algo);
@@ -3721,7 +3725,9 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    sss_wolfssl_object_t *otherPartyKeyObject,
 +    sss_wolfssl_object_t *derivedKeyObject)
 +{
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret = 0;
++#endif
 +    sss_status_t retval = kStatus_SSS_Fail;
 +#ifdef HAVE_ECC
 +    ecc_key* ecKeyPrv = NULL;
@@ -3735,7 +3741,9 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +   curve448_key* keyPrv448 = NULL;
 +   curve448_key* keyExt448 = NULL;
 +#endif
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    size_t sharedSecretLen;
++#endif
 +    unsigned int sharedSecretLen_Derived;
 +    uint8_t *secret     = NULL;
 +
@@ -4142,7 +4150,9 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    size_t *pKeyBitLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret = 0;
++#endif
 +#ifndef NO_RSA
 +    RsaKey* rsaKey = NULL;
 +#endif
@@ -4877,7 +4887,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +        case kAlgorithm_SSS_AES_CBC:
 +        case kAlgorithm_SSS_AES_CTR:
 +            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
-+        #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++        #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +            if (ret == 0) {
 +                /* HostCrypto should use software crypto, not SE05x */
 +                aes.useSWCrypt = 1;
@@ -5140,7 +5150,9 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    size_t *tagLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret = 0;
++#endif
 +
 +    ENSURE_OR_GO_EXIT(context != NULL);
 +    if (size > 0) {
@@ -5157,7 +5169,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    if (context->algorithm == kAlgorithm_SSS_AES_GCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESGCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -5191,7 +5203,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    else if (context->algorithm == kAlgorithm_SSS_AES_CCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESCCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -5251,7 +5263,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
 +    ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +    if (ret == 0) {
 +        /* HostCrypto should use software crypto, not SE05x */
 +        context->aes->useSWCrypt = 1;
@@ -5593,7 +5605,9 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    uint8_t *mac, size_t *macLen)
 +{
 +    int ret = 0;
++#ifndef NO_HMAC
 +    int hashType;
++#endif
 +    unsigned int outSz;
 +    sss_status_t retval = kStatus_SSS_Fail;
 +
@@ -6320,6 +6334,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +}
 +#endif
 +
++#if SSSFTR_SW_ECC
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
 +{
@@ -6414,7 +6429,9 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +    return retval;
 +}
++#endif
 +
++#if SSSFTR_SW_RSA
 +#ifdef _MSC_VER
 +#pragma warning(disable : 4127)
 +#endif
@@ -6451,6 +6468,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +
 +    return retval;
 +}
++#endif
 +
 +#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */
 diff -Naur simw-top/sss/sssAkmLists.mk /home/pi/se_mw/simw-top/sss/sssAkmLists.mk

--- a/nxp-se05x-middleware/simw-top-v040200.patch
+++ b/nxp-se05x-middleware/simw-top-v040200.patch
@@ -3023,7 +3023,7 @@ diff -Naur simw-top/sss/src/keystore/keystore_pc.c /home/pi/se_mw/simw-top/sss/s
 diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 --- simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	1969-12-31 17:00:00.000000000 -0700
 +++ /home/pi/se_mw/simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c	2022-11-11 10:27:06.335662156 -0700
-@@ -0,0 +1,3447 @@
+@@ -0,0 +1,3456 @@
 +/*
 + *
 + * Copyright 2018-2020 NXP
@@ -3091,6 +3091,8 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    #undef HAVE_CURVE448
 +    #undef HAVE_ED25519
 +    #undef HAVE_HKDF
++    #undef HAVE_AES_ECB
++    #undef WOLFSSL_AES_COUNTER
 +    #undef HAVE_AESGCM
 +    #undef WOLFSSL_AESGCM
 +    #undef HAVE_AESCCM
@@ -3717,6 +3719,7 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +    }
 +#else
 +    LOG_E("wolfSSL not compiled with HAVE_HKDF");
++    retval = kStatus_SSS_Fail;
 +#endif /* HAVE_HKDF */
 +    return retval;
 +}
@@ -4878,6 +4881,12 @@ diff -Naur simw-top/sss/src/wolfssl/fsl_sss_wolfssl_apis.c /home/pi/se_mw/simw-t
 +#ifndef NO_DES3
 +    Des  des;
 +    Des3 des3;
++#endif
++
++#if SSS_WOLFSSL_SCP03_ONLY
++    if (context->algorithm != kAlgorithm_SSS_AES_CBC) {
++        return retval;
++    }
 +#endif
 +
 +    /* Set encrypt/decrypt key */

--- a/nxp-se05x-middleware/simw-top-v040701.patch
+++ b/nxp-se05x-middleware/simw-top-v040701.patch
@@ -5182,7 +5182,7 @@ new file mode 100644
 index 0000000..5a9aa2d
 --- /dev/null
 +++ b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
-@@ -0,0 +1,3304 @@
+@@ -0,0 +1,3424 @@
 +/*
 + *
 + * Copyright 2018-2025 NXP
@@ -5218,6 +5218,38 @@ index 0000000..5a9aa2d
 +#include <string.h>
 +
 +#include "nxLog_sss.h"
++
++#define SSS_WOLFSSL_SCP03_ONLY SSS_HAVE_SE05X_AUTH_PLATFSCP03
++
++/* A pure Platform SCP03 build only needs AES-CBC, CMAC and the RNG used to
++ * create the host challenge. Keep the complete SSS API surface available,
++ * but do not make the unused implementations reference other wolfCrypt
++ * algorithms. This is intentionally done after the wolfSSL headers have been
++ * included so the library configuration and public type layouts stay intact. */
++#if SSS_WOLFSSL_SCP03_ONLY
++    #undef SSSFTR_SW_ECC
++    #define SSSFTR_SW_ECC 0
++    #undef SSSFTR_SW_RSA
++    #define SSSFTR_SW_RSA 0
++    #ifndef NO_RSA
++        #define NO_RSA
++    #endif
++    #ifndef NO_HMAC
++        #define NO_HMAC
++    #endif
++    #ifndef NO_DES3
++        #define NO_DES3
++    #endif
++    #undef HAVE_ECC
++    #undef HAVE_CURVE25519
++    #undef HAVE_CURVE448
++    #undef HAVE_ED25519
++    #undef HAVE_HKDF
++    #undef HAVE_AESGCM
++    #undef WOLFSSL_AESGCM
++    #undef HAVE_AESCCM
++    #undef WOLFSSL_CCM
++#endif
 +
 +#define MAX_KEY_OBJ_COUNT KS_N_ENTIRES
 +#define MAX_FILE_NAME_SIZE 255
@@ -6633,6 +6665,7 @@ index 0000000..5a9aa2d
 +    uint8_t *destData, size_t *destLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    sss_wolfssl_object_t *keyObj = context->keyObject;
 +    int ret      = 0;
 +    int padding  = 0;
@@ -6665,6 +6698,13 @@ index 0000000..5a9aa2d
 +    }
 +
 +    wc_FreeRng(&rng);
++#else
++    (void)context;
++    (void)srcData;
++    (void)srcLen;
++    (void)destData;
++    (void)destLen;
++#endif
 +
 +    return retval;
 +}
@@ -6674,6 +6714,7 @@ index 0000000..5a9aa2d
 +    uint8_t *destData, size_t *destLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    sss_wolfssl_object_t *keyObj = context->keyObject;
 +    int ret     = 0;
 +    int padding = 0;
@@ -6698,6 +6739,13 @@ index 0000000..5a9aa2d
 +        *destLen = ret;
 +        retval = kStatus_SSS_Success;
 +    }
++#else
++    (void)context;
++    (void)srcData;
++    (void)srcLen;
++    (void)destData;
++    (void)destLen;
++#endif
 +
 +    return retval;
 +}
@@ -6707,6 +6755,7 @@ index 0000000..5a9aa2d
 +    uint8_t *signature, size_t *signatureLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret      = 0;
 +    int padding  = 0;
 +    int mgf      = 0;
@@ -6800,6 +6849,13 @@ index 0000000..5a9aa2d
 +    }
 +
 +    wc_FreeRng(&rng);
++#else
++    (void)context;
++    (void)digest;
++    (void)digestLen;
++    (void)signature;
++    (void)signatureLen;
++#endif
 +
 +    return retval;
 +}
@@ -6809,6 +6865,7 @@ index 0000000..5a9aa2d
 +    uint8_t *signature, size_t signatureLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret      = 0;
 +    int padding  = 0;
 +    int mgf      = 0;
@@ -6909,6 +6966,13 @@ index 0000000..5a9aa2d
 +            LOG_E("Unsupported cipherType for digest sign");
 +            break;
 +    }
++#else
++    (void)context;
++    (void)digest;
++    (void)digestLen;
++    (void)signature;
++    (void)signatureLen;
++#endif
 +
 +    return retval;
 +
@@ -7996,6 +8060,7 @@ index 0000000..5a9aa2d
 +/* Functions : sss_wolfssl_md                                                 */
 +/* ************************************************************************** */
 +
++#if !SSS_WOLFSSL_SCP03_ONLY
 +sss_status_t sss_wolfssl_digest_context_init(
 +    sss_wolfssl_digest_t *context, sss_wolfssl_session_t *session,
 +    sss_algorithm_t algorithm, sss_mode_t mode)
@@ -8168,6 +8233,61 @@ index 0000000..5a9aa2d
 +    }
 +    memset(context, 0, sizeof(*context));
 +}
++#else
++sss_status_t sss_wolfssl_digest_context_init(
++    sss_wolfssl_digest_t *context, sss_wolfssl_session_t *session,
++    sss_algorithm_t algorithm, sss_mode_t mode)
++{
++    (void)context;
++    (void)session;
++    (void)algorithm;
++    (void)mode;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_one_go(
++    sss_wolfssl_digest_t *context, const uint8_t *message, size_t messageLen,
++    uint8_t *digest, size_t *digestLen)
++{
++    (void)context;
++    (void)message;
++    (void)messageLen;
++    (void)digest;
++    (void)digestLen;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_init(sss_wolfssl_digest_t *context)
++{
++    (void)context;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_update(sss_wolfssl_digest_t *context,
++    const uint8_t *message, size_t messageLen)
++{
++    (void)context;
++    (void)message;
++    (void)messageLen;
++    return kStatus_SSS_Fail;
++}
++
++sss_status_t sss_wolfssl_digest_finish(sss_wolfssl_digest_t *context,
++    uint8_t *digest, size_t *digestLen)
++{
++    (void)context;
++    (void)digest;
++    (void)digestLen;
++    return kStatus_SSS_Fail;
++}
++
++void sss_wolfssl_digest_context_free(sss_wolfssl_digest_t *context)
++{
++    if (context != NULL) {
++        memset(context, 0, sizeof(*context));
++    }
++}
++#endif /* !SSS_WOLFSSL_SCP03_ONLY */
 +
 +/* End: wolfssl_md */
 +

--- a/nxp-se05x-middleware/simw-top-v040701.patch
+++ b/nxp-se05x-middleware/simw-top-v040701.patch
@@ -5179,10 +5179,10 @@ index 0000000..80a44f4
 +#endif /* SSS_APIS_INC_FSL_SSS_WOLFSSL_TYPES_H_ */
 diff --git a/sss/src/wolfssl/fsl_sss_wolfssl_apis.c b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 new file mode 100644
-index 0000000..5a9aa2d
+index 0000000..d1d1a78
 --- /dev/null
 +++ b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
-@@ -0,0 +1,3424 @@
+@@ -0,0 +1,3429 @@
 +/*
 + *
 + * Copyright 2018-2025 NXP
@@ -5218,6 +5218,11 @@ index 0000000..5a9aa2d
 +#include <string.h>
 +
 +#include "nxLog_sss.h"
++
++/* Record the Aes layout before SCP03-only pruning removes HAVE_AESGCM. */
++#if defined(WOLFSSL_SE050) && defined(HAVE_AESGCM)
++    #define SSS_WOLFSSL_AES_HAS_USESWCRYPT
++#endif
 +
 +#define SSS_WOLFSSL_SCP03_ONLY SSS_HAVE_SE05X_AUTH_PLATFSCP03
 +
@@ -7031,7 +7036,7 @@ index 0000000..5a9aa2d
 +        case kAlgorithm_SSS_AES_CBC:
 +        case kAlgorithm_SSS_AES_CTR:
 +            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
-+        #ifdef WOLFSSL_SE050
++        #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +            if (ret == 0) {
 +                /* HostCrypto should use software crypto, not SE05x */
 +                aes.useSWCrypt = 1;
@@ -7311,7 +7316,7 @@ index 0000000..5a9aa2d
 +    if (context->algorithm == kAlgorithm_SSS_AES_GCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESGCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef WOLFSSL_SE050
++    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -7345,7 +7350,7 @@ index 0000000..5a9aa2d
 +    else if (context->algorithm == kAlgorithm_SSS_AES_CCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESCCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef WOLFSSL_SE050
++    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -7405,7 +7410,7 @@ index 0000000..5a9aa2d
 +
 +#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
 +    ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef WOLFSSL_SE050
++    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
 +    if (ret == 0) {
 +        /* HostCrypto should use software crypto, not SE05x */
 +        context->aes->useSWCrypt = 1;

--- a/nxp-se05x-middleware/simw-top-v040701.patch
+++ b/nxp-se05x-middleware/simw-top-v040701.patch
@@ -5179,10 +5179,10 @@ index 0000000..80a44f4
 +#endif /* SSS_APIS_INC_FSL_SSS_WOLFSSL_TYPES_H_ */
 diff --git a/sss/src/wolfssl/fsl_sss_wolfssl_apis.c b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 new file mode 100644
-index 0000000..d1d1a78
+index 0000000..bc3b972
 --- /dev/null
 +++ b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
-@@ -0,0 +1,3435 @@
+@@ -0,0 +1,3453 @@
 +/*
 + *
 + * Copyright 2018-2025 NXP
@@ -5221,7 +5221,7 @@ index 0000000..d1d1a78
 +
 +/* Record the Aes layout before SCP03-only pruning removes HAVE_AESGCM. */
 +#if defined(WOLFSSL_SE050) && defined(HAVE_AESGCM)
-+    #define SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #define SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +#endif
 +
 +#define SSS_WOLFSSL_SCP03_ONLY SSS_HAVE_SE05X_AUTH_PLATFSCP03
@@ -5264,16 +5264,20 @@ index 0000000..d1d1a78
 +/* Functions : Private sss wolfSSL declaration                                */
 +/* ************************************************************************** */
 +
++#if SSSFTR_SW_RSA
 +static sss_status_t sss_wolfssl_generate_rsa_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#endif
 +#ifdef HAVE_ECC
 +static sss_status_t sss_wolfssl_generate_ecc_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
 +#endif
++#if SSSFTR_SW_ECC
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
 +static sss_status_t sss_wolfssl_generate_ed_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#endif
 +
 +#ifndef NO_HMAC
 +static int sss_wolfssl_get_hmac_type_from_algo(int algo);
@@ -5880,7 +5884,9 @@ index 0000000..d1d1a78
 +    sss_wolfssl_object_t *otherPartyKeyObject,
 +    sss_wolfssl_object_t *derivedKeyObject)
 +{
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret = 0;
++#endif
 +    sss_status_t retval = kStatus_SSS_Fail;
 +#ifdef HAVE_ECC
 +    ecc_key* ecKeyPrv = NULL;
@@ -5894,7 +5900,9 @@ index 0000000..d1d1a78
 +   curve448_key* keyPrv448 = NULL;
 +   curve448_key* keyExt448 = NULL;
 +#endif
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    size_t sharedSecretLen;
++#endif
 +    unsigned int sharedSecretLen_Derived;
 +    uint8_t *secret     = NULL;
 +
@@ -6301,7 +6309,9 @@ index 0000000..d1d1a78
 +    size_t *pKeyBitLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret = 0;
++#endif
 +#ifndef NO_RSA
 +    RsaKey* rsaKey = NULL;
 +#endif
@@ -7040,7 +7050,7 @@ index 0000000..d1d1a78
 +        case kAlgorithm_SSS_AES_CBC:
 +        case kAlgorithm_SSS_AES_CTR:
 +            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
-+        #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++        #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +            if (ret == 0) {
 +                /* HostCrypto should use software crypto, not SE05x */
 +                aes.useSWCrypt = 1;
@@ -7303,7 +7313,9 @@ index 0000000..d1d1a78
 +    size_t *tagLen)
 +{
 +    sss_status_t retval = kStatus_SSS_Fail;
++#if !SSS_WOLFSSL_SCP03_ONLY
 +    int ret = 0;
++#endif
 +
 +    ENSURE_OR_GO_EXIT(context != NULL);
 +    if (size > 0) {
@@ -7320,7 +7332,7 @@ index 0000000..d1d1a78
 +    if (context->algorithm == kAlgorithm_SSS_AES_GCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESGCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -7354,7 +7366,7 @@ index 0000000..d1d1a78
 +    else if (context->algorithm == kAlgorithm_SSS_AES_CCM) {
 +#if !defined(NO_AES) && defined(HAVE_AESCCM)
 +        ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +        if (ret == 0) {
 +            /* HostCrypto should use software crypto, not SE05x */
 +            context->aes->useSWCrypt = 1;
@@ -7414,7 +7426,7 @@ index 0000000..d1d1a78
 +
 +#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
 +    ret = wc_AesInit(context->aes, NULL, INVALID_DEVID);
-+    #ifdef SSS_WOLFSSL_AES_HAS_USESWCRYPT
++    #ifdef SSS_WOLFSSL_AES_HAS_SE050_FIELDS
 +    if (ret == 0) {
 +        /* HostCrypto should use software crypto, not SE05x */
 +        context->aes->useSWCrypt = 1;
@@ -7756,7 +7768,9 @@ index 0000000..d1d1a78
 +    uint8_t *mac, size_t *macLen)
 +{
 +    int ret = 0;
++#ifndef NO_HMAC
 +    int hashType;
++#endif
 +    unsigned int outSz;
 +    sss_status_t retval = kStatus_SSS_Fail;
 +
@@ -8485,6 +8499,7 @@ index 0000000..d1d1a78
 +}
 +#endif
 +
++#if SSSFTR_SW_ECC
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
 +{
@@ -8579,7 +8594,9 @@ index 0000000..d1d1a78
 +
 +    return retval;
 +}
++#endif
 +
++#if SSSFTR_SW_RSA
 +#ifdef _MSC_VER
 +#pragma warning(disable : 4127)
 +#endif
@@ -8616,5 +8633,6 @@ index 0000000..d1d1a78
 +
 +    return retval;
 +}
++#endif
 +
 +#endif /* SSS_HAVE_HOSTCRYPTO_WOLFSSL */

--- a/nxp-se05x-middleware/simw-top-v040701.patch
+++ b/nxp-se05x-middleware/simw-top-v040701.patch
@@ -5179,10 +5179,10 @@ index 0000000..80a44f4
 +#endif /* SSS_APIS_INC_FSL_SSS_WOLFSSL_TYPES_H_ */
 diff --git a/sss/src/wolfssl/fsl_sss_wolfssl_apis.c b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
 new file mode 100644
-index 0000000..bc3b972
+index 0000000..f24658e
 --- /dev/null
 +++ b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
-@@ -0,0 +1,3453 @@
+@@ -0,0 +1,3462 @@
 +/*
 + *
 + * Copyright 2018-2025 NXP
@@ -5250,6 +5250,8 @@ index 0000000..bc3b972
 +    #undef HAVE_CURVE448
 +    #undef HAVE_ED25519
 +    #undef HAVE_HKDF
++    #undef HAVE_AES_ECB
++    #undef WOLFSSL_AES_COUNTER
 +    #undef HAVE_AESGCM
 +    #undef WOLFSSL_AESGCM
 +    #undef HAVE_AESCCM
@@ -5876,6 +5878,7 @@ index 0000000..bc3b972
 +    }
 +#else
 +    LOG_E("wolfSSL not compiled with HAVE_HKDF");
++    retval = kStatus_SSS_Fail;
 +#endif /* HAVE_HKDF */
 +    return retval;
 +}
@@ -7041,6 +7044,12 @@ index 0000000..bc3b972
 +#ifndef NO_DES3
 +    Des  des;
 +    Des3 des3;
++#endif
++
++#if SSS_WOLFSSL_SCP03_ONLY
++    if (context->algorithm != kAlgorithm_SSS_AES_CBC) {
++        return retval;
++    }
 +#endif
 +
 +    /* Set encrypt/decrypt key */

--- a/nxp-se05x-middleware/simw-top-v040701.patch
+++ b/nxp-se05x-middleware/simw-top-v040701.patch
@@ -5182,7 +5182,7 @@ new file mode 100644
 index 0000000..d1d1a78
 --- /dev/null
 +++ b/sss/src/wolfssl/fsl_sss_wolfssl_apis.c
-@@ -0,0 +1,3429 @@
+@@ -0,0 +1,3435 @@
 +/*
 + *
 + * Copyright 2018-2025 NXP
@@ -5266,8 +5266,10 @@ index 0000000..d1d1a78
 +
 +static sss_status_t sss_wolfssl_generate_rsa_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#ifdef HAVE_ECC
 +static sss_status_t sss_wolfssl_generate_ecc_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
++#endif
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen);
 +static sss_status_t sss_wolfssl_generate_ed_key(
@@ -6265,11 +6267,13 @@ index 0000000..d1d1a78
 +
 +    switch (cipher_type) {
 +#if SSSFTR_SW_ECC
++#ifdef HAVE_ECC
 +        case kSSS_CipherType_EC_NIST_P:
 +        case kSSS_CipherType_EC_NIST_K:
 +        case kSSS_CipherType_EC_BRAINPOOL:
 +            retval = sss_wolfssl_generate_ecc_key(keyObject, keyBitLen);
 +            break;
++#endif
 +        case kSSS_CipherType_EC_MONTGOMERY:
 +            retval = sss_wolfssl_generate_ec_mont_key(keyObject, keyBitLen);
 +            break;
@@ -8366,6 +8370,7 @@ index 0000000..d1d1a78
 +/* ************************************************************************** */
 +/* Functions : Private sss wolfssl functions                                  */
 +/* ************************************************************************** */
++#ifdef HAVE_ECC
 +static sss_status_t sss_wolfssl_generate_ecc_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen)
 +{
@@ -8478,6 +8483,7 @@ index 0000000..d1d1a78
 +
 +    return retval;
 +}
++#endif
 +
 +static sss_status_t sss_wolfssl_generate_ec_mont_key(
 +    sss_wolfssl_object_t *keyObject, size_t keyBitLen)


### PR DESCRIPTION
SCP03-only builds only need AES-CBC, AES-CMAC and RNG. This path reduces those builds to those algorithms. In testing on our Docker builds this reduced the binary from 423K to 165K.