### PR TITLE
Fix ntp 4.2.8p18 patch for wolfSSL support

### DIFF
--- a/ntp/4.2.8p18/README.md
+++ b/ntp/4.2.8p18/README.md
@@ -1,7 +1,7 @@
 ## Build Instructions
 
 ### Build wolfSSL
-+ Configure wolfSSL with `./configure --enable-ntp`. Add `--enable-debug` if you want to enable the debug version of wolfSSL.
++ Configure wolfSSL with `./configure --enable-ntp CFLAGS="-DOPENSSL_EXTRA_BSD"`. NTP uses `MD5Init`/`MD5Update`/`MD5Final`, which wolfSSL only provides under `OPENSSL_EXTRA_BSD`. Add `--enable-debug` if you want to enable the debug version of wolfSSL.
 + Compile with `make`.
 + Install wolfSSL into /usr/local with `sudo make install`.
 

--- a/ntp/4.2.8p18/ntp-4.2.8p18.patch
+++ b/ntp/4.2.8p18/ntp-4.2.8p18.patch
@@ -1,7 +1,7 @@
-From bea7911a7a7179bb82632cee4a84a6f8d3655a16 Mon Sep 17 00:00:00 2001
+From ed5858f50be0778d7c9e049c8829bbfca8cc92f3 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
-Date: Tue, 18 Aug 2026 23:43:51 +0000
-Subject: [PATCH] Update ntp 4.2.8p18 patch for wolfSSL
+Date: Wed, 19 Aug 2026 16:17:18 +0000
+Subject: [PATCH] Fix ntp 4.2.8p18 patch for wolfSSL
 
 ---
  configure.ac                      |  4 +++
@@ -23,7 +23,7 @@ Subject: [PATCH] Update ntp 4.2.8p18 patch for wolfSSL
  create mode 100644 sntp/m4/ntp_wolfssl.m4
 
 diff --git a/configure.ac b/configure.ac
-index aef7053..1262795 100644
+index aef7053..a6d3b65 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -117,6 +117,8 @@ LIBOPTS_CHECK_NOBUILD([sntp/libopts])
@@ -39,7 +39,7 @@ index aef7053..1262795 100644
  esac
  AC_MSG_RESULT([$ans])
  
-+if test $USE_WOLFSSL = no; then
++if test "x$USE_WOLFSSL" = xno; then
  # if we have crypto, by default Autokey is enabled
  AC_ARG_ENABLE(
      [autokey],
@@ -283,14 +283,14 @@ index 1be2ea3..db1f302 100644
  #	    endif
  		/* [Bug 3457] DON'T use plain EVP_DigestInit! It would
 diff --git a/sntp/m4/ntp_libntp.m4 b/sntp/m4/ntp_libntp.m4
-index e0cc216..e63a33a 100644
+index e0cc216..d11f956 100644
 --- a/sntp/m4/ntp_libntp.m4
 +++ b/sntp/m4/ntp_libntp.m4
 @@ -1123,8 +1123,10 @@ dnl build from tarball.  It's only useful when modifying libntp source code
  dnl and rebuilding in a client subdir rather than the whole package.
  AM_CONDITIONAL([LIBNTP_SUBMAKES], [test x"$enable_dependency_tracking" = x"yes"])
  
-+if test $USE_WOLFSSL = no; then
++if test "x$USE_WOLFSSL" = xno; then
  NTP_OPENSSL
  NTP_CRYPTO_RAND
 +fi
@@ -299,7 +299,7 @@ index e0cc216..e63a33a 100644
  LDADD_LIBNTP="$LDADD_LIBNTP $LIBS"
 diff --git a/sntp/m4/ntp_wolfssl.m4 b/sntp/m4/ntp_wolfssl.m4
 new file mode 100644
-index 0000000..0f5da10
+index 0000000..f8d4de2
 --- /dev/null
 +++ b/sntp/m4/ntp_wolfssl.m4
 @@ -0,0 +1,58 @@
@@ -335,7 +335,7 @@ index 0000000..0f5da10
 +    USE_WOLFSSL=yes
 +],[USE_WOLFSSL=no])
 +
-+if test $USE_WOLFSSL = yes; then
++if test "x$USE_WOLFSSL" = xyes; then
 +    SAVED_CFLAGS=$CFLAGS
 +    CFLAGS="$CFLAGS $CPPFLAGS_NTP"
 +    AC_CHECK_HEADER([wolfssl/options.h])

--- a/ntp/4.2.8p18/ntp-4.2.8p18.patch
+++ b/ntp/4.2.8p18/ntp-4.2.8p18.patch
@@ -1,93 +1,78 @@
-From 66cb95ad98247b1ea8073986847fc4d9a3a9b783 Mon Sep 17 00:00:00 2001
+From bea7911a7a7179bb82632cee4a84a6f8d3655a16 Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
-Date: Fri, 20 Feb 2026 19:02:02 +0100
-Subject: [PATCH] Patch for wolfSSL
+Date: Tue, 18 Aug 2026 23:43:51 +0000
+Subject: [PATCH] Update ntp 4.2.8p18 patch for wolfSSL
 
 ---
- configure.ac                      | 60 ++++++++++++++++---------------
- include/ntp_md5.h                 |  8 +++--
+ configure.ac                      |  4 +++
+ include/libssl_compat.h           |  4 +++
+ include/ntp_md5.h                 |  6 ++--
  libntp/lib/isc/include/isc/util.h |  2 +-
  libntp/lib/isc/lib.c              |  2 +-
  libntp/lib/isc/sockaddr.c         |  6 ++--
- libntp/ssl_init.c                 |  4 ---
+ libntp/libssl_compat.c            |  3 ++
+ libntp/ssl_init.c                 |  8 ++---
  ntpd/ntp_crypto.c                 | 11 +++++-
+ ntpq/ntpq.c                       |  4 +--
  sntp/configure.ac                 |  2 ++
+ sntp/crypto.c                     |  2 +-
+ sntp/m4/ntp_libntp.m4             |  2 ++
+ sntp/m4/ntp_wolfssl.m4            | 58 +++++++++++++++++++++++++++++++
  util/ntp-keygen.c                 | 22 ++++++++++--
- 9 files changed, 74 insertions(+), 43 deletions(-)
+ 15 files changed, 117 insertions(+), 19 deletions(-)
+ create mode 100644 sntp/m4/ntp_wolfssl.m4
 
 diff --git a/configure.ac b/configure.ac
-index aef7053..de9e789 100644
+index aef7053..1262795 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3008,34 +3008,38 @@ case "$ntp_libparse" in
+@@ -117,6 +117,8 @@ LIBOPTS_CHECK_NOBUILD([sntp/libopts])
+ 
+ NTP_LIBEVENT_CHECK_NOBUILD([2], [sntp/libevent])
+ 
++NTP_WOLFSSL
++
+ NTP_LIBNTP
+ 
+ dnl  we need to check for cross compile tools for vxWorks here
+@@ -3008,6 +3010,7 @@ case "$ntp_libparse" in
  esac
  AC_MSG_RESULT([$ans])
  
--# if we have crypto, by default Autokey is enabled
--AC_ARG_ENABLE(
--    [autokey],
--    AS_HELP_STRING(
--	[--enable-autokey],
--	[+ support NTP Autokey protocol]
--	),
--    [ntp_autokey=$enableval],
--    [ntp_autokey=$ntp_openssl]
--)
--case "$ntp_autokey" in
-- no)
--    ;;
-- *)
--    case "$ntp_openssl" in
--     no)
--	AC_MSG_WARN([Disabling Autokey, crypto unavailable.])
--	ntp_autokey=no
--	;;
--     *)
--	AC_DEFINE([AUTOKEY], [1], [Support NTP Autokey protocol?])
--	ntp_autokey=yes
--	;;
--    esac
--    ;;
--esac
--AC_MSG_CHECKING([if NTP Autokey protocol will be supported])
--AC_MSG_RESULT([$ntp_autokey])
-+NTP_WOLFSSL
-+
 +if test $USE_WOLFSSL = no; then
-+	# if we have crypto, by default Autokey is enabled
-+	AC_ARG_ENABLE(
-+	    [autokey],
-+	    AS_HELP_STRING(
-+		[--enable-autokey],
-+		[+ support NTP Autokey protocol]
-+		),
-+	    [ntp_autokey=$enableval],
-+	    [ntp_autokey=$ntp_openssl]
-+	)
-+	case "$ntp_autokey" in
-+	 no)
-+	    ;;
-+	 *)
-+	    case "$ntp_openssl" in
-+	     no)
-+		AC_MSG_WARN([Disabling Autokey, crypto unavailable.])
-+		ntp_autokey=no
-+		;;
-+	     *)
-+		AC_DEFINE([AUTOKEY], [1], [Support NTP Autokey protocol?])
-+		ntp_autokey=yes
-+		;;
-+	    esac
-+	    ;;
-+	esac
-+	AC_MSG_CHECKING([if NTP Autokey protocol will be supported])
-+	AC_MSG_RESULT([$ntp_autokey])
+ # if we have crypto, by default Autokey is enabled
+ AC_ARG_ENABLE(
+     [autokey],
+@@ -3036,6 +3039,7 @@ case "$ntp_autokey" in
+ esac
+ AC_MSG_CHECKING([if NTP Autokey protocol will be supported])
+ AC_MSG_RESULT([$ntp_autokey])
 +fi
  
  AC_SUBST([MAKE_CHECK_LAYOUT])
  AC_MSG_CHECKING([if we want to run check-layout])
+diff --git a/include/libssl_compat.h b/include/libssl_compat.h
+index 2a3697c..2964515 100644
+--- a/include/libssl_compat.h
++++ b/include/libssl_compat.h
+@@ -20,6 +20,8 @@
+ #ifndef NTP_LIBSSL_COMPAT_H
+ #define NTP_LIBSSL_COMPAT_H
+ 
++#ifndef WITH_WOLFSSL
++
+ #include "openssl/evp.h"
+ #include "openssl/dsa.h"
+ #include "openssl/rsa.h"
+@@ -116,4 +118,6 @@ extern int	sslshim_X509_get_signature_nid(const X509 *x);
+ #endif /* OPENSSL_VERSION_NUMBER < v1.1.0 */
+ /* ----------------------------------------------------------------- */
+ 
++#endif /* !WITH_WOLFSSL */
++
+ #endif /* NTP_LIBSSL_COMPAT_H */
 diff --git a/include/ntp_md5.h b/include/ntp_md5.h
-index 22caff3..0e12bf5 100644
+index 22caff3..fc2b6a8 100644
 --- a/include/ntp_md5.h
 +++ b/include/ntp_md5.h
 @@ -7,6 +7,7 @@
@@ -98,7 +83,7 @@ index 22caff3..0e12bf5 100644
  # if defined HAVE_MD5_H && defined HAVE_MD5INIT
  #  include <md5.h>
  # else
-@@ -17,18 +18,19 @@
+@@ -17,17 +18,18 @@
  #  define MD5Update(c, p, s)	isc_md5_update(c, (const void *)p, s)
  #  define MD5Final(d, c)	isc_md5_final((c), (d))	/* swapped */
  # endif
@@ -115,12 +100,10 @@ index 22caff3..0e12bf5 100644
  #  define CMAC                  "AES128CMAC"
  #  define AES_128_KEY_SIZE      16
 -# endif /*HAVE_OPENSSL_CMAC_H*/
--#else	/* !OPENSSL follows */
 +# endif /* HAVE_OPENSSL_CMAC_H || (WITH_WOLFSSL && WOLFSSL_CMAC) */
-+#else /* !OPENSSL follows */
+ #else	/* !OPENSSL follows */
  /*
   * Provide OpenSSL-alike MD5 API if we're not using OpenSSL
-  */
 diff --git a/libntp/lib/isc/include/isc/util.h b/libntp/lib/isc/include/isc/util.h
 index 670b28b..96b35c0 100644
 --- a/libntp/lib/isc/include/isc/util.h
@@ -178,10 +161,42 @@ index c6932d4..b7184f0 100644
  			    "%s: %d",
  			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKADDR,
  					   ISC_MSG_UNKNOWNFAMILY,
+diff --git a/libntp/libssl_compat.c b/libntp/libssl_compat.c
+index 5527682..3a3ab79 100644
+--- a/libntp/libssl_compat.c
++++ b/libntp/libssl_compat.c
+@@ -17,6 +17,7 @@
+ #include "config.h"
+ #include "ntp_types.h"
+ 
++#ifndef WITH_WOLFSSL
+ /* ----------------------------------------------------------------- */
+ #ifdef OPENSSL
+ # include <string.h>
+@@ -339,3 +340,5 @@ NONEMPTY_TRANSLATION_UNIT
+ /* ----------------------------------------------------------------- */
+ #endif
+ /* ----------------------------------------------------------------- */
++
++#endif /* !WITH_WOLFSSL */
 diff --git a/libntp/ssl_init.c b/libntp/ssl_init.c
-index 6de8a0b..7756b79 100644
+index 6de8a0b..03e8794 100644
 --- a/libntp/ssl_init.c
 +++ b/libntp/ssl_init.c
+@@ -18,11 +18,11 @@
+ # include <openssl/evp.h>
+ # include <openssl/opensslv.h>
+ # include "libssl_compat.h"
+-# ifdef HAVE_OPENSSL_CMAC_H
++# if defined(HAVE_OPENSSL_CMAC_H) || (defined(WITH_WOLFSSL) && defined(WOLFSSL_CMAC))
+ #  include <openssl/cmac.h>
+ #  define CMAC_LENGTH	16
+ #  define CMAC		"AES128CMAC"
+-# endif /*HAVE_OPENSSL_CMAC_H*/
++# endif /* HAVE_OPENSSL_CMAC_H || (WITH_WOLFSSL && WOLFSSL_CMAC) */
+ 
+ EVP_MD_CTX *digest_ctx;
+ 
 @@ -134,10 +134,6 @@ keytype_from_text(
  	key_type = 0;
  #endif
@@ -224,19 +239,128 @@ index 38a62fd..6b44637 100644
  			/* fall through */
  		default:
  			DPRINTF(1, ("cert_parse: %s\n",
+diff --git a/ntpq/ntpq.c b/ntpq/ntpq.c
+index 56ff4e5..92623c0 100644
+--- a/ntpq/ntpq.c
++++ b/ntpq/ntpq.c
+@@ -41,10 +41,10 @@
+ #  endif
+ # endif
+ # include "libssl_compat.h"
+-# ifdef HAVE_OPENSSL_CMAC_H
++# if defined(HAVE_OPENSSL_CMAC_H) || (defined(WITH_WOLFSSL) && defined(WOLFSSL_CMAC))
+ #  include <openssl/cmac.h>
+ #  define CMAC "AES128CMAC"
+-# endif
++# endif /* HAVE_OPENSSL_CMAC_H || (WITH_WOLFSSL && WOLFSSL_CMAC) */
+ #endif
+ #include <ssl_applink.c>
+ 
 diff --git a/sntp/configure.ac b/sntp/configure.ac
-index 4fb182b..9213f62 100644
+index 4fb182b..1e9f3b2 100644
 --- a/sntp/configure.ac
 +++ b/sntp/configure.ac
-@@ -120,6 +120,8 @@ NTP_FACILITYNAMES
- # Checks for typedefs, structures, and compiler characteristics.
- AC_HEADER_STDBOOL
+@@ -60,6 +60,8 @@ NTP_LOCINFO()
+ 
+ AM_PROG_AR
  
 +NTP_WOLFSSL
 +
- NTP_IPV6
+ NTP_LIBNTP
  
- ###
+ LT_INIT([disable-shared])
+diff --git a/sntp/crypto.c b/sntp/crypto.c
+index 1be2ea3..db1f302 100644
+--- a/sntp/crypto.c
++++ b/sntp/crypto.c
+@@ -81,7 +81,7 @@ compute_mac(
+ 			goto mac_fail;
+ 		}
+ #ifdef OPENSSL	/* OpenSSL 1 supports return codes 0 fail, 1 okay */
+-#	    ifdef EVP_MD_CTX_FLAG_NON_FIPS_ALLOW
++#	    if defined(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW) && !defined(WITH_WOLFSSL)
+ 		EVP_MD_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+ #	    endif
+ 		/* [Bug 3457] DON'T use plain EVP_DigestInit! It would
+diff --git a/sntp/m4/ntp_libntp.m4 b/sntp/m4/ntp_libntp.m4
+index e0cc216..e63a33a 100644
+--- a/sntp/m4/ntp_libntp.m4
++++ b/sntp/m4/ntp_libntp.m4
+@@ -1123,8 +1123,10 @@ dnl build from tarball.  It's only useful when modifying libntp source code
+ dnl and rebuilding in a client subdir rather than the whole package.
+ AM_CONDITIONAL([LIBNTP_SUBMAKES], [test x"$enable_dependency_tracking" = x"yes"])
+ 
++if test $USE_WOLFSSL = no; then
+ NTP_OPENSSL
+ NTP_CRYPTO_RAND
++fi
+ 
+ dnl add to LDADD_LIBNTP set by ntp_compiler.m4
+ LDADD_LIBNTP="$LDADD_LIBNTP $LIBS"
+diff --git a/sntp/m4/ntp_wolfssl.m4 b/sntp/m4/ntp_wolfssl.m4
+new file mode 100644
+index 0000000..0f5da10
+--- /dev/null
++++ b/sntp/m4/ntp_wolfssl.m4
+@@ -0,0 +1,58 @@
++dnl ####################################################################
++dnl wolfSSL support
++dnl
++dnl Provides the --with-wolfssl=DIR command-line option.  When given,
++dnl the wolfSSL library is used in place of OpenSSL:
++dnl
++dnl	- include paths and -lwolfssl are added to CPPFLAGS_NTP /
++dnl	  LDADD_NTP so that all NTP binaries pick them up
++dnl	- WOLFSSL_USE_OPTIONS_H is defined so that the wolfSSL headers
++dnl	  include the build-time options.h on behalf of NTP
++dnl	- OPENSSL, WITH_WOLFSSL, ENABLE_CMAC, USE_OPENSSL_CRYPTO_RAND
++dnl	  and AUTOKEY are defined for config.h
++dnl
++dnl wolfSSL must be built with OPENSSL_EXTRA_BSD (e.g.
++dnl ./configure --enable-ntp CFLAGS="-DOPENSSL_EXTRA_BSD"), NTP uses
++dnl MD5Init/MD5Update/MD5Final which wolfSSL only provides under it.
++dnl
++dnl Must be called before NTP_LIBNTP (which calls NTP_OPENSSL).
++dnl
++dnl Output variables:
++dnl	USE_WOLFSSL	yes if wolfSSL is used, no otherwise
++dnl
++dnl ####################################################################
++AC_DEFUN([NTP_WOLFSSL], [
++AC_ARG_WITH(wolfssl,
++    AC_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
++[
++    CPPFLAGS_NTP="$CPPFLAGS_NTP -I${withval}/include/ -I${withval}/include/wolfssl -DWOLFSSL_USE_OPTIONS_H"
++    LDADD_NTP="$LDADD_NTP -L${withval}/lib -lwolfssl"
++    USE_WOLFSSL=yes
++],[USE_WOLFSSL=no])
++
++if test $USE_WOLFSSL = yes; then
++    SAVED_CFLAGS=$CFLAGS
++    CFLAGS="$CFLAGS $CPPFLAGS_NTP"
++    AC_CHECK_HEADER([wolfssl/options.h])
++    CFLAGS=$SAVED_CFLAGS
++    if test $ac_cv_header_wolfssl_options_h = yes; then
++        AC_MSG_CHECKING([for OPENSSL_EXTRA_BSD in wolfssl/options.h])
++        if grep -q "define OPENSSL_EXTRA_BSD" ${withval}/include/wolfssl/options.h; then
++            ans=yes
++        else
++            ans=no
++        fi
++        AC_MSG_RESULT([$ans])
++        if test $ans = no; then
++            AC_MSG_ERROR([wolfSSL was built without OPENSSL_EXTRA_BSD, which is required for MD5Init/MD5Update/MD5Final. Rebuild wolfSSL with: ./configure --enable-ntp CFLAGS="-DOPENSSL_EXTRA_BSD"])
++        fi
++        AC_DEFINE([OPENSSL], [], [Use OpenSSL?])
++        AC_DEFINE([WITH_WOLFSSL], [], [Use wolfSSL?])
++        AC_DEFINE([ENABLE_CMAC], [1], [Enable CMAC support?])
++        AC_DEFINE([USE_OPENSSL_CRYPTO_RAND], [1], [Use OpenSSL's crypto random functions?])
++        AC_DEFINE([AUTOKEY], [1], [Support NTP Autokey protocol?])
++    else
++        AC_MSG_ERROR([Unable to find wolfssl.])
++    fi
++fi
++])
 diff --git a/util/ntp-keygen.c b/util/ntp-keygen.c
 index c9c0ff9..de79f48 100644
 --- a/util/ntp-keygen.c
@@ -303,5 +427,5 @@ index c9c0ff9..de79f48 100644
  }
  
 -- 
-2.43.0
+2.39.5
 

--- a/ntp/4.2.8p18/ntp-4.2.8p18.patch
+++ b/ntp/4.2.8p18/ntp-4.2.8p18.patch
@@ -299,10 +299,10 @@ index e0cc216..d11f956 100644
  LDADD_LIBNTP="$LDADD_LIBNTP $LIBS"
 diff --git a/sntp/m4/ntp_wolfssl.m4 b/sntp/m4/ntp_wolfssl.m4
 new file mode 100644
-index 0000000..f8d4de2
+index 0000000..75594ad
 --- /dev/null
 +++ b/sntp/m4/ntp_wolfssl.m4
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,68 @@
 +dnl ####################################################################
 +dnl wolfSSL support
 +dnl
@@ -310,8 +310,7 @@ index 0000000..f8d4de2
 +dnl the wolfSSL library is used in place of OpenSSL:
 +dnl
 +dnl	- include paths and -lwolfssl are added to CPPFLAGS_NTP /
-+dnl	  LDADD_NTP so that all NTP binaries pick them up
-+dnl	- WOLFSSL_USE_OPTIONS_H is defined so that the wolfSSL headers
++dnl	  LDADD_NTP, and WOLFSSL_USE_OPTIONS_H makes the wolfSSL headers
 +dnl	  include the build-time options.h on behalf of NTP
 +dnl	- OPENSSL, WITH_WOLFSSL, ENABLE_CMAC, USE_OPENSSL_CRYPTO_RAND
 +dnl	  and AUTOKEY are defined for config.h
@@ -328,27 +327,38 @@ index 0000000..f8d4de2
 +dnl ####################################################################
 +AC_DEFUN([NTP_WOLFSSL], [
 +AC_ARG_WITH(wolfssl,
-+    AC_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
++    AS_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
 +[
-+    CPPFLAGS_NTP="$CPPFLAGS_NTP -I${withval}/include/ -I${withval}/include/wolfssl -DWOLFSSL_USE_OPTIONS_H"
-+    LDADD_NTP="$LDADD_NTP -L${withval}/lib -lwolfssl"
-+    USE_WOLFSSL=yes
++    case "$withval" in
++     no)
++        USE_WOLFSSL=no
++        ;;
++     yes|"")
++        AC_MSG_ERROR([--with-wolfssl needs the wolfSSL install prefix, e.g. --with-wolfssl=/usr/local])
++        ;;
++     *)
++        wolfssl_prefix=$withval
++        USE_WOLFSSL=yes
++        ;;
++    esac
 +],[USE_WOLFSSL=no])
 +
 +if test "x$USE_WOLFSSL" = xyes; then
-+    SAVED_CFLAGS=$CFLAGS
-+    CFLAGS="$CFLAGS $CPPFLAGS_NTP"
++    CPPFLAGS_NTP="$CPPFLAGS_NTP -I$wolfssl_prefix/include/ -I$wolfssl_prefix/include/wolfssl -DWOLFSSL_USE_OPTIONS_H"
++    LDADD_NTP="$LDADD_NTP -L$wolfssl_prefix/lib -lwolfssl"
++    SAVED_CPPFLAGS=$CPPFLAGS
++    CPPFLAGS="$CPPFLAGS $CPPFLAGS_NTP"
 +    AC_CHECK_HEADER([wolfssl/options.h])
-+    CFLAGS=$SAVED_CFLAGS
-+    if test $ac_cv_header_wolfssl_options_h = yes; then
++    CPPFLAGS=$SAVED_CPPFLAGS
++    if test "x$ac_cv_header_wolfssl_options_h" = xyes; then
 +        AC_MSG_CHECKING([for OPENSSL_EXTRA_BSD in wolfssl/options.h])
-+        if grep -q "define OPENSSL_EXTRA_BSD" ${withval}/include/wolfssl/options.h; then
++        if grep -q "define OPENSSL_EXTRA_BSD" "$wolfssl_prefix/include/wolfssl/options.h"; then
 +            ans=yes
 +        else
 +            ans=no
 +        fi
 +        AC_MSG_RESULT([$ans])
-+        if test $ans = no; then
++        if test "x$ans" = xno; then
 +            AC_MSG_ERROR([wolfSSL was built without OPENSSL_EXTRA_BSD, which is required for MD5Init/MD5Update/MD5Final. Rebuild wolfSSL with: ./configure --enable-ntp CFLAGS="-DOPENSSL_EXTRA_BSD"])
 +        fi
 +        AC_DEFINE([OPENSSL], [], [Use OpenSSL?])


### PR DESCRIPTION
https://github.com/wolfSSL/wolfssl/pull/11207 needs to be merged before this. Otherwise wolfssl CI will fail.

The 4.2.8p18 patch was incomplete: it lacked the `ntp_wolfssl.m4` macro (so `--with-wolfssl` was unrecognized and `USE_WOLFSSL` was never defined), and p18 moved the `NTP_OPENSSL`/`NTP_CRYPTO_RAND` checks into `NTP_LIBNTP` in `sntp/m4/ntp_libntp.m4`, so the old patch insertions ran too late and system OpenSSL kept being detected and linked.

- Add `sntp/m4/ntp_wolfssl.m4` implementing `--with-wolfssl=DIR`:
  - adds include paths, `-lwolfssl` and `-DWOLFSSL_USE_OPTIONS_H` to `CPPFLAGS_NTP` so all NTP binaries pick them up
  - checks `wolfssl/options.h` exists and was built with `OPENSSL_EXTRA_BSD` (required for `MD5Init`/`MD5Update`/`MD5Final`), failing configure with a clear error otherwise
  - defines `OPENSSL`, `WITH_WOLFSSL`, `ENABLE_CMAC`, `USE_OPENSSL_CRYPTO_RAND` and `AUTOKEY`
- Call `NTP_WOLFSSL` before `NTP_LIBNTP` in `configure.ac` and `sntp/configure.ac`, and wrap `NTP_OPENSSL`/`NTP_CRYPTO_RAND` (and the autokey block) in `if test $USE_WOLFSSL = no` so system OpenSSL isn't detected/linked when wolfSSL is used.
- Port the p17 compatibility fixes:
  - `WITH_WOLFSSL` guards in `libssl_compat.h`/`.c`
  - CMAC guards (`WITH_WOLFSSL && WOLFSSL_CMAC`) in `ntp_md5.h`/`ssl_init.c`/`ntpq.c`
  - `EVP_MD_CTX_FLAG_NON_FIPS_ALLOW` guard in `sntp/crypto.c`
  - `BN_GENCB`/`BN_gcd`/`BN_bin2bn` workarounds in `ntp-keygen.c` and `ntp_crypto.c`
  - rename `FATAL_ERROR` to `NTP_FATAL_ERROR` (collides with a wolfSSL macro)
  - remove the `md5` key-type prefix in `keytype_from_text`
- Document in the README building wolfSSL with `./configure --enable-ntp CFLAGS="-DOPENSSL_EXTRA_BSD"` (`--enable-md4` additionally needed to pass `make check`).